### PR TITLE
Adapt the converter for dealing with reversed ParticleID relations

### DIFF
--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(k4EDM4hep2LcioConv PUBLIC
 target_link_libraries(k4EDM4hep2LcioConv PUBLIC
   LCIO::lcio
   EDM4HEP::edm4hep
-  EDM4HEP::edm4hepUtils
+  EDM4HEP::utils
 )
 
 set(public_headers

--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -10,7 +10,9 @@ target_include_directories(k4EDM4hep2LcioConv PUBLIC
 
 target_link_libraries(k4EDM4hep2LcioConv PUBLIC
   LCIO::lcio
-  EDM4HEP::edm4hep)
+  EDM4HEP::edm4hep
+  EDM4HEP::edm4hepUtils
+)
 
 set(public_headers
   include/${PROJECT_NAME}/k4EDM4hep2LcioConv.h

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -400,7 +400,7 @@ namespace EDM4hep2LCIOConv {
   void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
 
   template<typename PidMapT, typename RecoParticleMapT>
-  void resolveRelationsParticleIDs(PidMapT& pidMap, RecoParticleMapT& recoMap);
+  void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap);
 
   /**
    * Resolve all relations in all converted objects that are held in the map.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -85,6 +85,7 @@ namespace EDM4hep2LCIOConv {
     ObjectMapT<lcio::VertexImpl*, edm4hep::Vertex> vertices {};
     ObjectMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle> recoParticles {};
     ObjectMapT<lcio::MCParticleImpl*, edm4hep::MCParticle> mcParticles {};
+    ObjectMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID> particleIDs {};
   };
 
   /**
@@ -322,6 +323,15 @@ namespace EDM4hep2LCIOConv {
   }
 
   /**
+   * Convert EDM4hep ParticleIDs to LCIO. NOTE: Since ParticleIDs cannot live in
+   * their own collections in LCIO this simply populates the pidMap that maps
+   * LCIO to EDM4hep particleIDs. **This just converts the data it is crucial to
+   * also resolve the relations afterwards!**
+   */
+  template<typename PidMapT>
+  void convertParticleIDs(const edm4hep::ParticleIDCollection* const edmCollection, PidMapT& pidMap, const int algoId);
+
+  /**
    * Convert EDM4hep EventHeader to LCIO. This will directly populate the
    * corresponding information in the passed LCEvent. The input collection needs
    * to be of length 1!
@@ -388,6 +398,9 @@ namespace EDM4hep2LCIOConv {
    */
   template<typename ClusterMapT, typename CaloHitMapT>
   void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
+
+  template<typename PidMapT, typename RecoParticleMapT>
+  void resolveRelationsParticleIDs(PidMapT& pidMap, RecoParticleMapT& recoMap);
 
   /**
    * Resolve all relations in all converted objects that are held in the map.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -456,43 +456,6 @@ namespace EDM4hep2LCIOConv {
         float rp[3] = {edm_rp.getReferencePoint()[0], edm_rp.getReferencePoint()[1], edm_rp.getReferencePoint()[2]};
         lcio_recp->setReferencePoint(rp);
         lcio_recp->setGoodnessOfPID(edm_rp.getGoodnessOfPID());
-
-        // Convert ParticleIDs associated to the recoparticle
-        for (const auto& edm_pid : edm_rp.getParticleIDs()) {
-          if (edm_pid.isAvailable()) {
-            auto* lcio_pid = new lcio::ParticleIDImpl;
-
-            lcio_pid->setType(edm_pid.getType());
-            lcio_pid->setPDG(edm_pid.getPDG());
-            lcio_pid->setLikelihood(edm_pid.getLikelihood());
-            lcio_pid->setAlgorithmType(edm_pid.getAlgorithmType());
-            for (const auto& param : edm_pid.getParameters()) {
-              lcio_pid->addParameter(param);
-            }
-
-            lcio_recp->addParticleID(lcio_pid);
-          }
-        }
-
-        // Link sinlge associated Particle
-        auto edm_pid_used = edm_rp.getParticleIDUsed();
-        if (edm_pid_used.isAvailable()) {
-          for (const auto& lcio_pid : lcio_recp->getParticleIDs()) {
-            bool is_same = true;
-            is_same = is_same && (lcio_pid->getType() == edm_pid_used.getType());
-            is_same = is_same && (lcio_pid->getPDG() == edm_pid_used.getPDG());
-            is_same = is_same && (lcio_pid->getLikelihood() == edm_pid_used.getLikelihood());
-            is_same = is_same && (lcio_pid->getAlgorithmType() == edm_pid_used.getAlgorithmType());
-            for (auto i = 0u; i < edm_pid_used.parameters_size(); ++i) {
-              is_same = is_same && (edm_pid_used.getParameters(i) == lcio_pid->getParameters()[i]);
-            }
-            if (is_same) {
-              lcio_recp->setParticleIDUsed(lcio_pid);
-              break;
-            }
-          }
-        }
-
         // Add LCIO and EDM4hep pair collections to vec
         k4EDM4hep2LcioConv::detail::mapInsert(lcio_recp, edm_rp, recoparticles_vec);
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -392,23 +392,6 @@ namespace EDM4hep2LCIOConv {
           subdetEnergies.push_back(edmEnergy);
         }
 
-        // Convert ParticleIDs associated to the recoparticle
-        for (const auto& edm_pid : edm_cluster.getParticleIDs()) {
-          if (edm_pid.isAvailable()) {
-            auto* lcio_pid = new lcio::ParticleIDImpl;
-
-            lcio_pid->setType(edm_pid.getType());
-            lcio_pid->setPDG(edm_pid.getPDG());
-            lcio_pid->setLikelihood(edm_pid.getLikelihood());
-            lcio_pid->setAlgorithmType(edm_pid.getAlgorithmType());
-            for (const auto& param : edm_pid.getParameters()) {
-              lcio_pid->addParameter(param);
-            }
-
-            lcio_cluster->addParticleID(lcio_pid);
-          }
-        }
-
         // Add LCIO and EDM4hep pair collections to vec
         k4EDM4hep2LcioConv::detail::mapInsert(lcio_cluster, edm_cluster, clusterMap);
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -724,7 +724,7 @@ namespace EDM4hep2LCIOConv {
   }
 
   template<typename PidMapT, typename RecoParticleMapT>
-  void resolveRelationsParticleIDs(PidMapT& pidMap, RecoParticleMapT& recoMap)
+  void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap)
   {
     for (auto& [lcioPid, edmPid] : pidMap) {
       const auto edmReco = edmPid.getParticle();

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -217,7 +217,7 @@ namespace LCIO2EDM4hepConv {
    *
    * NOTE: Also populates ParticleID collections, as those are persisted as
    * part of the ReconstructedParticles in LCIO. The name of this collection is
-   * <name>_<pid_algo_name>
+   * <name>_PID_<pid_algo_name> (see getPIDCollName)
    */
   template<typename RecoMapT>
   std::vector<CollNamePair>
@@ -298,10 +298,6 @@ namespace LCIO2EDM4hepConv {
   /**
    * Convert a Cluster collection and return the resulting collection.
    * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   *
-   * NOTE: Also populates a ParticleID collection, as those are persisted as
-   * part of the Cluster collection in LCIO. The name of this collection is
-   * <name>_particleIDs
    */
   template<typename ClusterMapT>
   std::unique_ptr<edm4hep::ClusterCollection>

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -90,7 +90,6 @@ namespace LCIO2EDM4hepConv {
     ObjectMapT<lcio::ReconstructedParticle*, edm4hep::MutableReconstructedParticle> recoParticles {};
     ObjectMapT<lcio::MCParticle*, edm4hep::MutableMCParticle> mcParticles {};
     ObjectMapT<lcio::TrackerHitPlane*, edm4hep::MutableTrackerHitPlane> trackerHitPlanes {};
-    ObjectMapT<lcio::ParticleID*, edm4hep::MutableParticleID> particleIDs {};
   };
 
   using CollNamePair = std::tuple<std::string, std::unique_ptr<podio::CollectionBase>>;
@@ -204,12 +203,9 @@ namespace LCIO2EDM4hepConv {
    * part of the ReconstructedParticles in LCIO. The name of this collection is
    * <name>_<pid_algo_name>
    */
-  template<typename RecoMapT, typename PIDMapT>
-  std::vector<CollNamePair> convertReconstructedParticles(
-    const std::string& name,
-    EVENT::LCCollection* LCCollection,
-    RecoMapT& recoparticlesMap,
-    PIDMapT& particleIDMap);
+  template<typename RecoMapT>
+  std::vector<CollNamePair>
+  convertReconstructedParticles(const std::string& name, EVENT::LCCollection* LCCollection, RecoMapT& recoparticlesMap);
 
   /**
    * Convert a Vertex collection and return the resulting collection.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -35,6 +35,7 @@ namespace edm4hep {
 #endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include "edm4hep/utils/ParticleIDUtils.h"
 
 // LCIO
 #include <EVENT/CalorimeterHit.h>
@@ -170,6 +171,21 @@ namespace LCIO2EDM4hepConv {
   inline edm4hep::Vector3f Vector3fFrom(const double* v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
 
   inline edm4hep::Vector3f Vector3fFrom(const EVENT::FloatVec& v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
+
+  /**
+   * Get the name of a ParticleID collection from the name of the reco
+   * collection (from which it is created) and the PID algorithm name.
+   */
+  inline std::string getPIDCollName(const std::string& recoCollName, const std::string& algoName)
+  {
+    return recoCollName + "_PID_" + algoName;
+  }
+
+  /**
+   * Get the meta information for all particle id collections that are available
+   * from the PIDHandler
+   */
+  std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl);
 
   /**
    * Convert a TrackState

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -200,9 +200,9 @@ namespace LCIO2EDM4hepConv {
    * Convert a ReconstructedParticle collection and return the resulting collection.
    * Simultaneously populates the mapping from LCIO to EDM4hep objects.
    *
-   * NOTE: Also populates a ParticleID collection, as those are persisted as
+   * NOTE: Also populates ParticleID collections, as those are persisted as
    * part of the ReconstructedParticles in LCIO. The name of this collection is
-   * <name>_particleIDs
+   * <name>_<pid_algo_name>
    */
   template<typename RecoMapT, typename PIDMapT>
   std::vector<CollNamePair> convertReconstructedParticles(

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -291,12 +291,9 @@ namespace LCIO2EDM4hepConv {
    * part of the Cluster collection in LCIO. The name of this collection is
    * <name>_particleIDs
    */
-  template<typename ClusterMapT, typename PIDMapT>
-  std::vector<CollNamePair> convertClusters(
-    const std::string& name,
-    EVENT::LCCollection* LCCollection,
-    ClusterMapT& clusterMap,
-    PIDMapT& particleIDMap);
+  template<typename ClusterMapT>
+  std::unique_ptr<edm4hep::ClusterCollection>
+  convertClusters(const std::string& name, EVENT::LCCollection* LCCollection, ClusterMapT& clusterMap);
 
   /**
    * Create an EventHeaderCollection and fills it with the Metadata.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -159,20 +159,6 @@ namespace LCIO2EDM4hepConv {
           lval.addToParticleIDs(k4EDM4hep2LcioConv::detail::getMapped(pidIt));
         }
       }
-
-      const auto lcioPidUsed = rval->getParticleIDUsed();
-      if (lcioPidUsed == nullptr) {
-        continue;
-      }
-      if (const auto edm4hepPid = k4EDM4hep2LcioConv::detail::mapLookupTo(lcioPidUsed, particleIDMap)) {
-        lval.setParticleIDUsed(edm4hepPid.value());
-      }
-      else {
-        auto pid = convertParticleID(lcioPidUsed);
-        particleIDs->push_back(pid);
-        k4EDM4hep2LcioConv::detail::mapInsert(lcioPidUsed, pid, particleIDMap);
-        lval.setParticleIDUsed(pid);
-      }
     }
 
     std::vector<CollNamePair> results;

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -174,7 +174,7 @@ namespace LCIO2EDM4hepConv {
     results.reserve(particleIDs.size() + 1);
     results.emplace_back(name, std::move(dest));
     for (auto& [id, coll] : particleIDs) {
-      results.emplace_back(name + "_PID_" + pidHandler.getAlgorithmName(id), std::move(coll));
+      results.emplace_back(getPIDCollName(name, pidHandler.getAlgorithmName(id)), std::move(coll));
     }
     return results;
   }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -152,11 +152,11 @@ namespace LCIO2EDM4hepConv {
         const auto [pidIt, pidInserted] = k4EDM4hep2LcioConv::detail::mapInsert(
           lcioPid, pid, particleIDMap, k4EDM4hep2LcioConv::detail::InsertMode::Checked);
         if (pidInserted) {
-          lval.addToParticleIDs(pid);
+          // TODO
           particleIDs->push_back(pid);
         }
         else {
-          lval.addToParticleIDs(k4EDM4hep2LcioConv::detail::getMapped(pidIt));
+          // TODO
         }
       }
     }

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -36,12 +36,6 @@ namespace EDM4hep2LCIOConv {
     return std::find(coll->begin(), coll->end(), collection_name) != coll->end();
   }
 
-  std::tuple<std::string, std::string> getPidAlgoName(const std::string& collectionName)
-  {
-    const auto pidPos = collectionName.find("_PID_");
-    return {collectionName.substr(pidPos + 5), collectionName.substr(0, pidPos)};
-  }
-
   void sortParticleIDs(std::vector<ParticleIDConvData>& pidCollections)
   {
     std::sort(pidCollections.begin(), pidCollections.end(), [](const auto& pid1, const auto& pid2) {

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -1,5 +1,7 @@
 #include "k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h"
 
+#include <UTIL/PIDHandler.h>
+
 #include <iostream>
 
 namespace LCIO2EDM4hepConv {
@@ -69,6 +71,17 @@ namespace LCIO2EDM4hepConv {
     header.setTimeStamp(evt->getTimeStamp());
     header.setWeight(evt->getWeight());
     return headerColl;
+  }
+
+  std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl)
+  {
+    std::vector<edm4hep::utils::ParticleIDMeta> pidInfos {};
+    const auto pidHandler = UTIL::PIDHandler(recoColl);
+    for (const auto id : pidHandler.getAlgorithmIDs()) {
+      pidInfos.emplace_back(pidHandler.getAlgorithmName(id), id, pidHandler.getParameterNames(id));
+    }
+
+    return pidInfos;
   }
 
   podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc src/CompareEDM4hepEDM4hep.cc)
 target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep LCIO::lcio)
-target_include_directories(edmCompare PUBLIC ${LCIO_INCLUDE_DIRS})
+target_include_directories(edmCompare
+  PUBLIC
+    ${LCIO_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/k4EDM4hep2LcioConv/include>
+)
 
 add_library(TestUtils SHARED src/EDM4hep2LCIOUtilities.cc)
 target_link_libraries(TestUtils PUBLIC EDM4HEP::edm4hep LCIO::lcio)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc src
 target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep LCIO::lcio)
 target_include_directories(edmCompare
   PUBLIC
-    ${LCIO_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/k4EDM4hep2LcioConv/include>
 )
 

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -28,6 +28,9 @@ int main()
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");
   ASSERT_SAME_OR_ABORT(edm4hep::ClusterCollection, "clusters");
   ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "recos");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo1");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo2");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo3");
 
   return 0;
 }

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -16,8 +16,8 @@
 
 int main()
 {
-  const auto origEvent = createExampleEvent();
-  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(origEvent);
+  const auto& [origEvent, metadata] = createExampleEvent();
+  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(origEvent, metadata);
   const auto roundtripEvent = LCIO2EDM4hepConv::convertEvent(lcioEvent.get());
 
   ASSERT_SAME_OR_ABORT(edm4hep::CalorimeterHitCollection, "caloHits");
@@ -28,9 +28,9 @@ int main()
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");
   ASSERT_SAME_OR_ABORT(edm4hep::ClusterCollection, "clusters");
   ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "recos");
-  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo1");
-  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo2");
-  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "recos_PID_algo3");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_1");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_2");
+  ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_3");
 
   return 0;
 }

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -11,8 +11,8 @@
 
 int main()
 {
-  const auto edmEvent = createExampleEvent();
-  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(edmEvent);
+  const auto& [edmEvent, metadata] = createExampleEvent();
+  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(edmEvent, metadata);
 
   if (!compareEventHeader(lcioEvent.get(), &edmEvent)) {
     return 1;

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -8,6 +8,7 @@
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/ParticleIDCollection.h"
 
 #include <edm4hep/TrackState.h>
 #include <iostream>
@@ -321,17 +322,22 @@ bool compare(
         relParticles[iP].getObjectID(),
         "related particle " << iP << " in reco particle " << i);
     }
-
-    const auto origRelPIDs = origReco.getParticleIDs();
-    const auto relPIDs = reco.getParticleIDs();
-    REQUIRE_SAME(origRelPIDs.size(), relPIDs.size(), "number of related ParticleIDs in reco particle" << i);
-    for (size_t iP = 0; iP < relPIDs.size(); ++iP) {
-      REQUIRE_SAME(
-        origRelPIDs[iP].getObjectID(),
-        relPIDs[iP].getObjectID(),
-        "related ParticleID " << iP << " in reco particle " << i);
-    }
   }
 
+  return true;
+}
+
+bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl)
+{
+  REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    const auto origPid = origColl[i];
+    const auto pid = roundtripColl[i];
+
+    REQUIRE_SAME(origPid.getAlgorithmType(), pid.getAlgorithmType(), "algorithm type in ParticleID " << i);
+
+    REQUIRE_SAME(
+      origPid.getParticle().getObjectID(), pid.getParticle().getObjectID(), "related particle in ParticleID " << i);
+  }
   return true;
 }

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -334,7 +334,17 @@ bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::Parti
     const auto origPid = origColl[i];
     const auto pid = roundtripColl[i];
 
-    REQUIRE_SAME(origPid.getAlgorithmType(), pid.getAlgorithmType(), "algorithm type in ParticleID " << i);
+    // This might not be preserved in roundtripping
+    // REQUIRE_SAME(origPid.getAlgorithmType(), pid.getAlgorithmType(), "algorithm type in ParticleID " << i);
+
+    REQUIRE_SAME(origPid.getType(), pid.getType(), "type in ParticleID " << i);
+
+    const auto origParams = origPid.getParameters();
+    const auto params = pid.getParameters();
+    REQUIRE_SAME(origParams.size(), params.size(), "parameter sizes in ParticleID " << i);
+    for (size_t iP = 0; iP < params.size(); ++iP) {
+      REQUIRE_SAME(origParams[iP], params[iP], "parameter " << iP << " in ParticleID " << i);
+    }
 
     REQUIRE_SAME(
       origPid.getParticle().getObjectID(), pid.getParticle().getObjectID(), "related particle in ParticleID " << i);

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -335,7 +335,7 @@ bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::Parti
     const auto pid = roundtripColl[i];
 
     // This might not be preserved in roundtripping
-    // REQUIRE_SAME(origPid.getAlgorithmType(), pid.getAlgorithmType(), "algorithm type in ParticleID " << i);
+    REQUIRE_SAME(origPid.getAlgorithmType(), pid.getAlgorithmType(), "algorithm type in ParticleID " << i);
 
     REQUIRE_SAME(origPid.getType(), pid.getType(), "type in ParticleID " << i);
 

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -25,4 +25,6 @@ bool compare(
   const edm4hep::ReconstructedParticleCollection& origColl,
   const edm4hep::ReconstructedParticleCollection& roundtripColl);
 
+bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl);
+
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -18,8 +18,6 @@
  * the single object compare. All comparison functions return true if all
  * comparisons succeeded or false in case any comparison failed returning as
  * early as possible.
- *
- * TODO: Also compare relations
  */
 
 /// Convert the two 32 bit cellIDs into one 64 bit value

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -194,16 +194,17 @@ bool compare(
     lcioElem, edm4hepElem, getStartVertex, objectMaps.vertices, "startVertex in ReconstructedParticle");
 
   const auto& lcioPIDs = lcioElem->getParticleIDs();
-  const auto edmPIDs = edm4hepElem.getParticleIDs();
-  ASSERT_COMPARE_VALS(lcioPIDs.size(), edmPIDs.size(), "particleIDs with different sizes in ReconstructedParticle");
+  // TODO
+  // const auto edmPIDs = edm4hepElem.getParticleIDs();
+  // ASSERT_COMPARE_VALS(lcioPIDs.size(), edmPIDs.size(), "particleIDs with different sizes in ReconstructedParticle");
 
-  for (size_t i = 0; i < lcioPIDs.size(); ++i) {
-    if (!compare(lcioPIDs[i], edmPIDs[i])) {
-      std::cerr << "particle ID " << i << " differs in ReconstructedParticle (LCIO: " << lcioPIDs[i]
-                << ", EDM4hep: " << edmPIDs[i] << ")" << std::endl;
-      return false;
-    }
-  }
+  // for (size_t i = 0; i < lcioPIDs.size(); ++i) {
+  //   if (!compare(lcioPIDs[i], edmPIDs[i])) {
+  //     std::cerr << "particle ID " << i << " differs in ReconstructedParticle (LCIO: " << lcioPIDs[i]
+  //               << ", EDM4hep: " << edmPIDs[i] << ")" << std::endl;
+  //     return false;
+  //   }
+  // }
 
   return true;
 }

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -205,22 +205,6 @@ bool compare(
     }
   }
 
-  const auto lcioPIDUsed = lcioElem->getParticleIDUsed();
-  const auto edmPIDUsed = edm4hepElem.getParticleIDUsed();
-  if (lcioPIDUsed == nullptr) {
-    if (edmPIDUsed.isAvailable()) {
-      std::cerr << "particleIDUsed is not available in LCIO, but points to " << edmPIDUsed.getObjectID()
-                << " in EDM4hep for ReconstructedParticle" << std::endl;
-      return false;
-    }
-  }
-  else {
-    if (!compare(lcioPIDUsed, edmPIDUsed)) {
-      std::cerr << "particleIDUsed differs in ReconstructedParticle (LCIO: " << lcioPIDUsed
-                << ", EDM4hep: " << edmPIDUsed << ")" << std::endl;
-      return false;
-    }
-  }
   return true;
 }
 

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -34,6 +34,8 @@ namespace edm4hep {
 #endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include "edm4hep/utils/ParticleIDUtils.h"
+
 #include "podio/Frame.h"
 
 #include <EVENT/CalorimeterHit.h>
@@ -53,6 +55,7 @@ namespace edm4hep {
 #include <EVENT/TrackerHit.h>
 #include <EVENT/TrackerHitPlane.h>
 #include <EVENT/Vertex.h>
+#include <UTIL/PIDHandler.h>
 #include <lcio.h>
 
 bool compare(

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -428,7 +428,8 @@ std::tuple<podio::Frame, podio::Frame> createExampleEvent()
       test_config::recoRecoIdcs),
     "recos");
 
-  int algoId = 1;
+  // Start at 0 here because that is also where the PIDHandler in LCIO starts
+  int algoId = 0;
   for (auto& pidColl : createParticleIDs(test_config::pidRecoIdcs, recoColl)) {
     // Make sure to use the same name as is generated for the LCIO to EDM4hep
     // conversion

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -4,7 +4,6 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
-#include <string>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -364,13 +364,16 @@ std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
   collections.reserve(recoIdcs.size());
 
   int algoId = 0;
+  float param = 0;
   for (const auto& idcs : recoIdcs) {
     algoId++;
     auto& coll = collections.emplace_back();
     for (const auto idx : idcs) {
       auto pid = coll.create();
       pid.setAlgorithmType(algoId);
+      pid.setType(idx);
       pid.setParticle(recoParticles[idx]);
+      pid.addToParameters(param++);
     }
   }
 

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -108,11 +108,8 @@ namespace test_config {
   /// particle
   const static std::vector<IdxPair> recoRecoIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}, {1, 2}, {2, 4}};
 
-  /// The ParticleIDs algorithmType that will be create for some reco particles.
-  /// The first index is the reco paritcle to which a ParticleID with algorithm
-  /// type of the second index will be attached
-  const static std::vector<IdxPair> recoPIDTypes = {{0, 1}, {0, 2}, {1, 1}, {2, 1}, {2, 2}, {3, 1}, {4, 2}};
-
+  /// The number of entries for the generated ParticleID collections
+  const static std::vector<std::vector<int>> pidRecoIdcs = {{1, 3, 4}, {2, 3}, {0, 1, 2, 3, 4, 5}};
 } // namespace test_config
 
 /**
@@ -176,14 +173,17 @@ edm4hep::ClusterCollection createClusters(
   const std::vector<test_config::IdxPair>& clusterHitIdcs,
   const std::vector<test_config::IdxPair>& clusterClusterIdcs);
 
-std::tuple<edm4hep::ReconstructedParticleCollection, edm4hep::ParticleIDCollection> createRecoParticles(
+edm4hep::ReconstructedParticleCollection createRecoParticles(
   const int nRecos,
   const edm4hep::TrackCollection& tracks,
   const std::vector<test_config::IdxPair>& trackIdcs,
   const edm4hep::ClusterCollection& clusters,
   const std::vector<test_config::IdxPair>& clusterIdcs,
-  const std::vector<test_config::IdxPair>& recIdcs,
-  const std::vector<test_config::IdxPair>& pidAlgTypes);
+  const std::vector<test_config::IdxPair>& recIdcs);
+
+std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
+  const std::vector<std::vector<int>>& recoIdcs,
+  const edm4hep::ReconstructedParticleCollection& recoParticles);
 
 /**
  * Create an example event that can be used to test the converter.

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -186,7 +186,8 @@ std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
   const edm4hep::ReconstructedParticleCollection& recoParticles);
 
 /**
- * Create an example event that can be used to test the converter.
+ * Create an example event that can be used to test the converter. Also populate
+ * a metadata frame that can be used in the conversion.
  *
  * Content:
  *
@@ -207,6 +208,6 @@ std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
  * | recos                | ReconstructedParticleCollection | createRecoParticles      |
  * | recos_particleIDs    | ParticleIDCollection            | createRecoParticles      |
  */
-podio::Frame createExampleEvent();
+std::tuple<podio::Frame, podio::Frame> createExampleEvent();
 
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -15,7 +15,9 @@
 #include "EVENT/MCParticle.h"
 #include "EVENT/LCEvent.h"
 #include "EVENT/LCCollection.h"
+#include "EVENT/ParticleID.h"
 #include "UTIL/LCIterator.h"
+#include "UTIL/PIDHandler.h"
 
 #include "edm4hep/TrackCollection.h"
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
@@ -36,8 +38,15 @@ namespace edm4hep {
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include "edm4hep/ParticleIDCollection.h"
 
 #include "podio/Frame.h"
+
+#include "k4EDM4hep2LcioConv/MappingUtils.h"
+
+#include <vector>
+#include <string>
+#include <unordered_map>
 
 template<typename LcioT, typename EDM4hepT, typename MapT>
 void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl)
@@ -58,10 +67,46 @@ void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl)
     fillMap<EVENT::Type>(mapName, lcioColl, edm4hepColl);        \
   }
 
+void fillRecoPIDMaps(
+  ObjectMappings::Map<const EVENT::ReconstructedParticle*>& recoMap,
+  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID>& pidMap,
+  const std::string& recoName,
+  EVENT::LCEvent* lcEvt,
+  const podio::Frame& edmEvt)
+{
+  UTIL::LCIterator<EVENT::ReconstructedParticle> lcioIt(lcEvt, recoName);
+  UTIL::PIDHandler pidHandler(lcioIt());
+  const auto& edmColl = edmEvt.get<edm4hep::ReconstructedParticleCollection>(recoName);
+
+  // Simply need to assume here that per algorithm the pid "collections" run in
+  // parallel.
+  std::unordered_map<std::string, unsigned> algoIdcs {};
+  for (const auto edmElem : edmColl) {
+    const auto* lcioElem = lcioIt.next();
+    recoMap.emplace(lcioElem, edmElem.getObjectID());
+
+    for (const auto* lcioPid : lcioElem->getParticleIDs()) {
+      const auto& algoName = pidHandler.getAlgorithmName(lcioPid->getAlgorithmType());
+      auto idx = algoIdcs[algoName]++;
+      // No need to do any fancy caching, because the Frame does that already
+      const auto& pidColl = edmEvt.get<edm4hep::ParticleIDCollection>(recoName + "_PID_" + algoName);
+      pidMap.emplace(lcioPid, pidColl[idx]);
+    }
+  }
+}
+
+std::string getRecoName(const std::string& pidName)
+{
+  const auto pos = pidName.find("_PID_");
+  if (pos != std::string::npos) {
+    return pidName.substr(0, pos);
+  }
+  return "";
+}
+
 ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt)
 {
   ObjectMappings mapping {};
-
   for (const auto& name : *(lcEvt->getCollectionNames())) {
     // We only use non subset collections here, because we want the "real"
     // objects
@@ -81,7 +126,6 @@ ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Fra
     FILL_MAP(RawCalorimeterHit, mapping.rawCaloHits);
     FILL_MAP(SimCalorimeterHit, mapping.simCaloHits);
     FILL_MAP(MCParticle, mapping.mcParticles);
-    FILL_MAP(ReconstructedParticle, mapping.recoParticles);
     FILL_MAP(Vertex, mapping.vertices);
     // Need special treatment for TPCHit type mismatch
     if (type == "TPCHit") {
@@ -91,6 +135,11 @@ ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Fra
     if (type == "TrackerHit") {
       auto& edm4hepColl = edmEvt.get<edm4hep::TrackerHit3DCollection>(name);
       fillMap<EVENT::TrackerHit>(mapping.trackerHits, lcioColl, edm4hepColl);
+    }
+    // Special treatment for reco particles and ParticleIDs because of
+    // conceptual differences
+    if (type == "ReconstructedParticle") {
+      fillRecoPIDMaps(mapping.recoParticles, mapping.particleIDs, name, lcEvt, edmEvt);
     }
   }
 

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -18,11 +18,16 @@ namespace EVENT {
   class ReconstructedParticle;
   class MCParticle;
   class LCEvent;
+  class ParticleID;
 } // namespace EVENT
 
 namespace podio {
   class Frame;
 } // namespace podio
+
+namespace edm4hep {
+  class ParticleID;
+}
 
 struct ObjectMappings {
   template<typename K>
@@ -40,6 +45,8 @@ struct ObjectMappings {
   Map<const EVENT::ReconstructedParticle*> recoParticles {};
   Map<const EVENT::TPCHit*> tpcHits {};
   Map<const EVENT::Vertex*> vertices {};
+
+  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs;
 
   static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
 };


### PR DESCRIPTION
BEGINRELEASENOTES
- Adapt the conversion of `ReconstructedParticle` and `ParticleID` after the reversal of the relations in https://github.com/key4hep/EDM4hep/pull/268

ENDRELEASENOTES

Necessary due to https://github.com/key4hep/EDM4hep/pull/268

- [x] Includes #53 
- [x] Includes #54
- [ ] Needs https://github.com/key4hep/EDM4hep/pull/268
- [x] Needs https://github.com/AIDASoft/podio/pull/586