### PR TITLE
Do not forward declare `podio::ObjectID`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 include(cmake/compiler_output.cmake)
 
 find_package(LCIO REQUIRED)
+find_package(PODIO REQUIRED)
 find_package(EDM4HEP REQUIRED)
 
 add_subdirectory(k4EDM4hep2LcioConv)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 include(cmake/compiler_output.cmake)
 
 find_package(LCIO REQUIRED)
-find_package(PODIO REQUIRED)
+find_package(podio REQUIRED)
 find_package(EDM4HEP REQUIRED)
 
 add_subdirectory(k4EDM4hep2LcioConv)

--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(k4EDM4hep2LcioConv SHARED
   src/k4EDM4hep2LcioConv.cpp
   src/k4Lcio2EDM4hepConv.cpp
   )
+add_library(k4EDM4hep2LcioConv::k4EDM4hep2LcioConv ALIAS k4EDM4hep2LcioConv)
 
 target_include_directories(k4EDM4hep2LcioConv PUBLIC
   ${LCIO_INCLUDE_DIRS}

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -12,7 +12,6 @@
 #include "EVENT/LCCollection.h"
 
 #include "podio/RelationRange.h"
-#include "podio/ObjectID.h"
 
 #include <cmath>
 #include <array>

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -30,7 +30,6 @@
 #include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/VertexCollection.h"
 
-#include "podio/ObjectID.h"
 #include "podio/Frame.h"
 
 template<typename LcioT, typename EDM4hepT, typename MapT>

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -2,6 +2,7 @@
 #define K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
 
 #include <unordered_map>
+#include "podio/ObjectID.h"
 
 namespace EVENT {
   class Track;
@@ -20,7 +21,6 @@ namespace EVENT {
 } // namespace EVENT
 
 namespace podio {
-  class ObjectID;
   class Frame;
 } // namespace podio
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not forward declare `podio::ObjectID` since this doesn't always build
- Add a library alias for the `k4EDM4hep2LcioConv` target
- Add `podio` to the list of required packages (it's already there in the spack recipe)

ENDRELEASENOTES

Building `k4EDM4hep2LcioConv` standalone in Alma 9 doesn't seem to be working (I can reproduce in lxplus) because of some issues with forward declaring. I'm not exactly sure why it works fine for builds with spack but doesn't work if you try to build it standalone (have some guesses because spack uses some different cmake variables). In this case anyway `ObjectID.h` has only `podio::ObjectID`inside so I don't think anything can be gained from forward declaring since anyone using the struct will have to include this file, which I believe is the case before this PR if the chain of includes is untangled for the tests.
