### PR TITLE
Remove legacy compatibility and require minimum EDM4hep version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(cmake/compiler_output.cmake)
 
 find_package(LCIO REQUIRED)
 find_package(podio REQUIRED)
-find_package(EDM4HEP REQUIRED)
+find_package(EDM4HEP REQUIRED VERSION 0.10)
 
 add_subdirectory(k4EDM4hep2LcioConv)
 add_subdirectory(standalone)

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -20,35 +20,12 @@
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#if __has_include("edm4hep/RawTimeSeriesCollection.h")
 #include <edm4hep/RawTimeSeriesCollection.h>
-#else
-#include <edm4hep/TPCHitCollection.h>
-namespace edm4hep {
-  using RawTimeSeries = TPCHit;
-  using MutableRawTimeSeries = MutableTPCHit;
-  using RawTimeSeriesCollection = TPCHitCollection;
-} // namespace edm4hep
-#endif
 
 #include <edm4hep/TrackCollection.h>
 #include <edm4hep/TrackerHitCollection.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/VertexCollection.h>
-
-#if __has_include("edm4hep/EDM4hepVersion.h")
-#include "edm4hep/EDM4hepVersion.h"
-#else
-  // Copy the necessary parts from  the header above to make whatever we need to work here
-#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
-  // v00-07-02 is the last version without that still has TPCHits
-#if __has_include("edm4hep/TPCHitCollection.h")
-#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 7, 2)
-#else
-// v00-09 is the last version without the capitalization change of the track vector members
-#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
-#endif
-#endif
 
 #include "podio/Frame.h"
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -31,7 +31,6 @@ namespace EDM4hep2LCIOConv {
         lcio_tr->setdEdxError(edm_tr.getDEdxError());
         lcio_tr->setRadiusOfInnermostHit(edm_tr.getRadiusOfInnermostHit());
 
-#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
         // Loop over the hit Numbers in the track
         lcio_tr->subdetectorHitNumbers().resize(edm_tr.subdetectorHitNumbers_size());
         for (int i = 0; i < edm_tr.subdetectorHitNumbers_size(); ++i) {
@@ -46,22 +45,6 @@ namespace EDM4hep2LCIOConv {
             lcio_tr->subdetectorHitNumbers()[i] = 0;
           }
         }
-#else
-        // Loop over the hit Numbers in the track
-        lcio_tr->subdetectorHitNumbers().resize(edm_tr.subDetectorHitNumbers_size());
-        for (int i = 0; i < edm_tr.subDetectorHitNumbers_size(); ++i) {
-          lcio_tr->subdetectorHitNumbers()[i] = edm_tr.getSubDetectorHitNumbers(i);
-        }
-
-        // Pad until 50 hitnumbers are resized
-        const int hit_number_limit = 50;
-        if (edm_tr.subDetectorHitNumbers_size() < hit_number_limit) {
-          lcio_tr->subdetectorHitNumbers().resize(hit_number_limit);
-          for (int i = edm_tr.subDetectorHitNumbers_size(); i < hit_number_limit; ++i) {
-            lcio_tr->subdetectorHitNumbers()[i] = 0;
-          }
-        }
-#endif
 
         // Link multiple associated TrackerHits if found in converted ones
         for (const auto& edm_rp_trh : edm_tr.getTrackerHits()) {
@@ -362,19 +345,12 @@ namespace EDM4hep2LCIOConv {
         lcio_tpchit->setQuality(edm_tpchit.getQuality());
 
         std::vector<int> rawdata;
-#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 7, 2)
+
         for (int i = 0; i < edm_tpchit.adcCounts_size(); ++i) {
           rawdata.push_back(edm_tpchit.getAdcCounts(i));
         }
 
         lcio_tpchit->setRawData(rawdata.data(), edm_tpchit.adcCounts_size());
-#else
-        for (int i = 0; i < edm_tpchit.rawDataWords_size(); ++i) {
-          rawdata.push_back(edm_tpchit.getRawDataWords(i));
-        }
-
-        lcio_tpchit->setRawData(rawdata.data(), edm_tpchit.rawDataWords_size());
-#endif
 
         // Save TPC Hits LCIO and EDM4hep collections
         k4EDM4hep2LcioConv::detail::mapInsert(lcio_tpchit, edm_tpchit, tpc_hits_vec);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -345,7 +345,6 @@ namespace EDM4hep2LCIOConv {
         lcio_tpchit->setQuality(edm_tpchit.getQuality());
 
         std::vector<int> rawdata;
-
         for (int i = 0; i < edm_tpchit.adcCounts_size(); ++i) {
           rawdata.push_back(edm_tpchit.getAdcCounts(i));
         }


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove compatibility with all legacy versions of EDM4hep since #34 made the minimum version 0.10.1 in any case.

ENDRELEASENOTES

Fixes #30 