### PR TITLE
Change ${LCIO_LIBRARIES} to LCIO::lcio

### DIFF
--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(k4EDM4hep2LcioConv PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_link_libraries(k4EDM4hep2LcioConv PUBLIC
-  ${LCIO_LIBRARIES}
+  LCIO::lcio
   EDM4HEP::edm4hep)
 
 set(public_headers

--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(k4EDM4hep2LcioConv SHARED
 add_library(k4EDM4hep2LcioConv::k4EDM4hep2LcioConv ALIAS k4EDM4hep2LcioConv)
 
 target_include_directories(k4EDM4hep2LcioConv PUBLIC
-  ${LCIO_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc src/CompareEDM4hepEDM4hep.cc)
-target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep ${LCIO_LIBRARIES})
+target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep LCIO::lcio)
 target_include_directories(edmCompare PUBLIC ${LCIO_INCLUDE_DIRS})
 
 add_library(TestUtils SHARED src/EDM4hep2LCIOUtilities.cc)
-target_link_libraries(TestUtils PUBLIC EDM4HEP::edm4hep ${LCIO_LIBRARIES})
+target_link_libraries(TestUtils PUBLIC EDM4HEP::edm4hep LCIO::lcio)
 target_include_directories(TestUtils PUBLIC ${LCIO_INCLUDE_DIRS})
 
 add_executable(compare-contents compare_contents.cpp)
@@ -26,7 +26,7 @@ target_include_directories(edm4hep_roundtrip PRIVATE
 add_test(NAME edm4hep_roundtrip COMMAND edm4hep_roundtrip)
 
 include(ExternalData)
-list(APPEND ExternalData_URL_TEMPLATES
+set(ExternalData_URL_TEMPLATES
  "https://key4hep.web.cern.ch:443/testFiles/k4EDM4hep2LcioConv/%(hash)"
  )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Change ${LCIO_LIBRARIES} to LCIO::lcio
- Remove unnecessary LCIO_INCLUDE_DIRS

ENDRELEASENOTES

The second one helps building together k4MarlinWrapper and LCIO with `add_subdirectory` or `FetchContent`, otherwise LCIO_INCLUDE_DIRS will point to the source code and you can't have paths in the source tree in the target_include_directories call