### PR TITLE
Fix a compilation error

### DIFF
--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
           continue;
         }
       }
-      const auto type = [&edmEvent, &name]() {
+      const auto type = [&edmEvent, &name]() -> std::string_view {
         const auto coll = edmEvent.get(name);
         if (coll) {
           return coll->getTypeName();


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a compilation error in compare_contents.cpp

ENDRELEASENOTES

I am using GCC 11.3.0 and LCG 103 environment. When building this project, I got following error information:
```
[ 88%] Building CXX object tests/CMakeFiles/compare-contents.dir/compare_contents.cpp.o
/tmp/lint/cepc-/k4EDM4hep2LcioConv-src/tests/compare_contents.cpp: In lambda function:
/tmp/lint/cepc-/k4EDM4hep2LcioConv-src/tests/compare_contents.cpp:69:16: error: inconsistent types 'std::__cxx11::basic_string<char>' and 'std::basic_string_view<char>' deduced for lambda return type
   69 |         return empty;
      |                ^~~~~
gmake[2]: *** [tests/CMakeFiles/compare-contents.dir/compare_contents.cpp.o] Error 1
gmake[1]: *** [tests/CMakeFiles/compare-contents.dir/all] Error 2
```

In order to fix this compilation error, the return type of lambda function is declared explicitly. 