### PR TITLE
Track Conversion - Fix for Track Type

### DIFF
--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -10,17 +10,18 @@ lcio::LCCollectionVec* convTracks(
 {
   auto* tracks = new lcio::LCCollectionVec(lcio::LCIO::TRACK);
 
-  // Loop over EDM4hep tracks converting them to lcio tracks
+  // Loop over EDM4hep tracks converting them to lcio tracks.
   
   for (const auto& edm_tr : (*tracks_coll)) {
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();
-      // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
+      // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO TrackImpl
+      // and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
       int type = edm_tr.getType();
-      for (int i = 0; i<sizeof(int)*8;i++){
-	if (type & (1<<i)){
-	   lcio_tr->setTypeBit(i);	  
-	}
+      for (int i = 0; i < sizeof(int) * 8; i++) {
+        if (type & (1 << i)) {
+          lcio_tr->setTypeBit(i);
+        }
       }
       lcio_tr->setChi2(edm_tr.getChi2());
       lcio_tr->setNdf(edm_tr.getNdf());
@@ -646,7 +647,6 @@ lcio::LCCollectionVec* convMCParticles(
       lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
       int status = edm_mcp.getGeneratorStatus();
       lcio_mcp->setSimulatorStatus(status);
-
 
       double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};
       lcio_mcp->setVertex(vertex);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -644,7 +644,7 @@ lcio::LCCollectionVec* convMCParticles(
       lcio_mcp->setPDG(edm_mcp.getPDG());
       lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
       // Note LCIO sets some Bits during writing which makes a trivial integer conversion afterwards not work
-      int status = edm_mcp.getSimulatorStatus(); 
+      int status = edm_mcp.getSimulatorStatus();
       lcio_mcp->setSimulatorStatus(status);
 
       double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -647,8 +647,6 @@ lcio::LCCollectionVec* convMCParticles(
       int status = edm_mcp.getGeneratorStatus();
       lcio_mcp->setSimulatorStatus(status);
 
-         }
-       }
 
       double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};
       lcio_mcp->setVertex(vertex);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -14,8 +14,13 @@ lcio::LCCollectionVec* convTracks(
   for (const auto& edm_tr : (*tracks_coll)) {
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();
-
-      lcio_tr->setTypeBit(edm_tr.getType());
+      int type = edm_tr.getType();
+      for (int i = 0; i<sizeof(int)*8;i++){
+	if (type & (1<<i)){
+	   lcio_tr->setTypeBit(i);	  
+	}
+      }
+      std::cout<<"using new conversion method"<<std::endl;
       lcio_tr->setChi2(edm_tr.getChi2());
       lcio_tr->setNdf(edm_tr.getNdf());
       lcio_tr->setdEdx(edm_tr.getDEdx());

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -11,7 +11,6 @@ lcio::LCCollectionVec* convTracks(
   auto* tracks = new lcio::LCCollectionVec(lcio::LCIO::TRACK);
 
   // Loop over EDM4hep tracks converting them to lcio tracks.
-
   for (const auto& edm_tr : (*tracks_coll)) {
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -16,7 +16,7 @@ lcio::LCCollectionVec* convTracks(
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();
       // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO
-      // TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
+      // TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Type bit by bit.
       int type = edm_tr.getType();
       for (int i = 0; i < sizeof(int) * 8; i++) {
         if (type & (1 << i)) {

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -11,9 +11,11 @@ lcio::LCCollectionVec* convTracks(
   auto* tracks = new lcio::LCCollectionVec(lcio::LCIO::TRACK);
 
   // Loop over EDM4hep tracks converting them to lcio tracks
+  
   for (const auto& edm_tr : (*tracks_coll)) {
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();
+      // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
       int type = edm_tr.getType();
       for (int i = 0; i<sizeof(int)*8;i++){
 	if (type & (1<<i)){
@@ -643,10 +645,7 @@ lcio::LCCollectionVec* convMCParticles(
       lcio_mcp->setPDG(edm_mcp.getPDG());
       lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
       int status = edm_mcp.getGeneratorStatus();
-//	std::cout<<"Simulator status read "<<status<<std::endl;
-          lcio_mcp->setSimulatorStatus(status);
-          auto lcio_status =lcio_mcp->getSimulatorStatus();
-// 	  std::cout<<"Simulator status read by lcio "<<lcio_status<<std::endl;
+      lcio_mcp->setSimulatorStatus(status);
 
          }
        }

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -19,9 +19,7 @@ lcio::LCCollectionVec* convTracks(
       // TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Type bit by bit.
       int type = edm_tr.getType();
       for (int i = 0; i < sizeof(int) * 8; i++) {
-        if (type & (1 << i)) {
-          lcio_tr->setTypeBit(i);
-        }
+        lcio_tr->setTypeBit(i, type & (1 << i));
       }
       lcio_tr->setChi2(edm_tr.getChi2());
       lcio_tr->setNdf(edm_tr.getNdf());
@@ -645,7 +643,8 @@ lcio::LCCollectionVec* convMCParticles(
     if (edm_mcp.isAvailable()) {
       lcio_mcp->setPDG(edm_mcp.getPDG());
       lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
-      int status = edm_mcp.getGeneratorStatus();
+      // Note LCIO sets some Bits during writing which makes a trivial integer conversion afterwards not work
+      int status = edm_mcp.getSimulatorStatus(); 
       lcio_mcp->setSimulatorStatus(status);
 
       double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -11,12 +11,12 @@ lcio::LCCollectionVec* convTracks(
   auto* tracks = new lcio::LCCollectionVec(lcio::LCIO::TRACK);
 
   // Loop over EDM4hep tracks converting them to lcio tracks.
-  
+
   for (const auto& edm_tr : (*tracks_coll)) {
     if (edm_tr.isAvailable()) {
       auto* lcio_tr = new lcio::TrackImpl();
-      // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO TrackImpl
-      // and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
+      // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO
+      // TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Tzpe bit by bit.
       int type = edm_tr.getType();
       for (int i = 0; i < sizeof(int) * 8; i++) {
         if (type & (1 << i)) {

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -20,7 +20,6 @@ lcio::LCCollectionVec* convTracks(
 	   lcio_tr->setTypeBit(i);	  
 	}
       }
-      std::cout<<"using new conversion method"<<std::endl;
       lcio_tr->setChi2(edm_tr.getChi2());
       lcio_tr->setNdf(edm_tr.getNdf());
       lcio_tr->setdEdx(edm_tr.getDEdx());
@@ -643,7 +642,15 @@ lcio::LCCollectionVec* convMCParticles(
     if (edm_mcp.isAvailable()) {
       lcio_mcp->setPDG(edm_mcp.getPDG());
       lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
-      // lcio_mcp->setSimulatorStatus(edm_mcp.getSimulatorStatus());
+      int status = edm_mcp.getGeneratorStatus();
+//	std::cout<<"Simulator status read "<<status<<std::endl;
+          lcio_mcp->setSimulatorStatus(status);
+          auto lcio_status =lcio_mcp->getSimulatorStatus();
+// 	  std::cout<<"Simulator status read by lcio "<<lcio_status<<std::endl;
+
+         }
+       }
+
       double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};
       lcio_mcp->setVertex(vertex);
       lcio_mcp->setTime(edm_mcp.getTime());


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the setting of the Track Type in the Tracks Collection in LCIO. It is now set bit wise as required by LCIO

ENDRELEASENOTES
