### PR TITLE
Make it possible to keep the MCParticle momenta as float

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -100,8 +100,8 @@ namespace LCIO2EDM4hepConv {
       lval.setColorFlow(edm4hep::Vector2i(rval->getColorFlow()));
       lval.setVertex(edm4hep::Vector3d(rval->getVertex()));
       lval.setEndpoint(edm4hep::Vector3d(rval->getEndpoint()));
-      lval.setMomentum(rval->getMomentum());
-      lval.setMomentumAtEndpoint(rval->getMomentumAtEndpoint());
+      lval.setMomentum(Vector3fFrom(rval->getMomentum()));
+      lval.setMomentumAtEndpoint(Vector3fFrom(rval->getMomentumAtEndpoint()));
 
       const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, mcparticlesMap);
       if (!inserted) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make it possible to keep working with MCParticle momenta based on floats for now. See https://github.com/key4hep/EDM4hep/pull/266

ENDRELEASENOTES
