### PR TITLE
Synchronizing name for the Cell ID encoding string

### DIFF
--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -33,7 +33,7 @@ namespace EDM4hep2LCIOConv {
     for (const auto& name : collections) {
       const auto edmCollection = edmEvent.get(name);
 
-      const auto& cellIDStr = metadata.getParameter<std::string>(podio::collMetadataParamName(name, "CellIDEncoding"));
+      const auto& cellIDStr = metadata.getParameter<std::string>(podio::collMetadataParamName(name, "CellIDEncodingString"));
 
       if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
         auto lcColl = convTracks(coll, objectMappings.tracks, objectMappings.trackerHits);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -33,7 +33,8 @@ namespace EDM4hep2LCIOConv {
     for (const auto& name : collections) {
       const auto edmCollection = edmEvent.get(name);
 
-      const auto& cellIDStr = metadata.getParameter<std::string>(podio::collMetadataParamName(name, "CellIDEncodingString"));
+      const auto& cellIDStr =
+        metadata.getParameter<std::string>(podio::collMetadataParamName(name, "CellIDEncodingString"));
 
       if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
         auto lcColl = convTracks(coll, objectMappings.tracks, objectMappings.trackerHits);


### PR DESCRIPTION
BEGINRELEASENOTES
- Synchronizing name for the Cell ID encoding string between the converter and k4RecCalorimeter algorithms

ENDRELEASENOTES
Found by:
@SwathiSasikumar and @Zehvogel 
