### PR TITLE
Add the conversion of TrackerHitPlane from EDM4hep to LCIO

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -21,7 +21,6 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
-
 #include <edm4hep/TrackCollection.h>
 #include <edm4hep/TrackerHitCollection.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
@@ -45,6 +44,7 @@
 #include <IMPL/TrackImpl.h>
 #include <IMPL/TrackStateImpl.h>
 #include <IMPL/TrackerHitImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
 #include <IMPL/VertexImpl.h>
 #include <LCIOSTLTypes.h>
 #include <UTIL/CellIDEncoder.h>
@@ -67,6 +67,7 @@ namespace EDM4hep2LCIOConv {
   struct CollectionsPairVectors {
     ObjectMapT<lcio::TrackImpl*, edm4hep::Track> tracks {};
     ObjectMapT<lcio::TrackerHitImpl*, edm4hep::TrackerHit> trackerHits {};
+    ObjectMapT<lcio::TrackerHitPlaneImpl*, edm4hep::TrackerHitPlane> trackerHitPlanes {};
     ObjectMapT<lcio::SimTrackerHitImpl*, edm4hep::SimTrackerHit> simTrackerHits {};
     ObjectMapT<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit> caloHits {};
     ObjectMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalorimeterHit> rawCaloHits {};
@@ -89,6 +90,12 @@ namespace EDM4hep2LCIOConv {
     const edm4hep::TrackerHitCollection* const trackerhits_coll,
     const std::string& cellIDstr,
     TrackerHitMapT& trackerhits_vec);
+
+  template<typename TrackerHitPlaneMapT>
+  lcio::LCCollectionVec* convTrackerHitPlanes(
+    const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll,
+    const std::string& cellIDstr,
+    TrackerHitPlaneMapT& trackerhits_vec);
 
   template<typename SimTrHitMapT, typename MCParticleMapT>
   lcio::LCCollectionVec* convSimTrackerHits(

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -128,10 +128,6 @@ namespace EDM4hep2LCIOConv {
         lcio_trh->setEDepError(edm_trh.getEDepError());
         lcio_trh->setTime(edm_trh.getTime());
         lcio_trh->setQuality(edm_trh.getQuality());
-        std::bitset<sizeof(uint32_t)> type_bits = edm_trh.getQuality();
-        for (int j = 0; j < sizeof(uint32_t); j++) {
-          lcio_trh->setQualityBit(j, (type_bits[j] == 0) ? 0 : 1);
-        }
 
         // Save intermediate trackerhits ref
         k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerhits_vec);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -45,6 +45,10 @@ namespace EDM4hep2LCIOConv {
         auto lcColl = convTrackerHits(coll, cellIDStr, objectMappings.trackerHits);
         lcioEvent->addCollection(lcColl, name);
       }
+      else if (auto coll = dynamic_cast<const edm4hep::TrackerHitPlaneCollection*>(edmCollection)) {
+        auto lcColl = convTrackerHitPlanes(coll, cellIDStr, objectMappings.trackerHitPlanes);
+        lcioEvent->addCollection(lcColl, name);
+      }
       else if (auto coll = dynamic_cast<const edm4hep::SimTrackerHitCollection*>(edmCollection)) {
         auto lcColl = convSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits, objectMappings.mcParticles);
         lcioEvent->addCollection(lcColl, name);
@@ -93,7 +97,7 @@ namespace EDM4hep2LCIOConv {
         std::cerr << "Error trying to convert requested " << edmCollection->getValueTypeName() << " with name " << name
                   << "\n"
                   << "List of supported types: "
-                  << "Track, TrackerHit, SimTrackerHit, "
+                  << "Track, TrackerHit, TrackerHitPlane, SimTrackerHit, "
                   << "Cluster, CalorimeterHit, RawCalorimeterHit, "
                   << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
                   << "MCParticle." << std::endl;

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -25,6 +25,7 @@ int main()
   ASSERT_SAME_OR_ABORT(edm4hep::SimCalorimeterHitCollection, "simCaloHits");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackCollection, "tracks");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitCollection, "trackerHits");
+  ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");
   ASSERT_SAME_OR_ABORT(edm4hep::ClusterCollection, "clusters");
 
   return 0;

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -6,6 +6,7 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/ClusterCollection.h"
 
 #include <edm4hep/TrackState.h>
@@ -213,6 +214,32 @@ bool compare(const edm4hep::TrackerHitCollection& origColl, const edm4hep::Track
     REQUIRE_SAME(origHit.getEDepError(), hit.getEDepError(), "EDepError in hit " << i);
     REQUIRE_SAME(origHit.getPosition(), hit.getPosition(), "Position in hit " << i);
     REQUIRE_SAME(origHit.getCovMatrix(), hit.getCovMatrix(), "CovMatrix in hit " << i);
+  }
+
+  return true;
+}
+
+bool compare(
+  const edm4hep::TrackerHitPlaneCollection& origColl,
+  const edm4hep::TrackerHitPlaneCollection& roundtripColl)
+{
+  REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    auto origHit = origColl[i];
+    auto hit = roundtripColl[i];
+
+    REQUIRE_SAME(origHit.getCellID(), hit.getCellID(), "cellID in hit " << i);
+    REQUIRE_SAME(origHit.getType(), hit.getType(), "type in hit " << i);
+    REQUIRE_SAME(origHit.getQuality(), hit.getQuality(), "quality in hit " << i);
+    REQUIRE_SAME(origHit.getTime(), hit.getTime(), "time in hit " << i);
+    REQUIRE_SAME(origHit.getEDep(), hit.getEDep(), "EDep in hit " << i);
+    REQUIRE_SAME(origHit.getEDepError(), hit.getEDepError(), "EDepError in hit " << i);
+    REQUIRE_SAME(origHit.getPosition(), hit.getPosition(), "Position in hit " << i);
+    REQUIRE_SAME(origHit.getCovMatrix(), hit.getCovMatrix(), "CovMatrix in hit " << i);
+    REQUIRE_SAME(origHit.getU(), hit.getU(), "U in hit " << i);
+    REQUIRE_SAME(origHit.getV(), hit.getV(), "V in hit " << i);
+    REQUIRE_SAME(origHit.getDu(), hit.getDu(), "Du in hit " << i);
+    REQUIRE_SAME(origHit.getDv(), hit.getDv(), "Dv in hit " << i);
   }
 
   return true;

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -15,6 +15,10 @@ bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackColle
 
 bool compare(const edm4hep::TrackerHitCollection& origColl, const edm4hep::TrackerHitCollection& roundtripColl);
 
+bool compare(
+  const edm4hep::TrackerHitPlaneCollection& origColl,
+  const edm4hep::TrackerHitPlaneCollection& roundtripColl);
+
 bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterCollection& roundtripColl);
 
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -188,7 +188,6 @@ edm4hep::TrackCollection createTracks(
   const int subdetectorhitnumbers,
   const int num_track_states,
   const edm4hep::TrackerHitCollection& trackerHits,
-  const edm4hep::TrackerHitPlaneCollection& trackerHitPlanes,
   const std::vector<std::size_t>& link_trackerhit_idcs,
   const std::vector<test_config::IdxPair>& track_link_tracks_idcs)
 {
@@ -336,7 +335,6 @@ podio::Frame createExampleEvent()
       test_config::nSubdetectorHitNumbers,
       test_config::nTrackStates,
       trackerHits,
-      trackerHitPlanes,
       test_config::trackTrackerHitIdcs,
       test_config::trackTrackIdcs),
     "tracks");

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -5,6 +5,7 @@
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TrackerHitCollection.h"
+#include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
 #include "edm4hep/TrackCollection.h"
@@ -160,11 +161,34 @@ edm4hep::TrackerHitCollection createTrackerHits(const int num_elements)
   return coll;
 }
 
+edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements)
+{
+  edm4hep::TrackerHitPlaneCollection coll {};
+  for (int i = 0; i < num_elements; ++i) {
+    auto elem = coll.create();
+    elem.setCellID(createCellID(i));
+    elem.setType(i * 42 + 123);
+    elem.setQuality(i + 42);
+    elem.setTime(0.1f * i);
+    elem.setEDep(1.0f * i);
+    elem.setEDepError(2.0f * i);
+    elem.setU({1.2f * i, 2.1f * i});
+    elem.setV({3.4f * i, 4.3f * i});
+    elem.setDu(0.25f * i);
+    elem.setDv(0.5f * i);
+    // Covariance matrix not handled by conversion
+    // elem.setCovMatrix(createCov<3>());
+  }
+
+  return coll;
+}
+
 edm4hep::TrackCollection createTracks(
   const int num_elements,
   const int subdetectorhitnumbers,
   const int num_track_states,
   const edm4hep::TrackerHitCollection& trackerHits,
+  const edm4hep::TrackerHitPlaneCollection& trackerHitPlanes,
   const std::vector<std::size_t>& link_trackerhit_idcs,
   const std::vector<test_config::IdxPair>& track_link_tracks_idcs)
 {
@@ -305,12 +329,14 @@ podio::Frame createExampleEvent()
   const auto& rawCaloHits = event.put(createRawCalorimeterHits(test_config::nRawCaloHits), "rawCaloHits");
   const auto& tpcHits = event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
   const auto& trackerHits = event.put(createTrackerHits(test_config::nTrackerHits), "trackerHits");
+  const auto& trackerHitPlanes = event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
   const auto& tracks = event.put(
     createTracks(
       test_config::nTracks,
       test_config::nSubdetectorHitNumbers,
       test_config::nTrackStates,
       trackerHits,
+      trackerHitPlanes,
       test_config::trackTrackerHitIdcs,
       test_config::trackTrackIdcs),
     "tracks");

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -12,6 +12,7 @@ namespace edm4hep {
   class RawCalorimeterHitCollection;
   class RawTimeSeriesCollection;
   class TrackerHitCollection;
+  class TrackerHitPlaneCollection;
   class TrackCollection;
   class SimCalorimeterHitCollection;
   class CaloHitContributionCollection;


### PR DESCRIPTION
BEGINRELEASENOTES
- Add conversion of TrackerHitPlane from EDM4hep to LCIO.
  - NOTE: The covariance matrix is not set, because there is no public setter available to do so in LCIO.

ENDRELEASENOTES
