### PR TITLE
Add option to convert only a subset of collections

### DIFF
--- a/doc/LCIO2EDM4hep.md
+++ b/doc/LCIO2EDM4hep.md
@@ -54,6 +54,12 @@ certain collections. In this case it is the **users responsibility to provide
 the missing types** as otherwise the conversion will simply skip these
 collections, or potentially even crash.
 
+## Converting only a subset of collections
+Using the same mechanism as for patching collections it is also possible to only
+convert a subset of all available collections. `lcio2edm4hep` uses the contents
+of the `colltypefile` to determine the contents of the output. If that contains
+only a subset of all collections, only that subset will be converted. Missing
+collections will still be patched in, in this case.
 
 # Library usage of the conversion functions
 The conversion functions are designed to also be usable as a library. The overall design is to make the conversion a two step process. Step one is converting the data and step two being the resolving of the relations and filling of subset collection.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -57,6 +57,7 @@
 #include <string>
 #include <unordered_map>
 #include <tuple>
+#include <vector>
 
 namespace LCIO2EDM4hepConv {
   template<typename LcioT, typename EdmT>
@@ -90,9 +91,12 @@ namespace LCIO2EDM4hepConv {
   podio::Frame convertRunHeader(EVENT::LCRunHeader* rheader);
 
   /**
-   * Convert a complete LCEvent from LCIO to EDM4hep
+   * Convert a complete LCEvent from LCIO to EDM4hep.
+   *
+   * A second, optional argument can be passed to limit the collections to
+   * convert to the subset that is passed.
    */
-  podio::Frame convertEvent(EVENT::LCEvent* evt);
+  podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert = {});
 
   /**
    * Convert an LCIOCollection by dispatching to the specific conversion

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -94,7 +94,10 @@ namespace LCIO2EDM4hepConv {
    * Convert a complete LCEvent from LCIO to EDM4hep.
    *
    * A second, optional argument can be passed to limit the collections to
-   * convert to the subset that is passed.
+   * convert to the subset that is passed. NOTE: There is an implicit assumption
+   * here that collsToConvert only contains collection names that are present in
+   * the passed evt. There is no exception handling internally to guard against
+   * collections that are missing.
    */
   podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert = {});
 

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -32,7 +32,7 @@ namespace LCIO2EDM4hepConv {
       covMatrix[11],
       covMatrix[12],
       covMatrix[13],
-      covMatrix[15],
+      covMatrix[14],
       0,
       0,
       0,

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -625,7 +625,6 @@ namespace LCIO2EDM4hepConv {
       const auto& lciotype = lcioColl->getTypeName();
       if (lciotype == "SimCalorimeterHit") {
         haveSimCaloHits = true;
-        std::cout << " found sim hits : " << lcioname << std::endl;
       }
       if (lciotype == "LCRelation") {
         LCRelations.push_back(std::make_pair(lcioname, lcioColl));

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -611,14 +611,14 @@ namespace LCIO2EDM4hepConv {
     std::vector<CollNamePair> edmevent;
     std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
     const auto& lcnames = evt->getCollectionNames();
-    bool haveSimCaloHits = false ;
+    bool haveSimCaloHits = false;
     // In this loop the data gets converted.
     for (const auto& lcioname : *lcnames) {
       const auto& lcioColl = evt->getCollection(lcioname);
       const auto& lciotype = lcioColl->getTypeName();
-      if (lciotype == "SimCalorimeterHit"){
-        haveSimCaloHits = true ;
-        std::cout << " found sim hits : " << lcioname << std::endl ;
+      if (lciotype == "SimCalorimeterHit") {
+        haveSimCaloHits = true;
+        std::cout << " found sim hits : " << lcioname << std::endl;
       }
       if (lciotype == "LCRelation") {
         LCRelations.push_back(std::make_pair(lcioname, lcioColl));
@@ -655,7 +655,7 @@ namespace LCIO2EDM4hepConv {
     // convert put the event parameters into the frame
     convertObjectParameters<EVENT::LCEvent>(evt, event);
     // Now everything is done and we simply populate a Frame
-    if( haveSimCaloHits ){
+    if (haveSimCaloHits) {
       // creating the CaloHitContributions to fill them into the Frame
       auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
       event.put(std::move(calocontr), "AllCaloHitContributionsCombined");

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -611,10 +611,15 @@ namespace LCIO2EDM4hepConv {
     std::vector<CollNamePair> edmevent;
     std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
     const auto& lcnames = evt->getCollectionNames();
+    bool haveSimCaloHits = false ;
     // In this loop the data gets converted.
     for (const auto& lcioname : *lcnames) {
       const auto& lcioColl = evt->getCollection(lcioname);
       const auto& lciotype = lcioColl->getTypeName();
+      if (lciotype == "SimCalorimeterHit"){
+        haveSimCaloHits = true ;
+        std::cout << " found sim hits : " << lcioname << std::endl ;
+      }
       if (lciotype == "LCRelation") {
         LCRelations.push_back(std::make_pair(lcioname, lcioColl));
         // We handle Relations (aka Associations) once we have converted all the
@@ -645,14 +650,16 @@ namespace LCIO2EDM4hepConv {
     // Filling all the OneToMany and OneToOne Relations and creating the AssociationCollections.
     resolveRelations(typeMapping);
     auto assoCollVec = createAssociations(typeMapping, LCRelations);
-    // creating the CaloHitContributions to fill them into the Frame
-    auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
     auto headerColl = createEventHeader(evt);
     podio::Frame event;
     // convert put the event parameters into the frame
     convertObjectParameters<EVENT::LCEvent>(evt, event);
     // Now everything is done and we simply populate a Frame
-    event.put(std::move(calocontr), "AllCaloHitContributionsCombined");
+    if( haveSimCaloHits ){
+      // creating the CaloHitContributions to fill them into the Frame
+      auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
+      event.put(std::move(calocontr), "AllCaloHitContributionsCombined");
+    }
     event.put(std::move(headerColl), "EventHeader");
     for (auto& [name, coll] : edmevent) {
       event.put(std::move(coll), name);

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -611,7 +611,7 @@ namespace LCIO2EDM4hepConv {
     std::vector<CollNamePair> edmevent;
     std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
 
-    const auto& lcnames = [&collsToConvert, &evt]() {
+    const auto& lcioNames = [&collsToConvert, &evt]() {
       if (collsToConvert.empty()) {
         return *evt->getCollectionNames();
       }
@@ -619,7 +619,7 @@ namespace LCIO2EDM4hepConv {
     }();
 
     // In this loop the data gets converted.
-    for (const auto& lcioname : lcnames) {
+    for (const auto& lcioname : lcioNames) {
       const auto& lcioColl = evt->getCollection(lcioname);
       const auto& lciotype = lcioColl->getTypeName();
       if (lciotype == "LCRelation") {
@@ -638,7 +638,7 @@ namespace LCIO2EDM4hepConv {
       }
     }
     // Filling of the Subset Colections
-    for (const auto& lcioname : lcnames) {
+    for (const auto& lcioname : lcioNames) {
 
       auto lcioColl = evt->getCollection(lcioname);
       if (lcioColl->isSubset()) {
@@ -653,12 +653,15 @@ namespace LCIO2EDM4hepConv {
     resolveRelations(typeMapping);
     auto assoCollVec = createAssociations(typeMapping, LCRelations);
     auto headerColl = createEventHeader(evt);
+
+    // Now everything is done and we simply populate a Frame
     podio::Frame event;
     // convert put the event parameters into the frame
     convertObjectParameters<EVENT::LCEvent>(evt, event);
-    // Now everything is done and we simply populate a Frame
-    if (not typeMapping.simCaloHits.empty()) { // only create CaloHitContributions if necessary
-      // creating the CaloHitContributions to fill them into the Frame
+
+    // only create CaloHitContributions if necessary (i.e. if we have converted
+    // SimCalorimeterHits)
+    if (not typeMapping.simCaloHits.empty()) {
       auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
       event.put(std::move(calocontr), "AllCaloHitContributionsCombined");
     }

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -618,14 +618,10 @@ namespace LCIO2EDM4hepConv {
       return collsToConvert;
     }();
 
-    bool haveSimCaloHits = false;
     // In this loop the data gets converted.
     for (const auto& lcioname : lcnames) {
       const auto& lcioColl = evt->getCollection(lcioname);
       const auto& lciotype = lcioColl->getTypeName();
-      if (lciotype == "SimCalorimeterHit") {
-        haveSimCaloHits = true;
-      }
       if (lciotype == "LCRelation") {
         LCRelations.push_back(std::make_pair(lcioname, lcioColl));
         // We handle Relations (aka Associations) once we have converted all the
@@ -661,7 +657,7 @@ namespace LCIO2EDM4hepConv {
     // convert put the event parameters into the frame
     convertObjectParameters<EVENT::LCEvent>(evt, event);
     // Now everything is done and we simply populate a Frame
-    if (haveSimCaloHits) {
+    if (not typeMapping.simCaloHits.empty()) { // only create CaloHitContributions if necessary
       // creating the CaloHitContributions to fill them into the Frame
       auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
       event.put(std::move(calocontr), "AllCaloHitContributionsCombined");

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -605,15 +605,22 @@ namespace LCIO2EDM4hepConv {
     return headerColl;
   }
 
-  podio::Frame convertEvent(EVENT::LCEvent* evt)
+  podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert)
   {
     auto typeMapping = LcioEdmTypeMapping {};
     std::vector<CollNamePair> edmevent;
     std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
-    const auto& lcnames = evt->getCollectionNames();
+
+    const auto& lcnames = [&collsToConvert, &evt]() {
+      if (collsToConvert.empty()) {
+        return *evt->getCollectionNames();
+      }
+      return collsToConvert;
+    }();
+
     bool haveSimCaloHits = false;
     // In this loop the data gets converted.
-    for (const auto& lcioname : *lcnames) {
+    for (const auto& lcioname : lcnames) {
       const auto& lcioColl = evt->getCollection(lcioname);
       const auto& lciotype = lcioColl->getTypeName();
       if (lciotype == "SimCalorimeterHit") {
@@ -636,7 +643,7 @@ namespace LCIO2EDM4hepConv {
       }
     }
     // Filling of the Subset Colections
-    for (const auto& lcioname : *lcnames) {
+    for (const auto& lcioname : lcnames) {
 
       auto lcioColl = evt->getCollection(lcioname);
       if (lcioColl->isSubset()) {

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -1,6 +1,5 @@
 #include "k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h"
 
-#include <EVENT/LCIO.h>
 #include <IO/LCReader.h>
 #include <IOIMPL/LCFactory.h>
 #include <UTIL/CheckCollections.h>

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -9,10 +9,11 @@
 
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <vector>
-#include <set>
 #include <utility>
+#include <cstdlib>
 
 std::vector<std::pair<std::string, std::string>> getNamesAndTypes(const std::string& collTypeFile)
 {
@@ -39,56 +40,98 @@ std::vector<std::pair<std::string, std::string>> getNamesAndTypes(const std::str
   return names_types;
 }
 
-constexpr auto usageMsg = R"(usage: lcio2edm4hep [-h] inputfile outputfile [colltypefile] [-s] [n])";
+constexpr auto usageMsg = R"(usage: lcio2edm4hep [-h] inputfile outputfile [colltypefile] [-n N])";
+
 constexpr auto helpMsg = R"(
 Convert an LCIO file to EDM4hep
 
 positional arguments:
   inputfile         the input LCIO file
   outputfile        the output EDM4hep file that will be created
-  colltypefile      an optional input file that specifies the names and types of collections
-  -s                if -s is appended, only the collections in 'colltypefile' are written
-                    otherwise all the specified collections are written
-  n                 optionally limit the number of events to n (only w/ -s option)
+  colltypefile      An optional input file that specifies the names and types of
+                    collections that should be present in the output.
 
 optional arguments:
   -h, --help        show this help message and exit
+  -n N              Limit the number of events to convert to N (default = -1, all events)
 
 Examples:
 - print this message:
 lcio2edm4hep -h
 - convert complete file (needs all lcio collections to be present in all files):
 lcio2edm4hep infile.slcio outfile_edm4hep.root
-- the same but providing complete set of collections:
+- the same but providing complete set of collections (either to patch collections in,
+  or to only convert a subset):
 lcio2edm4hep infile.slcio outfile_edm4hep.root coltype.txt
-- write only 42 events with the subset of collections specified in coltype.txt:
-lcio2edm4hep infile.slcio outfile_edm4hep.root coltype.txt -s 42
-
 )";
+
+struct ParsedArgs {
+  std::string inputFile {};
+  std::string outputFile {};
+  std::string patchFile {};
+  int nEvents {-1};
+};
+
+void printUsageAndExit()
+{
+  std::cerr << usageMsg << std::endl;
+  std::exit(1);
+}
+
+ParsedArgs parseArgs(std::vector<std::string> argv)
+{
+  // find help
+  if (std::find_if(argv.begin(), argv.end(), [](const auto& elem) {
+        return elem == "-h" || elem == "--help";
+      }) != argv.end()) {
+    std::cerr << usageMsg << '\n' << helpMsg << std::endl;
+    std::exit(0);
+  }
+
+  auto argc = argv.size();
+  if (argc < 3 || argc > 7) {
+    printUsageAndExit();
+  }
+
+  ParsedArgs args;
+  auto nEventIt = std::find(argv.begin(), argv.end(), "-n");
+  if (nEventIt != argv.end()) {
+    const auto index = std::distance(argv.begin(), nEventIt);
+    if (index > argc - 2) {
+      // No argument left to parse
+      printUsageAndExit();
+    }
+    const auto& value = argv[index + 1]; // get the actual value
+    try {
+      args.nEvents = std::stoi(value);
+    } catch (std::invalid_argument& err) {
+      std::cerr << "Cannot parse " << value << " as an integer" << std::endl;
+      printUsageAndExit();
+    }
+    argv.erase(nEventIt, nEventIt + 2);
+  }
+
+  argc = argv.size();
+  if (argc < 3) {
+    printUsageAndExit();
+  }
+  args.inputFile = argv[1];
+  args.outputFile = argv[2];
+  if (argc == 4) {
+    args.patchFile = argv[3];
+  }
+  return args;
+}
 
 int main(int argc, char* argv[])
 {
-  if (argc == 2 && (argv[1] == std::string("-h") || argv[1] == std::string("--help"))) {
-    std::cerr << usageMsg << '\n' << helpMsg << std::endl;
-    return 0;
-  }
+  const auto args = parseArgs({argv, argv + argc});
 
-  bool createSubset = false;
-
-  if (argc < 3 || (argc > 4 && (argv[4] != std::string("-s")))) {
-    std::cerr << usageMsg << std::endl;
-    return 1;
-  }
-  const auto outputFile = std::string(argv[2]);
-
-  bool patching = false;
   UTIL::CheckCollections colPatcher {};
-  std::vector<std::pair<std::string, std::string>> namesTypes;
-  std::set<std::string> subsetColls;
-  int maxEvt = -1;
-
-  if (argc >= 4) {
-    namesTypes = getNamesAndTypes(argv[3]);
+  std::vector<std::pair<std::string, std::string>> namesTypes {};
+  const bool patching = !args.patchFile.empty();
+  if (patching) {
+    namesTypes = getNamesAndTypes(args.patchFile);
     if (namesTypes.empty()) {
       std::cerr << "The provided list of collection names and types does not satisfy the required format: Pair of Name "
                    "and Type per line separated by space"
@@ -96,25 +139,25 @@ int main(int argc, char* argv[])
       return 1;
     }
     colPatcher.addPatchCollections(namesTypes);
-    patching = true;
-
-    if (argc >= 5 && (argv[4] == std::string("-s"))) {
-      // new mode: write only a subset of collection as specified in patch file
-      patching = false;
-      createSubset = true;
-      for (auto& nt : namesTypes) {
-        subsetColls.insert(nt.first);
-      }
-    }
-    if (argc == 6) maxEvt = std::atoi(argv[5]);
   }
+  // Construct a vector of collections to convert. If namesTypes is empty, this
+  // will be empty, and convertEvent will fall back to use the collections in
+  // the event
+  const auto collsToConvert = [&namesTypes]() {
+    std::vector<std::string> names;
+    names.reserve(namesTypes.size());
+    for (const auto& [name, type] : namesTypes) {
+      names.emplace_back(name);
+    }
+    return names;
+  }();
 
   auto lcreader = IOIMPL::LCFactory::getInstance()->createLCReader();
-  lcreader->open(argv[1]);
-  std::cout << "Number of events: " << lcreader->getNumberOfEvents() << '\n';
-  std::cout << "Number of runs: " << lcreader->getNumberOfRuns() << '\n';
+  lcreader->open(args.inputFile);
+  std::cout << "Number of events in file: " << lcreader->getNumberOfEvents() << '\n';
+  std::cout << "Number of runs in file: " << lcreader->getNumberOfRuns() << '\n';
 
-  podio::ROOTFrameWriter writer(outputFile);
+  podio::ROOTFrameWriter writer(args.outputFile);
 
   for (auto j = 0u; j < lcreader->getNumberOfRuns(); ++j) {
     if (j % 1 == 0) {
@@ -126,25 +169,17 @@ int main(int argc, char* argv[])
     writer.writeFrame(edmRunHeader, "runs");
   }
 
-  int nEvt = maxEvt > 0 ? maxEvt : lcreader->getNumberOfEvents();
-
+  const int nEvt = args.nEvents > 0 ? args.nEvents : lcreader->getNumberOfEvents();
   for (auto i = 0u; i < nEvt; ++i) {
     if (i % 10 == 0) {
       std::cout << "processing Event: " << i << std::endl;
     }
-    auto evt = lcreader->readNextEvent(EVENT::LCIO::UPDATE);
+    auto evt = lcreader->readNextEvent();
     // Patching the Event to make sure all events contain the same Collections.
     if (patching == true) {
       colPatcher.patchCollections(evt);
     }
-    if (createSubset) {
-      auto* colNames = evt->getCollectionNames();
-      for (auto& n : *colNames) {
-        if (subsetColls.find(n) == subsetColls.end()) evt->removeCollection(n);
-      }
-    }
-
-    const auto edmEvent = LCIO2EDM4hepConv::convertEvent(evt);
+    const auto edmEvent = LCIO2EDM4hepConv::convertEvent(evt, collsToConvert);
     writer.writeFrame(edmEvent, "events");
   }
 

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -73,10 +73,10 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  bool createSubset = false ;
+  bool createSubset = false;
 
-  if (argc < 3 || (argc >4 && (argv[4] != std::string("-s"))) )  {
-    std::cerr << usageMsg  << std::endl;
+  if (argc < 3 || (argc > 4 && (argv[4] != std::string("-s")))) {
+    std::cerr << usageMsg << std::endl;
     return 1;
   }
   const auto outputFile = std::string(argv[2]);
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
   bool patching = false;
   UTIL::CheckCollections colPatcher {};
   std::vector<std::pair<std::string, std::string>> namesTypes;
-  std::set<std::string> subsetColls ;
+  std::set<std::string> subsetColls;
   int maxEvt = -1;
 
   if (argc >= 4) {
@@ -98,15 +98,15 @@ int main(int argc, char* argv[])
     colPatcher.addPatchCollections(namesTypes);
     patching = true;
 
-    if( argc >= 5 && (argv[4] == std::string("-s") ) ){
+    if (argc >= 5 && (argv[4] == std::string("-s"))) {
       // new mode: write only a subset of collection as specified in patch file
-      patching = false ;
-      createSubset =  true ;
-      for(auto& nt : namesTypes){
-	    subsetColls.insert( nt.first ) ;
+      patching = false;
+      createSubset = true;
+      for (auto& nt : namesTypes) {
+        subsetColls.insert(nt.first);
       }
     }
-    if( argc == 6 ) maxEvt = std::atoi( argv[5] ) ;
+    if (argc == 6) maxEvt = std::atoi(argv[5]);
   }
 
   auto lcreader = IOIMPL::LCFactory::getInstance()->createLCReader();
@@ -126,29 +126,26 @@ int main(int argc, char* argv[])
     writer.writeFrame(edmRunHeader, "runs");
   }
 
-  int nEvt = maxEvt >0 ? maxEvt : lcreader->getNumberOfEvents() ;
+  int nEvt = maxEvt > 0 ? maxEvt : lcreader->getNumberOfEvents();
 
   for (auto i = 0u; i < nEvt; ++i) {
     if (i % 10 == 0) {
       std::cout << "processing Event: " << i << std::endl;
     }
-    auto evt = lcreader->readNextEvent( EVENT::LCIO::UPDATE);
+    auto evt = lcreader->readNextEvent(EVENT::LCIO::UPDATE);
     // Patching the Event to make sure all events contain the same Collections.
     if (patching == true) {
       colPatcher.patchCollections(evt);
-
     }
     if (createSubset) {
       auto* colNames = evt->getCollectionNames();
-      for( auto& n : *colNames ){
-      if( subsetColls.find( n ) == subsetColls.end() )
-	    evt->removeCollection( n ) ;
+      for (auto& n : *colNames) {
+        if (subsetColls.find(n) == subsetColls.end()) evt->removeCollection(n);
       }
     }
 
     const auto edmEvent = LCIO2EDM4hepConv::convertEvent(evt);
     writer.writeFrame(edmEvent, "events");
-
   }
 
   writer.finish();


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the possibility to convert only a subset of collections and events.
- Fix minor bug in TrackState conversion (covMatrix[15])
- Write `AllCaloHitContributionsCombined` only if needed, i.e. `SimCalorimeterHits` are present in the events in lcio2edm4hep

ENDRELEASENOTES
