### PR TITLE
Make tests work with older versions of podio

### DIFF
--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
         if (coll) {
           return coll->getTypeName();
         }
-        static constexpr std::string_view empty = "";
+        static const decltype(coll->getTypeName()) empty = "";
         return empty;
       }();
       if (type.empty()) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make it possible to build the tests also with older versions of podio where the `getXYZName` are not yet `std::string_view`s.

ENDRELEASENOTES

Effectively reviving #22 
