### PR TITLE
Add EDM4hep/include to the included directories

### DIFF
--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -7,7 +7,9 @@ add_library(k4EDM4hep2LcioConv::k4EDM4hep2LcioConv ALIAS k4EDM4hep2LcioConv)
 target_include_directories(k4EDM4hep2LcioConv PUBLIC
   ${LCIO_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<$<BOOL:${EDM4HEP_SOURCE_DIR}>:${EDM4HEP_SOURCE_DIR}/include>
+)
 
 target_link_libraries(k4EDM4hep2LcioConv PUBLIC
   ${LCIO_LIBRARIES}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the include directory at the top of EDM4hep for builds when EDM4hep and k4MarlinWrapper are built together and the include directory has not been installed yet and can't be used. For builds where EDM4hep is installed before k4MarlinWrapper the behavior is unchanged.

ENDRELEASENOTES
Same as https://github.com/key4hep/k4MarlinWrapper/pull/159