### PR TITLE
Convert all TrackerHit types

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -734,6 +734,11 @@ namespace EDM4hep2LCIOConv {
           if (const auto lcio_trh = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_tr_trh, lookup_pairs.trackerHits)) {
             lcio_tr->addHit(lcio_trh.value());
           }
+          else if (
+            const auto lcio_trh =
+              k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_tr_trh, lookup_pairs.trackerHitPlanes)) {
+            lcio_tr->addHit(lcio_trh.value());
+          }
         }
       }
     }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -388,12 +388,12 @@ namespace LCIO2EDM4hepConv {
   /**
    * Resolve the relations for Tracks
    */
-  template<typename TrackMapT, typename TrackHitMapT, typename TPCHitMapT, typename THPlaneHitMapT>
+  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
   void resolveRelationsTracks(
     TrackMapT& tracksMap,
     const TrackHitMapT& trackerHitMap,
-    const TPCHitMapT&,
-    const THPlaneHitMapT&);
+    const THPlaneHitMapT&,
+    const TPCHitMapT&);
 
   /**
    * Resolve the relations for Vertices

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -782,12 +782,12 @@ namespace LCIO2EDM4hepConv {
     }
   }
 
-  template<typename TrackMapT, typename TrackHitMapT, typename TPCHitMapT, typename THPlaneHitMapT>
+  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
   void resolveRelationsTracks(
     TrackMapT& tracksMap,
     const TrackHitMapT& trackerHitMap,
-    const TPCHitMapT&,
-    const THPlaneHitMapT&)
+    const THPlaneHitMapT& trackerHitPlaneMap,
+    const TPCHitMapT&)
   {
     for (auto& [lcio, edm] : tracksMap) {
       auto tracks = lcio->getTracks();
@@ -875,7 +875,7 @@ namespace LCIO2EDM4hepConv {
       updateMaps.recoParticles, lookupMaps.recoParticles, lookupMaps.vertices, lookupMaps.clusters, lookupMaps.tracks);
     resolveRelationsSimTrackerHits(updateMaps.simTrackerHits, lookupMaps.mcParticles);
     resolveRelationsClusters(updateMaps.clusters, lookupMaps.caloHits);
-    resolveRelationsTracks(updateMaps.tracks, lookupMaps.trackerHits, lookupMaps.tpcHits, lookupMaps.trackerHitPlanes);
+    resolveRelationsTracks(updateMaps.tracks, lookupMaps.trackerHits, lookupMaps.trackerHitPlanes, lookupMaps.tpcHits);
     resolveRelationsVertices(updateMaps.vertices, lookupMaps.recoParticles);
   }
 

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -385,12 +385,19 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
     }
   }
 
+  const auto& lcioHits = lcioElem->getTrackerHits();
   const auto edmHits = edm4hepElem.getTrackerHits();
+  ASSERT_COMPARE_VALS(lcioHits.size(), edmHits.size(), "number of tracker hits in Track");
   int iHit = 0;
   for (const auto* lcioHit : lcioElem->getTrackerHits()) {
-    // In EDM4hep only TrackerHits can be used in Tracks, so here we also only
-    // compare those
-    if (dynamic_cast<const IMPL::TrackerHitImpl*>(lcioHit)) {
+    if (const auto typedHit = dynamic_cast<const EVENT::TrackerHitPlane*>(lcioHit)) {
+      if (!compareRelation(
+            typedHit, edmHits[iHit], objectMaps.trackerHitPlanes, "TrackerHit " + std::to_string(iHit) + " in Track")) {
+        return false;
+      }
+      iHit++;
+    }
+    else if (dynamic_cast<const IMPL::TrackerHitImpl*>(lcioHit)) {
       if (!compareRelation(
             lcioHit, edmHits[iHit], objectMaps.trackerHits, "TrackerHit " + std::to_string(iHit) + " in Track")) {
         return false;

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -195,6 +195,7 @@ edm4hep::TrackCollection createTracks(
   const int subdetectorhitnumbers,
   const int num_track_states,
   const edm4hep::TrackerHit3DCollection& trackerHits,
+  const edm4hep::TrackerHitPlaneCollection& trackerHitPlanes,
   const std::vector<std::size_t>& link_trackerhit_idcs,
   const std::vector<test_config::IdxPair>& track_link_tracks_idcs)
 {
@@ -220,6 +221,7 @@ edm4hep::TrackCollection createTracks(
 
     for (auto& idx : link_trackerhit_idcs) {
       elem.addToTrackerHits(trackerHits[idx]);
+      elem.addToTrackerHits(trackerHitPlanes[idx]);
     }
 
     for (int j = 0; j < num_track_states; ++j) {
@@ -342,6 +344,7 @@ podio::Frame createExampleEvent()
       test_config::nSubdetectorHitNumbers,
       test_config::nTrackStates,
       trackerHits,
+      trackerHitPlanes,
       test_config::trackTrackerHitIdcs,
       test_config::trackTrackIdcs),
     "tracks");


### PR DESCRIPTION
BEGINRELEASENOTES
- Convert all TrackerHit types now that EDM4hep has a TrackerHit interface

ENDRELEASENOTES

- [x] Builds on #45 
- [x] Needs key4hep/EDM4hep#252