### PR TITLE
Add automated test cases for standalone converter and also check relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,4 @@ test/k4FWCoreTest/**/*.root
 test/inputFiles/*.slcio
 test/gaudi_opts/testConverterConstants.py
 
+/tests/inputFiles/

--- a/.gitignore
+++ b/.gitignore
@@ -246,5 +246,3 @@ test/k4FWCoreTest/**/*.root
 ## k4MarlinWrapper
 test/inputFiles/*.slcio
 test/gaudi_opts/testConverterConstants.py
-
-/tests/inputFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,22 @@ set( ${PROJECT_NAME}_VERSION_MINOR 5 )
 set( ${PROJECT_NAME}_VERSION_PATCH 0 )
 set( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
+# Define a default build type can be overriden by passing
+# ``-DCMAKE_BUILD_TYPE=<type>`` when invoking CMake
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      FORCE
+      )
+  else()
+    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      FORCE
+      )
+  endif()
+endif()
+
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -747,8 +747,8 @@ namespace LCIO2EDM4hepConv {
     for (auto& [lcio, edm] : recoparticlesMap) {
       edmnum++;
 
-      const auto& vertex = lcio->getStartVertex();
-      if (vertex != nullptr) {
+      const auto vertex = lcio->getStartVertex();
+      if (vertex) {
         if (const auto it = vertexMap.find(vertex); it != vertexMap.end()) {
           edm.setStartVertex(it->second);
         }

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -747,20 +747,19 @@ namespace LCIO2EDM4hepConv {
     for (auto& [lcio, edm] : recoparticlesMap) {
       edmnum++;
 
-      auto vertex = lcio->getStartVertex();
-      if (vertex == nullptr) {
-        continue;
-      }
-      if (const auto it = vertexMap.find(vertex); it != vertexMap.end()) {
-        edm.setStartVertex(it->second);
-      }
-      else {
-        std::cerr << "Cannot find corresponding EDM4hep Vertex for a LCIO Vertex, "
-                     "while trying to resolve the ReconstructedParticle Relations "
-                  << std::endl;
+      const auto& vertex = lcio->getStartVertex();
+      if (vertex != nullptr) {
+        if (const auto it = vertexMap.find(vertex); it != vertexMap.end()) {
+          edm.setStartVertex(it->second);
+        }
+        else {
+          std::cerr << "Cannot find corresponding EDM4hep Vertex for a LCIO Vertex, "
+                       "while trying to resolve the ReconstructedParticle Relations "
+                    << std::endl;
+        }
       }
 
-      auto clusters = lcio->getClusters();
+      const auto& clusters = lcio->getClusters();
       for (auto c : clusters) {
         if (c == nullptr) {
           continue;
@@ -776,7 +775,7 @@ namespace LCIO2EDM4hepConv {
         }
       }
 
-      auto tracks = lcio->getTracks();
+      const auto& tracks = lcio->getTracks();
       for (auto t : tracks) {
         if (t == nullptr) {
           continue;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,3 +6,26 @@ add_executable(compare-contents compare_contents.cpp)
 target_link_libraries(compare-contents PRIVATE edmCompare podio::podioRootIO)
 target_include_directories(compare-contents PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>)
+
+find_program(BASH_PROGRAM bash)
+
+add_test(fetch_test_inputs ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/get_test_data.sh)
+
+add_test(standalone_ild_rec_file ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_standalone_converter.sh ild_higgs_rec.slcio)
+
+add_test(standalone_ild_dst_file ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_standalone_converter.sh ild_higgs_dst.slcio)
+
+set_tests_properties(
+    fetch_test_inputs
+    standalone_ild_rec_file
+    standalone_ild_dst_file
+  PROPERTIES
+    ENVIRONMENT "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR};PATH=${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/standalone:$ENV{PATH}"
+)
+
+set_tests_properties(
+    standalone_ild_rec_file
+    standalone_ild_dst_file
+  PROPERTIES
+    DEPENDS fetch_test_inputs
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc)
+add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc)
 target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep ${LCIO_LIBRARIES})
 target_include_directories(edmCompare PUBLIC ${LCIO_INCLUDE_DIRS})
 

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -1,4 +1,5 @@
 #include "CompareEDM4hepLCIO.h"
+#include "ObjectMapping.h"
 
 #include "podio/ROOTFrameReader.h"
 #include "podio/Frame.h"
@@ -78,6 +79,8 @@ int main(int argc, char* argv[])
                   << ", EDM4hep: " << edmEvent.get(name)->size() << std::endl;
         return 1;
       }
+
+      const auto objectMapping = ObjectMappings::fromEvent(lcEvent, edmEvent);
 
       ASSERT_COMPARE_OR_EXIT(edm4hep::MCParticleCollection)
       ASSERT_COMPARE_OR_EXIT(edm4hep::ReconstructedParticleCollection)

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -12,7 +12,7 @@
 #define ASSERT_COMPARE_OR_EXIT(collType)                   \
   if (type == #collType) {                                 \
     auto& edmcoll = edmEvent.get<collType>(name);          \
-    if (!compare(lcioColl, edmcoll)) {                     \
+    if (!compare(lcioColl, edmcoll, objectMapping)) {      \
       std::cerr << "in collection: " << name << std::endl; \
       return 1;                                            \
     }                                                      \

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -73,6 +73,12 @@ int main(int argc, char* argv[])
         return 1;
       }
 
+      if (edmEvent.get(name)->size() != lcioColl->getNumberOfElements()) {
+        std::cerr << "Collection " << name << " has different sizes. LCIO: " << lcioColl->getNumberOfElements()
+                  << ", EDM4hep: " << edmEvent.get(name)->size() << std::endl;
+        return 1;
+      }
+
       ASSERT_COMPARE_OR_EXIT(edm4hep::MCParticleCollection)
       ASSERT_COMPARE_OR_EXIT(edm4hep::ReconstructedParticleCollection)
       ASSERT_COMPARE_OR_EXIT(edm4hep::TrackCollection)

--- a/tests/scripts/get_test_data.sh
+++ b/tests/scripts/get_test_data.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu
+
+TEST_INPUT_DIR=${TEST_DIR}/inputFiles
+mkdir -p ${TEST_INPUT_DIR}
+
+TEST_FILES=("ild_higgs_rec.slcio" "ild_higgs_dst.slcio")
+
+for input_file in ${TEST_FILES[@]}; do
+    if [ ! -f ${TEST_INPUT_DIR}/${input_file} ]; then
+        echo "${input_file} test input file not yet present. Fetching it"
+        wget https://key4hep.web.cern.ch/testFiles/k4EDM4hep2LcioConv/ILD/${input_file} -P ${TEST_INPUT_DIR}
+    fi
+done

--- a/tests/scripts/run_standalone_converter.sh
+++ b/tests/scripts/run_standalone_converter.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+input_file_base=${1}
+
+TEST_INPUT_DIR=${TEST_DIR}/inputFiles
+TEST_OUTPUT_DIR=testOutputs
+mkdir -p ${TEST_OUTPUT_DIR}
+
+input_file=${TEST_INPUT_DIR}/${input_file_base}
+output_file=${TEST_OUTPUT_DIR}/${input_file_base/.slcio/.edm4hep.root}
+patch_file=${TEST_OUTPUT_DIR}/${input_file_base/.slcio/_colls.txt}
+
+echo "Creating the patch file for the standalone converter"
+check_missing_cols --minimal ${input_file} > ${patch_file}
+
+echo "Running the standalone converter"
+lcio2edm4hep ${input_file} ${output_file} ${patch_file}
+
+echo "Comparing the converted and original contents"
+compare-contents ${input_file} ${output_file}

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -20,7 +20,10 @@
 
 // ================= CalorimeterHit ================
 
-bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHit& edm4hepElem)
+bool compare(
+  const EVENT::CalorimeterHit* lcioElem,
+  const edm4hep::CalorimeterHit& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   // LCIO has CellID0 and CellID1
   const auto lcioCellID = [&]() {
@@ -41,14 +44,17 @@ bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHi
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::CalorimeterHitCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::CalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::CalorimeterHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::CalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= Cluster ================
 
-bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem)
+bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem, const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in Cluster");
@@ -62,14 +68,20 @@ bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::ClusterCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::ClusterCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::Cluster>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::Cluster>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= MCParticle ================
 
-bool compare(const EVENT::MCParticle* lcioElem, const edm4hep::MCParticle& edm4hepElem)
+bool compare(
+  const EVENT::MCParticle* lcioElem,
+  const edm4hep::MCParticle& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPDG, "PDG in MCParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getGeneratorStatus, "generatorStatus in MCParticle");
@@ -96,9 +108,12 @@ bool compare(const EVENT::MCParticle* lcioElem, const edm4hep::MCParticle& edm4h
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticleCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::MCParticleCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::MCParticle>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::MCParticle>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= ParticleID ================
@@ -114,7 +129,10 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticle
 
 // ================= RawCalorimeterHit ================
 
-bool compare(const EVENT::RawCalorimeterHit* lcioElem, const edm4hep::RawCalorimeterHit& edm4hepElem)
+bool compare(
+  const EVENT::RawCalorimeterHit* lcioElem,
+  const edm4hep::RawCalorimeterHit& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   // LCIO has CellID0 and CellID1
   const auto lcioCellID = [&]() {
@@ -132,14 +150,20 @@ bool compare(const EVENT::RawCalorimeterHit* lcioElem, const edm4hep::RawCalorim
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawCalorimeterHitCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::RawCalorimeterHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::RawCalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= ReconstructedParticle ================
 
-bool compare(const EVENT::ReconstructedParticle* lcioElem, const edm4hep::ReconstructedParticle& edm4hepElem)
+bool compare(
+  const EVENT::ReconstructedParticle* lcioElem,
+  const edm4hep::ReconstructedParticle& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in ReconstructedParticle");
@@ -154,14 +178,18 @@ bool compare(const EVENT::ReconstructedParticle* lcioElem, const edm4hep::Recons
 
 bool compare(
   const lcio::LCCollection* lcioCollection,
-  const edm4hep::ReconstructedParticleCollection& edm4hepCollection)
+  const edm4hep::ReconstructedParticleCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::ReconstructedParticle>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::ReconstructedParticle>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= SimCalorimeterHit ================
 
-bool compare(const EVENT::SimCalorimeterHit* lcioElem, const edm4hep::SimCalorimeterHit& edm4hepElem)
+bool compare(
+  const EVENT::SimCalorimeterHit* lcioElem,
+  const edm4hep::SimCalorimeterHit& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   // LCIO has CellID0 and CellID1
   const auto lcioCellID = [&]() {
@@ -178,14 +206,20 @@ bool compare(const EVENT::SimCalorimeterHit* lcioElem, const edm4hep::SimCalorim
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimCalorimeterHitCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::SimCalorimeterHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::SimCalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= SimTrackerHit ================
 
-bool compare(const EVENT::SimTrackerHit* lcioElem, const edm4hep::SimTrackerHit& edm4hepElem)
+bool compare(
+  const EVENT::SimTrackerHit* lcioElem,
+  const edm4hep::SimTrackerHit& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEDep, "EDep in SimTrackerHit");
@@ -197,14 +231,17 @@ bool compare(const EVENT::SimTrackerHit* lcioElem, const edm4hep::SimTrackerHit&
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimTrackerHitCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::SimTrackerHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::SimTrackerHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::SimTrackerHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TPCHit ================
 
-bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem)
+bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem, const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in TPCHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getQuality, "quality in TPCHit");
@@ -213,14 +250,17 @@ bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4he
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawTimeSeriesCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::TPCHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::TPCHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= Track ================
 
-bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem)
+bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, const ObjectMappings& objectMaps)
 {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Track");
@@ -242,14 +282,20 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem)
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::Track>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::Track>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TrackerHit ================
 
-bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit& edm4hepElem)
+bool compare(
+  const EVENT::TrackerHit* lcioElem,
+  const edm4hep::TrackerHit& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   // LCIO has CellID0 and CellID1
   const auto lcioCellID = [&]() {
@@ -271,14 +317,20 @@ bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit& edm4h
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackerHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::TrackerHit>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::TrackerHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TrackerHitPlane ================
 
-bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPlane& edm4hepElem)
+bool compare(
+  const EVENT::TrackerHitPlane* lcioElem,
+  const edm4hep::TrackerHitPlane& edm4hepElem,
+  const ObjectMappings& objectMaps)
 {
   // LCIO has CellID0 and CellID1
   const auto lcioCellID = [&]() {
@@ -306,14 +358,17 @@ bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPl
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitPlaneCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::TrackerHitPlane>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::TrackerHitPlane>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= Vertex ================
 
-bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem)
+bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem, const ObjectMappings& objectMaps)
 {
   // LCIO has isPrimary (bool), EDM4hep has getPrimary (int32_t)
   ASSERT_COMPARE_VALS(lcioElem->isPrimary(), edm4hepElem.getPrimary(), "primary in Vertex");
@@ -327,9 +382,12 @@ bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem)
   return true;
 }
 
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexCollection& edm4hepCollection)
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::VertexCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
-  return compareCollection<EVENT::Vertex>(lcioCollection, edm4hepCollection);
+  return compareCollection<EVENT::Vertex>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent)

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -22,9 +22,17 @@
 
 bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHit& edm4hepElem)
 {
-  // TODO: cellID vs. cellID0 and cellID1 in LCIO
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in
-  // CalorimeterHit");
+  // LCIO has CellID0 and CellID1
+  const auto lcioCellID = [&]() {
+    const auto cellID0 = lcioElem->getCellID0();
+    const auto cellID1 = lcioElem->getCellID1();
+
+    uint64_t cellID = cellID1;
+    cellID = (cellID << 32) | cellID0;
+    return cellID;
+  }();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in CalorimeterHit");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in CalorimeterHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergyError, "energyError in CalorimeterHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTime, "time in CalorimeterHit");
@@ -108,9 +116,17 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticle
 
 bool compare(const EVENT::RawCalorimeterHit* lcioElem, const edm4hep::RawCalorimeterHit& edm4hepElem)
 {
-  // TODO: LCIO has getCellID0 and getCellID1
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID,
-  //                "cellID in RawCalorimeterHit");
+  // LCIO has CellID0 and CellID1
+  const auto lcioCellID = [&]() {
+    const auto cellID0 = lcioElem->getCellID0();
+    const auto cellID1 = lcioElem->getCellID1();
+
+    uint64_t cellID = cellID1;
+    cellID = (cellID << 32) | cellID0;
+    return cellID;
+  }();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in RawCalorimeterHit");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getAmplitude, "amplitude in RawCalorimeterHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTimeStamp, "timeStamp in RawCalorimeterHit");
   return true;
@@ -147,9 +163,16 @@ bool compare(
 
 bool compare(const EVENT::SimCalorimeterHit* lcioElem, const edm4hep::SimCalorimeterHit& edm4hepElem)
 {
-  // TODO: LCIO has getCellID0 and getCellID1
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID,
-  //                "cellID in SimCalorimeterHit");
+  // LCIO has CellID0 and CellID1
+  const auto lcioCellID = [&]() {
+    const auto cellID0 = lcioElem->getCellID0();
+    const auto cellID1 = lcioElem->getCellID1();
+    uint64_t cellID = cellID1;
+    cellID = (cellID << 32) | cellID0;
+    return cellID;
+  }();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in SimCalorimeterHit");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in SimCalorimeterHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in SimCalorimeterHit");
   return true;
@@ -218,8 +241,16 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackColle
 
 bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit& edm4hepElem)
 {
-  // TODO: LCIO has getCellID0 and getCellID1
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in TrackerHit");
+  // LCIO has CellID0 and CellID1
+  const auto lcioCellID = [&]() {
+    const auto cellID0 = lcioElem->getCellID0();
+    const auto cellID1 = lcioElem->getCellID1();
+    uint64_t cellID = cellID1;
+    cellID = (cellID << 32) | cellID0;
+    return cellID;
+  }();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHit");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in TrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getQuality, "quality in TrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTime, "time in TrackerHit");
@@ -239,9 +270,16 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHit
 
 bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPlane& edm4hepElem)
 {
-  // TODO: LCIO has getCellID0 and getCellID1
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in
-  // TrackerHitPlane");
+  // LCIO has CellID0 and CellID1
+  const auto lcioCellID = [&]() {
+    const auto cellID0 = lcioElem->getCellID0();
+    const auto cellID1 = lcioElem->getCellID1();
+    uint64_t cellID = cellID1;
+    cellID = (cellID << 32) | cellID0;
+    return cellID;
+  }();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHitPlane");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in TrackerHitPlane");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getQuality, "quality in TrackerHitPlane");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTime, "time in TrackerHitPlane");

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -3,6 +3,8 @@
 
 #include "IMPL/TrackerHitImpl.h"
 
+#include <cstdint>
+
 /**
  * The basic implementation of the functionality has been generated via modified
  * podio templates, employing some handwritten macros to facilitate the task.

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -103,12 +103,6 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticle
 //     ParticleID"); ASSERT_COMPARE(lcioElem, edm4hepElem, getLikelihood,
 //     "likelihood in ParticleID"); return true;
 // }
-//
-// bool compare(const lcio::LCCollection* lcioCollection, const
-// edm4hep::ParticleIDCollection& edm4hepCollection) {
-//  return compareCollection<EVENT::ParticleID>(lcioCollection,
-//  edm4hepCollection);
-// }
 
 // ================= RawCalorimeterHit ================
 

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -20,6 +20,17 @@
  * TODO: Also compare relations
  */
 
+/// Convert the two 32 bit cellIDs into one 64 bit value
+template<typename LcioT>
+auto to64BitCellID(LcioT* obj)
+{
+  const auto cellID0 = obj->getCellID0();
+  const auto cellID1 = obj->getCellID1();
+  uint64_t cellID = cellID1;
+  cellID = (cellID << 32) | cellID0;
+  return cellID;
+}
+
 // ================= CalorimeterHit ================
 
 bool compare(
@@ -27,15 +38,7 @@ bool compare(
   const edm4hep::CalorimeterHit& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  // LCIO has CellID0 and CellID1
-  const auto lcioCellID = [&]() {
-    const auto cellID0 = lcioElem->getCellID0();
-    const auto cellID1 = lcioElem->getCellID1();
-
-    uint64_t cellID = cellID1;
-    cellID = (cellID << 32) | cellID0;
-    return cellID;
-  }();
+  const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in CalorimeterHit");
 
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in CalorimeterHit");
@@ -140,15 +143,7 @@ bool compare(
   const edm4hep::RawCalorimeterHit& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  // LCIO has CellID0 and CellID1
-  const auto lcioCellID = [&]() {
-    const auto cellID0 = lcioElem->getCellID0();
-    const auto cellID1 = lcioElem->getCellID1();
-
-    uint64_t cellID = cellID1;
-    cellID = (cellID << 32) | cellID0;
-    return cellID;
-  }();
+  const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in RawCalorimeterHit");
 
   ASSERT_COMPARE(lcioElem, edm4hepElem, getAmplitude, "amplitude in RawCalorimeterHit");
@@ -209,14 +204,7 @@ bool compare(
   const edm4hep::SimCalorimeterHit& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  // LCIO has CellID0 and CellID1
-  const auto lcioCellID = [&]() {
-    const auto cellID0 = lcioElem->getCellID0();
-    const auto cellID1 = lcioElem->getCellID1();
-    uint64_t cellID = cellID1;
-    cellID = (cellID << 32) | cellID0;
-    return cellID;
-  }();
+  const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in SimCalorimeterHit");
 
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in SimCalorimeterHit");
@@ -388,14 +376,7 @@ bool compare(
   const edm4hep::TrackerHit& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  // LCIO has CellID0 and CellID1
-  const auto lcioCellID = [&]() {
-    const auto cellID0 = lcioElem->getCellID0();
-    const auto cellID1 = lcioElem->getCellID1();
-    uint64_t cellID = cellID1;
-    cellID = (cellID << 32) | cellID0;
-    return cellID;
-  }();
+  const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHit");
 
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in TrackerHit");
@@ -423,14 +404,7 @@ bool compare(
   const edm4hep::TrackerHitPlane& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  // LCIO has CellID0 and CellID1
-  const auto lcioCellID = [&]() {
-    const auto cellID0 = lcioElem->getCellID0();
-    const auto cellID1 = lcioElem->getCellID1();
-    uint64_t cellID = cellID1;
-    cellID = (cellID << 32) | cellID0;
-    return cellID;
-  }();
+  const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHitPlane");
 
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in TrackerHitPlane");

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -56,8 +56,8 @@ bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPositionError, "positionError in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getITheta, "iTheta in Cluster");
-  // TODO: LCIO has getIPhi not get Phi
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getPhi, "phi in Cluster");
+  // LCIO has getIPhi and EDM4hep has getPhi
+  ASSERT_COMPARE_VALS(lcioElem->getIPhi(), edm4hepElem.getPhi(), "phi in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getDirectionError, "directionError in Cluster");
   return true;
 }
@@ -225,9 +225,19 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem)
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getNdf, "ndf in Track");
-  // TODO: LCIO has getdEdx instead of getDEdx
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getDEdx, "dEdx in Track");
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getDEdxError, "dEdxError in Track");
+  // LCIO has getdEdx instead of getDEdx
+  ASSERT_COMPARE_VALS(lcioElem->getdEdx(), edm4hepElem.getDEdx(), "dEdx in Track");
+  ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), edm4hepElem.getDEdxError(), "dEdxError in Track");
+  // Also check whether these have been corretly put into the dQQuantities
+  const auto dxQuantities = edm4hepElem.getDxQuantities();
+  if (dxQuantities.size() != 1) {
+    std::cerr << "DxQuantities have not been filled correctly, expected exactly 1, got " << dxQuantities.size()
+              << " in Track" << std::endl;
+    return false;
+  }
+  ASSERT_COMPARE_VALS(lcioElem->getdEdx(), dxQuantities[0].value, "dEdx in DxQuantities in Track");
+  ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), dxQuantities[0].error, "dEdxError in DxQuantities in Track");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getRadiusOfInnermostHit, "radiusOfInnermostHit in Track");
   return true;
 }
@@ -287,9 +297,10 @@ bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPl
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEDepError, "eDepError in TrackerHitPlane");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getU, "u in TrackerHitPlane");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getV, "v in TrackerHitPlane");
-  // TODO: LCIO has getdU and getdV instead of getDu and getDv
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getDu, "du in TrackerHitPlane");
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getDv, "dv in TrackerHitPlane");
+  // LCIO has getdU and getdV instead of getDu and getDv
+  ASSERT_COMPARE_VALS(lcioElem->getdV(), edm4hepElem.getDv(), "dv in TrackerHitPlane");
+  ASSERT_COMPARE_VALS(lcioElem->getdU(), edm4hepElem.getDu(), "du in TrackerHitPlane");
+
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in TrackerHitPlane");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getCovMatrix, "covMatrix in TrackerHitPlane");
   return true;
@@ -304,8 +315,8 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHit
 
 bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem)
 {
-  // TODO: LCIO has isPrimary
-  // ASSERT_COMPARE(lcioElem, edm4hepElem, getPrimary, "primary in Vertex");
+  // LCIO has isPrimary (bool), EDM4hep has getPrimary (int32_t)
+  ASSERT_COMPARE_VALS(lcioElem->isPrimary(), edm4hepElem.getPrimary(), "primary in Vertex");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Vertex");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getProbability, "probability in Vertex");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in Vertex");

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -1,6 +1,8 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H
 #define K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H
 
+#include "ObjectMapping.h"
+
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
@@ -45,43 +47,92 @@
 #include <EVENT/Vertex.h>
 #include <lcio.h>
 
-bool compare(const EVENT::CalorimeterHit* lcio, const edm4hep::CalorimeterHit& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::CalorimeterHitCollection& edm4hepCollection);
-
-bool compare(const EVENT::Cluster* lcio, const edm4hep::Cluster& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::ClusterCollection& edm4hepCollection);
-
-bool compare(const EVENT::MCParticle* lcio, const edm4hep::MCParticle& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticleCollection& edm4hepCollection);
-
-bool compare(const EVENT::RawCalorimeterHit* lcio, const edm4hep::RawCalorimeterHit& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawCalorimeterHitCollection& edm4hepCollection);
-
-bool compare(const EVENT::ReconstructedParticle* lcio, const edm4hep::ReconstructedParticle& edm4hep);
+bool compare(
+  const EVENT::CalorimeterHit* lcio,
+  const edm4hep::CalorimeterHit& edm4hep,
+  const ObjectMappings& objectMaps);
 bool compare(
   const lcio::LCCollection* lcioCollection,
-  const edm4hep::ReconstructedParticleCollection& edm4hepCollection);
+  const edm4hep::CalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::SimCalorimeterHit* lcio, const edm4hep::SimCalorimeterHit& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimCalorimeterHitCollection& edm4hepCollection);
+bool compare(const EVENT::Cluster* lcio, const edm4hep::Cluster& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::ClusterCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::SimTrackerHit* lcio, const edm4hep::SimTrackerHit& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimTrackerHitCollection& edm4hepCollection);
+bool compare(const EVENT::MCParticle* lcio, const edm4hep::MCParticle& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::MCParticleCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::TPCHit* lcio, const edm4hep::RawTimeSeries& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawTimeSeriesCollection& edm4hepCollection);
+bool compare(
+  const EVENT::RawCalorimeterHit* lcio,
+  const edm4hep::RawCalorimeterHit& edm4hep,
+  const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::TrackerHit* lcio, const edm4hep::TrackerHit& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitCollection& edm4hepCollection);
+bool compare(
+  const EVENT::ReconstructedParticle* lcio,
+  const edm4hep::ReconstructedParticle& edm4hep,
+  const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::ReconstructedParticleCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::TrackerHitPlane* lcio, const edm4hep::TrackerHitPlane& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitPlaneCollection& edm4hepCollection);
+bool compare(
+  const EVENT::SimCalorimeterHit* lcio,
+  const edm4hep::SimCalorimeterHit& edm4hep,
+  const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::Track* lcio, const edm4hep::Track& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackCollection& edm4hepCollection);
+bool compare(const EVENT::SimTrackerHit* lcio, const edm4hep::SimTrackerHit& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::SimTrackerHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
-bool compare(const EVENT::Vertex* lcio, const edm4hep::Vertex& edm4hep);
-bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexCollection& edm4hepCollection);
+bool compare(const EVENT::TPCHit* lcio, const edm4hep::RawTimeSeries& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
+
+bool compare(const EVENT::TrackerHit* lcio, const edm4hep::TrackerHit& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackerHitCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
+
+bool compare(
+  const EVENT::TrackerHitPlane* lcio,
+  const edm4hep::TrackerHitPlane& edm4hep,
+  const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
+
+bool compare(const EVENT::Track* lcio, const edm4hep::Track& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::TrackCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
+
+bool compare(const EVENT::Vertex* lcio, const edm4hep::Vertex& edm4hep, const ObjectMappings& objectMaps);
+bool compare(
+  const lcio::LCCollection* lcioCollection,
+  const edm4hep::VertexCollection& edm4hepCollection,
+  const ObjectMappings& objectMaps);
 
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent);
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -122,6 +122,8 @@ bool compare(
   const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
   const ObjectMappings& objectMaps);
 
+bool compare(const EVENT::TrackState* lcio, const edm4hep::TrackState& edm4hep);
+
 bool compare(const EVENT::Track* lcio, const edm4hep::Track& edm4hep, const ObjectMappings& objectMaps);
 bool compare(
   const lcio::LCCollection* lcioCollection,

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -136,5 +136,7 @@ bool compare(
   const edm4hep::VertexCollection& edm4hepCollection,
   const ObjectMappings& objectMaps);
 
+bool compare(const EVENT::ParticleID* lcio, const edm4hep::ParticleID& edm4hep);
+
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent);
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -45,21 +45,11 @@
 #include <EVENT/Vertex.h>
 #include <lcio.h>
 
-// bool compare(const EVENT::CaloHitContribution *lcio,
-//             const edm4hep::CaloHitContribution &edm4hep);
-// bool compare(const lcio::LCCollection *lcioCollection,
-//             const edm4hep::CaloHitContributionCollection &edm4hepCollection);
-
 bool compare(const EVENT::CalorimeterHit* lcio, const edm4hep::CalorimeterHit& edm4hep);
 bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::CalorimeterHitCollection& edm4hepCollection);
 
 bool compare(const EVENT::Cluster* lcio, const edm4hep::Cluster& edm4hep);
 bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::ClusterCollection& edm4hepCollection);
-
-// bool compare(const EVENT::EventHeader *lcio,
-//              const edm4hep::EventHeader &edm4hep);
-// bool compare(const lcio::LCCollection *lcioCollection,
-//              const edm4hep::EventHeaderCollection &edm4hepCollection);
 
 bool compare(const EVENT::MCParticle* lcio, const edm4hep::MCParticle& edm4hep);
 bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticleCollection& edm4hepCollection);

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -1,6 +1,8 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_COMPARISONUTILS_H
 #define K4EDM4HEP2LCIOCONV_TEST_COMPARISONUTILS_H
 
+#include "ObjectMapping.h"
+
 #include "edm4hep/Vector2f.h"
 #include "edm4hep/Vector2i.h"
 #include "edm4hep/Vector3d.h"
@@ -125,12 +127,15 @@ VECTOR2_COMPARE(float, edm4hep::Vector2f)
 // Compare an LCIO collection and an EDM4hep collection. Assumes that a compare
 // function working with the element types is available
 template<typename LCIOT, typename EDM4hepCollT>
-bool compareCollection(const lcio::LCCollection* lcioCollection, const EDM4hepCollT& edm4hepCollection)
+bool compareCollection(
+  const lcio::LCCollection* lcioCollection,
+  const EDM4hepCollT& edm4hepCollection,
+  const ObjectMappings& objectMaps)
 {
   UTIL::LCIterator<LCIOT> lcioIt(lcioCollection);
   int counter = 0;
   for (const auto edm4hepElem : edm4hepCollection) {
-    if (!compare(lcioIt.next(), edm4hepElem)) {
+    if (!compare(lcioIt.next(), edm4hepElem, objectMaps)) {
       std::cerr << "in Element " << counter << std::endl;
       return false;
     }

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -177,6 +177,7 @@ bool compareRelation(const LcioT* lcioElem, const EDM4hepT& edm4hepElem, const M
   }
   else {
     std::cerr << msg << " cannot find LCIO object " << lcioElem << " in object map for relation checking" << std::endl;
+    return false;
   }
 
   return true;

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -11,10 +11,18 @@
 #include "UTIL/LCIterator.h"
 #include "EVENT/LCCollection.h"
 
+#include "podio/RelationRange.h"
+#include "podio/ObjectID.h"
+
 #include <cmath>
 #include <array>
 #include <iostream>
 #include <vector>
+
+std::ostream& operator<<(std::ostream& os, const podio::ObjectID id)
+{
+  return os << "[" << id.collectionID << ": " << id.index << "]";
+}
 
 template<typename T>
 std::ostream& printContainer(std::ostream& os, const T& cont)
@@ -42,6 +50,12 @@ std::ostream& operator<<(std::ostream& os, const std::array<T, N>& arr)
   return printContainer(os, arr);
 }
 
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const podio::RelationRange<T>& range)
+{
+  return printContainer(os, range);
+}
+
 template<typename T, size_t N>
 bool operator==(const std::vector<T>& vec, const std::array<T, N>& arr)
 {
@@ -60,6 +74,26 @@ template<typename T, size_t N>
 bool operator!=(const std::vector<T>& vec, const std::array<T, N>& arr)
 {
   return !(vec == arr);
+}
+
+template<typename T>
+bool operator==(const std::vector<T>& vec, const podio::RelationRange<T>& range)
+{
+  if (vec.size() != range.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < vec.size(); ++i) {
+    if (vec[i] != range[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template<typename T>
+bool operator!=(const std::vector<T>& vec, const podio::RelationRange<T>& range)
+{
+  return !(vec == range);
 }
 
 template<typename T, typename U>
@@ -122,6 +156,74 @@ VECTOR2_COMPARE(float, edm4hep::Vector2f)
     const auto lcioV = lcioE->func();              \
     const auto edm4hepV = edm4hepE.func();         \
     ASSERT_COMPARE_VALS(lcioV, edm4hepV, msg)      \
+  }
+
+/**
+ * Compare a single relation by checking whether the LCIO object points to the
+ * correct EDM4hep element (using the ObjectIDs)
+ */
+template<typename LcioT, typename EDM4hepT, typename MapT>
+bool compareRelation(const LcioT* lcioElem, const EDM4hepT& edm4hepElem, const MapT& objectMap, const std::string& msg)
+{
+  if (lcioElem == nullptr && edm4hepElem.isAvailable()) {
+    std::cerr << msg << " LCIO element is empty but edm4hep element is not" << std::endl;
+  }
+  if (const auto it = objectMap.find(lcioElem); it != objectMap.end()) {
+    if (!(it->second == edm4hepElem.getObjectID())) {
+      std::cerr << msg << " LCIO element " << lcioElem << " points to " << it->second << " but should point to "
+                << edm4hepElem.getObjectID() << std::endl;
+      return false;
+    }
+  }
+  else {
+    std::cerr << msg << " cannot find LCIO object " << lcioElem << " in object map for relation checking" << std::endl;
+  }
+
+  return true;
+}
+
+/**
+ * Compare the relations in the form of a range of LCIO objects to the
+ * corresponding range of EDM4hep objects. This uses the LCIO object for lookup
+ * in the object map and then compares the object ID of the EDM4hep object.
+ *
+ * Naming is using the singular form to have an overload set in the macro below
+ * that dispatches this.
+ */
+template<typename LcioT, typename EDM4hepT, typename MapT>
+bool compareRelation(
+  const std::vector<LcioT*>& lcioRange,
+  const podio::RelationRange<EDM4hepT>& edm4hepRange,
+  const MapT& objectMap,
+  const std::string& msg)
+{
+  if (lcioRange.size() != edm4hepRange.size()) {
+    // Make sure to take into account that the LCIO -> EDM4hep conversion does
+    // not fill relations if the original relations in LCIO were empty
+    const auto nonNullLcio =
+      std::count_if(lcioRange.begin(), lcioRange.end(), [](const auto e) { return e != nullptr; });
+    if (nonNullLcio != edm4hepRange.size()) {
+      std::cerr << msg << " different sizes (even after taking null values into account)" << std::endl;
+      return false;
+    }
+  }
+
+  for (size_t i = 0; i < edm4hepRange.size(); ++i) {
+    const auto lcioElem = lcioRange[i];
+    const auto edm4hepElem = edm4hepRange[i];
+    if (!compareRelation(lcioElem, edm4hepElem, objectMap, msg)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#define ASSERT_COMPARE_RELATION(lcioE, edm4hepE, func, map, msg) \
+  {                                                              \
+    const auto& lcioRel = lcioE->func();                         \
+    const auto edm4hepRel = edm4hepE.func();                     \
+    return compareRelation(lcioRel, edm4hepRel, map, msg);       \
   }
 
 // Compare an LCIO collection and an EDM4hep collection. Assumes that a compare

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -127,10 +127,6 @@ VECTOR2_COMPARE(float, edm4hep::Vector2f)
 template<typename LCIOT, typename EDM4hepCollT>
 bool compareCollection(const lcio::LCCollection* lcioCollection, const EDM4hepCollT& edm4hepCollection)
 {
-  if (lcioCollection->getNumberOfElements() != edm4hepCollection.size()) {
-    return false;
-  }
-
   UTIL::LCIterator<LCIOT> lcioIt(lcioCollection);
   int counter = 0;
   for (const auto edm4hepElem : edm4hepCollection) {

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -20,11 +20,6 @@
 #include <vector>
 #include <algorithm>
 
-std::ostream& operator<<(std::ostream& os, const podio::ObjectID id)
-{
-  return os << "[" << id.collectionID << ": " << id.index << "]";
-}
-
 template<typename T>
 std::ostream& printContainer(std::ostream& os, const T& cont)
 {

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -18,6 +18,7 @@
 #include <array>
 #include <iostream>
 #include <vector>
+#include <algorithm>
 
 std::ostream& operator<<(std::ostream& os, const podio::ObjectID id)
 {

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -1,0 +1,92 @@
+#include "ObjectMapping.h"
+
+#include "EVENT/LCEvent.h"
+#include "EVENT/Track.h"
+#include "EVENT/TrackerHit.h"
+#include "EVENT/TrackerHitPlane.h"
+#include "EVENT/SimTrackerHit.h"
+#include "EVENT/CalorimeterHit.h"
+#include "EVENT/RawCalorimeterHit.h"
+#include "EVENT/SimCalorimeterHit.h"
+#include "EVENT/TPCHit.h"
+#include "EVENT/Cluster.h"
+#include "EVENT/Vertex.h"
+#include "EVENT/ReconstructedParticle.h"
+#include "EVENT/MCParticle.h"
+#include "EVENT/ParticleID.h"
+#include "EVENT/LCEvent.h"
+#include "EVENT/LCCollection.h"
+#include "UTIL/LCIterator.h"
+
+#include "edm4hep/TrackCollection.h"
+#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/RawCalorimeterHitCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/ParticleIDCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
+#include "edm4hep/VertexCollection.h"
+
+#include "podio/ObjectID.h"
+#include "podio/Frame.h"
+
+template<typename LcioT, typename EDM4hepT, typename MapT>
+void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl)
+{
+  // Simply assume that the collections have the same size here
+  UTIL::LCIterator<LcioT> lcioIt(lcioColl);
+
+  for (const auto edmElem : edmColl) {
+    const auto* lcioElem = lcioIt.next();
+    map.emplace(lcioElem, edmElem.getObjectID());
+  }
+}
+
+#define FILL_MAP(Type, mapName)                                  \
+  if (type == #Type) {                                           \
+    using namespace edm4hep;                                     \
+    auto& edm4hepColl = edmEvt.get<Type::collection_type>(name); \
+    fillMap<EVENT::Type>(mapName, lcioColl, edm4hepColl);        \
+  }
+
+ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt)
+{
+  ObjectMappings mapping {};
+
+  for (const auto& name : *(lcEvt->getCollectionNames())) {
+    // We only use non subset collections here, because we want the "real"
+    // objects
+    const auto lcioColl = lcEvt->getCollection(name);
+    if (lcioColl->isSubset()) {
+      continue;
+    }
+    const auto type = lcioColl->getTypeName();
+    if (type == "LCRelation") {
+      continue;
+    }
+    FILL_MAP(Track, mapping.tracks);
+    FILL_MAP(TrackerHit, mapping.trackerHits);
+    FILL_MAP(TrackerHitPlane, mapping.trackerHitPlanes);
+    FILL_MAP(SimTrackerHit, mapping.simTrackerHits);
+    FILL_MAP(Cluster, mapping.clusters);
+    FILL_MAP(CalorimeterHit, mapping.caloHits);
+    FILL_MAP(RawCalorimeterHit, mapping.rawCaloHits);
+    FILL_MAP(SimCalorimeterHit, mapping.simCaloHits);
+    FILL_MAP(MCParticle, mapping.mcParticles);
+    FILL_MAP(ReconstructedParticle, mapping.recoParticles);
+    FILL_MAP(ParticleID, mapping.particleIDs);
+    FILL_MAP(Vertex, mapping.vertices);
+    // Need special treatment for TPCHit type mismatch
+    if (type == "TPCHit") {
+      auto& edm4hepColl = edmEvt.get<edm4hep::RawTimeSeriesCollection>(name);
+      fillMap<EVENT::TPCHit>(mapping.tpcHits, lcioColl, edm4hepColl);
+    }
+  }
+
+  return mapping;
+}

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -13,7 +13,6 @@
 #include "EVENT/Vertex.h"
 #include "EVENT/ReconstructedParticle.h"
 #include "EVENT/MCParticle.h"
-#include "EVENT/ParticleID.h"
 #include "EVENT/LCEvent.h"
 #include "EVENT/LCCollection.h"
 #include "UTIL/LCIterator.h"
@@ -28,7 +27,6 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
-#include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/VertexCollection.h"
 

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -79,7 +79,6 @@ ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Fra
     FILL_MAP(SimCalorimeterHit, mapping.simCaloHits);
     FILL_MAP(MCParticle, mapping.mcParticles);
     FILL_MAP(ReconstructedParticle, mapping.recoParticles);
-    FILL_MAP(ParticleID, mapping.particleIDs);
     FILL_MAP(Vertex, mapping.vertices);
     // Need special treatment for TPCHit type mismatch
     if (type == "TPCHit") {

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -1,0 +1,58 @@
+// #include "EVENT/Track.h"
+// #include "EVENT/TrackerHit.h"
+// #include "EVENT/TrackerHitPlane.h"
+// #include "EVENT/SimTrackerHit.h"
+// #include "EVENT/CalorimeterHit.h"
+// #include "EVENT/RawCalorimeterHit.h"
+// #include "EVENT/SimCalorimeterHit.h"
+// #include "EVENT/TPCHit.h"
+// #include "EVENT/Cluster.h"
+// #include "EVENT/Vertex.h"
+// #include "EVENT/ReconstructedParticle.h"
+// #include "EVENT/MCParticle.h"
+// #include "EVENT/ParticleID.h"
+
+#include <unordered_map>
+
+namespace EVENT {
+  class Track;
+  class TrackerHit;
+  class TrackerHitPlane;
+  class SimTrackerHit;
+  class CalorimeterHit;
+  class RawCalorimeterHit;
+  class SimCalorimeterHit;
+  class TPCHit;
+  class Cluster;
+  class Vertex;
+  class ReconstructedParticle;
+  class MCParticle;
+  class ParticleID;
+  class LCEvent;
+} // namespace EVENT
+
+namespace podio {
+  class ObjectID;
+  class Frame;
+} // namespace podio
+
+struct ObjectMappings {
+  template<typename K>
+  using Map = std::unordered_map<K, podio::ObjectID>;
+
+  Map<const EVENT::Track*> tracks {};
+  Map<const EVENT::TrackerHit*> trackerHits {};
+  Map<const EVENT::TrackerHitPlane*> trackerHitPlanes {};
+  Map<const EVENT::SimTrackerHit*> simTrackerHits {};
+  Map<const EVENT::Cluster*> clusters {};
+  Map<const EVENT::CalorimeterHit*> caloHits {};
+  Map<const EVENT::RawCalorimeterHit*> rawCaloHits {};
+  Map<const EVENT::SimCalorimeterHit*> simCaloHits {};
+  Map<const EVENT::MCParticle*> mcParticles {};
+  Map<const EVENT::ReconstructedParticle*> recoParticles {};
+  Map<const EVENT::ParticleID*> particleIDs {};
+  Map<const EVENT::TPCHit*> tpcHits {};
+  Map<const EVENT::Vertex*> vertices {};
+
+  static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
+};

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -1,16 +1,5 @@
-// #include "EVENT/Track.h"
-// #include "EVENT/TrackerHit.h"
-// #include "EVENT/TrackerHitPlane.h"
-// #include "EVENT/SimTrackerHit.h"
-// #include "EVENT/CalorimeterHit.h"
-// #include "EVENT/RawCalorimeterHit.h"
-// #include "EVENT/SimCalorimeterHit.h"
-// #include "EVENT/TPCHit.h"
-// #include "EVENT/Cluster.h"
-// #include "EVENT/Vertex.h"
-// #include "EVENT/ReconstructedParticle.h"
-// #include "EVENT/MCParticle.h"
-// #include "EVENT/ParticleID.h"
+#ifndef K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
+#define K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
 
 #include <unordered_map>
 
@@ -56,3 +45,5 @@ struct ObjectMappings {
 
   static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
 };
+
+#endif

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -39,7 +39,6 @@ struct ObjectMappings {
   Map<const EVENT::SimCalorimeterHit*> simCaloHits {};
   Map<const EVENT::MCParticle*> mcParticles {};
   Map<const EVENT::ReconstructedParticle*> recoParticles {};
-  Map<const EVENT::ParticleID*> particleIDs {};
   Map<const EVENT::TPCHit*> tpcHits {};
   Map<const EVENT::Vertex*> vertices {};
 

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -16,7 +16,6 @@ namespace EVENT {
   class Vertex;
   class ReconstructedParticle;
   class MCParticle;
-  class ParticleID;
   class LCEvent;
 } // namespace EVENT
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add test setup to run the standalone converter on ILD REC and DST files with a comparison between the original and the converted file afterwards
- Make sure to check relations in converted objects
- Fix a bug in the relation resolution of the ReconstructedParticle that was uncovered.
- Make `RelWithDebInfo` the default build type.

ENDRELEASENOTES

Fixes #17 