### PR TITLE
Use the new edm4hep::CellIDEncoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(cmake/compiler_output.cmake)
 
 find_package(LCIO REQUIRED)
 find_package(podio REQUIRED)
-find_package(EDM4HEP REQUIRED)
+find_package(EDM4HEP 0.10.1 REQUIRED)
 
 add_subdirectory(k4EDM4hep2LcioConv)
 add_subdirectory(standalone)

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -1,4 +1,5 @@
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
+#include "edm4hep/Constants.h"
 #include "EVENT/MCParticle.h"
 
 namespace EDM4hep2LCIOConv {
@@ -33,7 +34,8 @@ namespace EDM4hep2LCIOConv {
     for (const auto& name : collections) {
       const auto edmCollection = edmEvent.get(name);
 
-      const auto& cellIDStr = metadata.getParameter<std::string>(podio::collMetadataParamName(name, "CellIDEncoding"));
+      const auto& cellIDStr =
+        metadata.getParameter<std::string>(podio::collMetadataParamName(name, edm4hep::CellIDEncoding));
 
       if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
         auto lcColl = convTracks(coll, objectMappings.tracks, objectMappings.trackerHits);


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the new `edm4hep::CellIDEncoding` for consistency. Needs https://github.com/key4hep/EDM4hep/pull/234

ENDRELEASENOTES

This should build fine with the nightlies tomorrow