### PR TITLE
Enable compiler warnings and fix them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,13 @@ endif()
 
 # Ninja compiler output
 include(cmake/compiler_output.cmake)
+include(cmake/build_flags.cmake)
+k4edm4hep2lcioconv_set_compiler_flags()
 
 find_package(LCIO 2.20.1 REQUIRED)
 find_package(podio REQUIRED)
 find_package(EDM4HEP 0.10.1 REQUIRED)
+
 
 add_subdirectory(k4EDM4hep2LcioConv)
 add_subdirectory(standalone)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ find_package(LCIO 2.20.1 REQUIRED)
 find_package(podio REQUIRED)
 find_package(EDM4HEP 0.10.1 REQUIRED)
 
-
 add_subdirectory(k4EDM4hep2LcioConv)
 add_subdirectory(standalone)
 

--- a/cmake/build_flags.cmake
+++ b/cmake/build_flags.cmake
@@ -1,0 +1,58 @@
+#---------------------------------------------------------------------------------------------------
+#---k4edm4hep2lcioconv_set_compiler_flags
+#
+#  Set compiler and linker flags
+#
+#---------------------------------------------------------------------------------------------------
+
+macro(k4edm4hep2lcioconv_set_compiler_flags)
+  include(CheckCXXCompilerFlag)
+
+  SET(COMPILER_FLAGS -fPIC -Wall -Wextra -Wpedantic)
+
+  # AppleClang/Clang specific warning flags
+  if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+    set ( COMPILER_FLAGS ${COMPILER_FLAGS} -Winconsistent-missing-override -Wheader-hygiene )
+  endif()
+
+  FOREACH( FLAG ${COMPILER_FLAGS} )
+    ## need to replace the minus or plus signs from the variables, because it is passed
+    ## as a macro to g++ which causes a warning about no whitespace after macro
+    ## definition
+    STRING(REPLACE "-" "_" FLAG_WORD ${FLAG} )
+    STRING(REPLACE "+" "P" FLAG_WORD ${FLAG_WORD} )
+
+    CHECK_CXX_COMPILER_FLAG( "${FLAG}" CXX_FLAG_WORKS_${FLAG_WORD} )
+    IF( ${CXX_FLAG_WORKS_${FLAG_WORD}} )
+      message( STATUS "Adding ${FLAG} to CXX_FLAGS" )
+      SET ( CMAKE_CXX_FLAGS "${FLAG} ${CMAKE_CXX_FLAGS} ")
+    ELSE()
+      message( STATUS "NOT Adding ${FLAG} to CXX_FLAGS" )
+    ENDIF()
+  ENDFOREACH()
+
+  # resolve which linker we use
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -Wl,--version OUTPUT_VARIABLE stdout ERROR_QUIET)
+  if("${stdout}" MATCHES "GNU ")
+    set(LINKER_TYPE "GNU")
+    message( STATUS "Detected GNU compatible linker" )
+  else()
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -Wl,-v ERROR_VARIABLE stderr )
+    if(("${stderr}" MATCHES "PROGRAM:ld") AND ("${stderr}" MATCHES "PROJECT:ld64"))
+      set(LINKER_TYPE "APPLE")
+      message( STATUS "Detected Apple linker" )
+    else()
+      set(LINKER_TYPE "unknown")
+      message( STATUS "Detected unknown linker" )
+    endif()
+  endif()
+
+  if("${LINKER_TYPE}" STREQUAL "APPLE")
+    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,dynamic_lookup")
+  elseif("${LINKER_TYPE}" STREQUAL "GNU")
+    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
+  else()
+    MESSAGE( WARNING "No known linker (GNU or Apple) has been detected, pass no flags to linker" )
+  endif()
+
+endmacro(k4edm4hep2lcioconv_set_compiler_flags)

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -123,23 +123,19 @@ namespace EDM4hep2LCIOConv {
     const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
     RawCaloHitMapT& raw_calo_hits_vec);
 
-  template<typename SimCaloHitMapT, typename MCParticleMapT>
+  template<typename SimCaloHitMapT>
   lcio::LCCollectionVec* convSimCalorimeterHits(
     const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
     const std::string& cellIDstr,
-    SimCaloHitMapT& sim_calo_hits_vec,
-    const MCParticleMapT& mcparticles);
+    SimCaloHitMapT& sim_calo_hits_vec);
 
   template<typename TPCHitMapT>
   lcio::LCCollectionVec* convTPCHits(
     const edm4hep::RawTimeSeriesCollection* const tpchit_coll,
     TPCHitMapT& tpc_hits_vec);
 
-  template<typename ClusterMapT, typename CaloHitMapT>
-  lcio::LCCollectionVec* convClusters(
-    const edm4hep::ClusterCollection* const cluster_coll,
-    ClusterMapT& cluster_vec,
-    const CaloHitMapT& calohits_vec);
+  template<typename ClusterMapT>
+  lcio::LCCollectionVec* convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec);
 
   template<typename VertexMapT, typename RecoPartMapT>
   lcio::LCCollectionVec* convVertices(

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -129,6 +129,16 @@ namespace EDM4hep2LCIOConv {
     const std::string& cellIDstr,
     SimCaloHitMapT& sim_calo_hits_vec);
 
+  template<typename SimCaloHitMapT, typename MCParticleMapT>
+  [[deprecated("remove MCParticleMap argument since it is unused")]] lcio::LCCollectionVec* convSimCalorimeterHits(
+    const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
+    const std::string& cellIDstr,
+    SimCaloHitMapT& sim_calo_hits_vec,
+    const MCParticleMapT&)
+  {
+    return convSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec);
+  }
+
   template<typename TPCHitMapT>
   lcio::LCCollectionVec* convTPCHits(
     const edm4hep::RawTimeSeriesCollection* const tpchit_coll,
@@ -136,6 +146,13 @@ namespace EDM4hep2LCIOConv {
 
   template<typename ClusterMapT>
   lcio::LCCollectionVec* convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec);
+
+  template<typename ClusterMapT, typename CaloHitMapT>
+  [[deprecated("remove CaloHitMap argument since it is unused")]] lcio::LCCollectionVec*
+  convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec, const CaloHitMapT&)
+  {
+    return convClusters(cluster_coll, cluster_vec);
+  }
 
   template<typename VertexMapT, typename RecoPartMapT>
   lcio::LCCollectionVec* convVertices(

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -613,9 +613,7 @@ namespace LCIO2EDM4hepConv {
   template<typename MCParticleMapT, typename MCParticleLookupMapT>
   void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap)
   {
-    int edmnum = 1;
     for (auto& [lcio, edm] : mcparticlesMap) {
-      edmnum++;
       auto daughters = lcio->getDaughters();
       auto parents = lcio->getParents();
 
@@ -680,9 +678,7 @@ namespace LCIO2EDM4hepConv {
     const ClusterMapT& clusterMap,
     const TrackMapT& tracksMap)
   {
-    int edmnum = 1;
     for (auto& [lcio, edm] : recoparticlesMap) {
-      edmnum++;
 
       const auto& vertex = lcio->getStartVertex();
       if (vertex != nullptr) {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -8,7 +8,7 @@ namespace LCIO2EDM4hepConv {
     // handle srting params
     EVENT::StringVec keys;
     const auto stringKeys = params.getStringKeys(keys);
-    for (int i = 0; i < stringKeys.size(); i++) {
+    for (auto i = 0u; i < stringKeys.size(); i++) {
       EVENT::StringVec sValues;
       const auto stringVals = params.getStringVals(stringKeys[i], sValues);
       event.putParameter(stringKeys[i], stringVals);
@@ -16,7 +16,7 @@ namespace LCIO2EDM4hepConv {
     // handle float params
     EVENT::StringVec fkeys;
     const auto floatKeys = params.getFloatKeys(fkeys);
-    for (int i = 0; i < floatKeys.size(); i++) {
+    for (auto i = 0u; i < floatKeys.size(); i++) {
       EVENT::FloatVec fValues;
       const auto floatVals = params.getFloatVals(floatKeys[i], fValues);
       event.putParameter(floatKeys[i], floatVals);
@@ -24,7 +24,7 @@ namespace LCIO2EDM4hepConv {
     // handle int params
     EVENT::StringVec ikeys;
     const auto intKeys = params.getIntKeys(ikeys);
-    for (int i = 0; i < intKeys.size(); i++) {
+    for (auto i = 0u; i < intKeys.size(); i++) {
       EVENT::IntVec iValues;
       const auto intVals = params.getIntVals(intKeys[i], iValues);
       event.putParameter(intKeys[i], intVals);
@@ -32,7 +32,7 @@ namespace LCIO2EDM4hepConv {
     // handle double params
     EVENT::StringVec dkeys;
     const auto dKeys = params.getDoubleKeys(dkeys);
-    for (int i = 0; i < dKeys.size(); i++) {
+    for (auto i = 0u; i < dKeys.size(); i++) {
       EVENT::DoubleVec dValues;
       const auto dVals = params.getDoubleVals(dKeys[i], dValues);
       event.putParameter(dKeys[i], dVals);
@@ -587,7 +587,7 @@ namespace LCIO2EDM4hepConv {
     auto contrCollection = std::make_unique<edm4hep::CaloHitContributionCollection>();
     for (auto& [lcioHit, edmHit] : SimCaloHitMap) {
       auto NMCParticle = lcioHit->getNMCParticles();
-      for (unsigned j = 0; j < NMCParticle; j++) {
+      for (int j = 0; j < NMCParticle; j++) {
         auto edm_contr = contrCollection->create();
         edmHit.addToContributions(edm_contr);
 

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -62,7 +62,7 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::SimCalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits, objectMappings.mcParticles);
+        auto lcColl = convSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits);
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::RawTimeSeriesCollection*>(edmCollection)) {
@@ -70,7 +70,7 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::ClusterCollection*>(edmCollection)) {
-        auto lcColl = convClusters(coll, objectMappings.clusters, objectMappings.caloHits);
+        auto lcColl = convClusters(coll, objectMappings.clusters);
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::VertexCollection*>(edmCollection)) {
@@ -89,7 +89,7 @@ namespace EDM4hep2LCIOConv {
       else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
         convEventHeader(coll, lcioEvent.get());
       }
-      else if (auto coll = dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
+      else if (dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
         // "converted" as part of FillMissingCollectoins at the end
         continue;
       }

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -95,7 +95,7 @@ ParsedArgs parseArgs(std::vector<std::string> argv)
     std::exit(0);
   }
 
-  auto argc = argv.size();
+  int argc = argv.size();
   if (argc < 3 || argc > 7) {
     printUsageAndExit();
   }
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
 
   podio::ROOTWriter writer(args.outputFile);
 
-  for (auto j = 0u; j < lcreader->getNumberOfRuns(); ++j) {
+  for (int j = 0; j < lcreader->getNumberOfRuns(); ++j) {
     if (j % 1 == 0) {
       std::cout << "processing RunHeader: " << j << std::endl;
     }
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
   }
 
   const int nEvt = args.nEvents > 0 ? args.nEvents : lcreader->getNumberOfEvents();
-  for (auto i = 0u; i < nEvt; ++i) {
+  for (int i = 0; i < nEvt; ++i) {
     if (i % 10 == 0) {
       std::cout << "processing Event: " << i << std::endl;
     }

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
         return 1;
       }
 
-      if (edmEvent.get(name)->size() != lcioColl->getNumberOfElements()) {
+      if (edmEvent.get(name)->size() != (unsigned) lcioColl->getNumberOfElements()) {
         std::cerr << "Collection " << name << " has different sizes. LCIO: " << lcioColl->getNumberOfElements()
                   << ", EDM4hep: " << coll->size() << std::endl;
         return 1;

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -28,7 +28,7 @@ int main()
     }
     try {
       const auto* lcColl = lcioEvent->getCollection(name);
-      if (lcColl->getNumberOfElements() != edmColl->size()) {
+      if ((unsigned) lcColl->getNumberOfElements() != edmColl->size()) {
         std::cerr << "Collection " << name << " has different sizes. EDM4hep: " << edmColl->size()
                   << ", LCIO: " << lcColl->getNumberOfElements() << std::endl;
         return 1;

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -35,10 +35,7 @@ auto to64BitCellID(LcioT* obj)
 
 // ================= CalorimeterHit ================
 
-bool compare(
-  const EVENT::CalorimeterHit* lcioElem,
-  const edm4hep::CalorimeterHit& edm4hepElem,
-  const ObjectMappings& objectMaps)
+bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHit& edm4hepElem, const ObjectMappings&)
 {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in CalorimeterHit");
@@ -155,7 +152,7 @@ bool compare(const EVENT::ParticleID* lcioElem, const edm4hep::ParticleID& edm4h
 bool compare(
   const EVENT::RawCalorimeterHit* lcioElem,
   const edm4hep::RawCalorimeterHit& edm4hepElem,
-  const ObjectMappings& objectMaps)
+  const ObjectMappings&)
 {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in RawCalorimeterHit");
@@ -250,7 +247,8 @@ bool compare(
 
   // Contributions are not part of the "proper LCIO"
   const auto edmContributions = edm4hepElem.getContributions();
-  ASSERT_COMPARE_VALS(lcioElem->getNMCContributions(), edmContributions.size(), "number of CaloHitContributions");
+  ASSERT_COMPARE_VALS(
+    (unsigned) lcioElem->getNMCContributions(), edmContributions.size(), "number of CaloHitContributions");
 
   for (int iCont = 0; iCont < lcioElem->getNMCContributions(); ++iCont) {
     const auto& edmContrib = edmContributions[iCont];
@@ -290,7 +288,8 @@ bool compare(
   const edm4hep::SimTrackerHit& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in SimTrackerHit");
+  const auto lcioCellID = to64BitCellID(lcioElem);
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEDep, "EDep in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTime, "time in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPathLength, "pathLength in SimTrackerHit");
@@ -316,9 +315,10 @@ bool compare(
 
 // ================= TPCHit ================
 
-bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem, const ObjectMappings& objectMaps)
+bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem, const ObjectMappings&)
 {
-  ASSERT_COMPARE(lcioElem, edm4hepElem, getCellID, "cellID in TPCHit");
+  const uint64_t lcioCellID = lcioElem->getCellID();
+  ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TPCHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getQuality, "quality in TPCHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getTime, "time in TPCHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getCharge, "charge in TPCHit");
@@ -422,10 +422,7 @@ bool compare(
 
 // ================= TrackerHit ================
 
-bool compare(
-  const EVENT::TrackerHit* lcioElem,
-  const edm4hep::TrackerHit3D& edm4hepElem,
-  const ObjectMappings& objectMaps)
+bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit3D& edm4hepElem, const ObjectMappings&)
 {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHit");
@@ -450,10 +447,7 @@ bool compare(
 
 // ================= TrackerHitPlane ================
 
-bool compare(
-  const EVENT::TrackerHitPlane* lcioElem,
-  const edm4hep::TrackerHitPlane& edm4hepElem,
-  const ObjectMappings& objectMaps)
+bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPlane& edm4hepElem, const ObjectMappings&)
 {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHitPlane");
@@ -513,12 +507,12 @@ bool compare(
 
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent)
 {
-
   const auto& edmEventHeader = edmEvent->get<edm4hep::EventHeaderCollection>("EventHeader")[0];
 
   ASSERT_COMPARE(lcevt, edmEventHeader, getEventNumber, "Event Number is not the same");
   ASSERT_COMPARE(lcevt, edmEventHeader, getRunNumber, "Run Number is not the same");
-  ASSERT_COMPARE(lcevt, edmEventHeader, getTimeStamp, "TimeStamp in EventHeader is not the same");
+  const uint64_t lcioTimeStamp = lcevt->getTimeStamp();
+  ASSERT_COMPARE_VALS(lcioTimeStamp, edmEventHeader.getTimeStamp(), "TimeStamp in EventHeader is not the same");
   ASSERT_COMPARE(lcevt, edmEventHeader, getWeight, "Weight in EventHeader is not the same");
 
   return true;

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -59,10 +59,12 @@ inline bool nanSafeComp(T x, U y)
 
 // Only enable for vectors
 template<typename T, typename = void>
-struct has_size_method : std::false_type {};
+struct has_size_method : std::false_type {
+};
 
 template<typename T>
-struct has_size_method<T, std::void_t<decltype(std::declval<T>().size())>> : std::true_type {};
+struct has_size_method<T, std::void_t<decltype(std::declval<T>().size())>> : std::true_type {
+};
 
 template<typename T, typename... Ts>
 constexpr bool isAnyOf = (std::is_same_v<T, Ts> || ...);

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -59,12 +59,10 @@ inline bool nanSafeComp(T x, U y)
 
 // Only enable for vectors
 template<typename T, typename = void>
-struct has_size_method : std::false_type {
-};
+struct has_size_method : std::false_type {};
 
 template<typename T>
-struct has_size_method<T, std::void_t<decltype(std::declval<T>().size())>> : std::true_type {
-};
+struct has_size_method<T, std::void_t<decltype(std::declval<T>().size())>> : std::true_type {};
 
 template<typename T, typename... Ts>
 constexpr bool isAnyOf = (std::is_same_v<T, Ts> || ...);
@@ -178,7 +176,7 @@ inline bool compareRelation(
     // not fill relations if the original relations in LCIO were empty
     const auto nonNullLcio =
       std::count_if(lcioRange.begin(), lcioRange.end(), [](const auto e) { return e != nullptr; });
-    if (nonNullLcio != edm4hepRange.size()) {
+    if ((unsigned) nonNullLcio != edm4hepRange.size()) {
       std::cerr << msg << " different sizes (even after taking null values into account)" << std::endl;
       return false;
     }

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -47,8 +47,8 @@ constexpr auto createCov()
     return i * (2 * N - i - 1) / 2 + j;
   };
 
-  for (int i = 0; i < N; ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (auto i = 0u; i < N; ++i) {
+    for (auto j = 0u; j < i; ++j) {
       const auto index = to_lower_tri(i, j);
       result[index] = i + 10 * j;
     }
@@ -315,11 +315,11 @@ edm4hep::ClusterCollection createClusters(
     }
   }
 
-  for (const auto [cluIdx, hitIdx] : clusterHitIdcs) {
+  for (const auto& [cluIdx, hitIdx] : clusterHitIdcs) {
     clusterColl[cluIdx].addToHits(caloHits[hitIdx]);
   }
 
-  for (const auto [targetI, sourceI] : clusterHitIdcs) {
+  for (const auto& [targetI, sourceI] : clusterClusterIdcs) {
     clusterColl[targetI].addToClusters(clusterColl[sourceI]);
   }
 
@@ -334,11 +334,11 @@ podio::Frame createExampleEvent()
   const auto& mcParticles =
     event.put(createMCParticles(test_config::nMCParticles, test_config::mcpParentIdcs), "mcParticles");
   const auto& caloHits = event.put(createCalorimeterHits(test_config::nCaloHits), "caloHits");
-  const auto& rawCaloHits = event.put(createRawCalorimeterHits(test_config::nRawCaloHits), "rawCaloHits");
-  const auto& tpcHits = event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
+  event.put(createRawCalorimeterHits(test_config::nRawCaloHits), "rawCaloHits");
+  event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
   const auto& trackerHits = event.put(createTrackerHits(test_config::nTrackerHits), "trackerHits");
-  const auto& trackerHitPlanes = event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
-  const auto& tracks = event.put(
+  event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
+  event.put(
     createTracks(
       test_config::nTracks,
       test_config::nSubdetectorHitNumbers,
@@ -359,7 +359,7 @@ podio::Frame createExampleEvent()
 
   auto [tmpSimCaloHits, tmpCaloHitConts] = createSimCalorimeterHits(
     test_config::nSimCaloHits, test_config::nCaloHitContributions, mcParticles, test_config::simCaloHitMCIdcs);
-  const auto& simCaloHits = event.put(std::move(tmpSimCaloHits), "simCaloHits");
+  event.put(std::move(tmpSimCaloHits), "simCaloHits");
   event.put(std::move(tmpCaloHitConts), "caloHitContributions");
 
   return event;

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -337,7 +337,7 @@ podio::Frame createExampleEvent()
   event.put(createRawCalorimeterHits(test_config::nRawCaloHits), "rawCaloHits");
   event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
   const auto& trackerHits = event.put(createTrackerHits(test_config::nTrackerHits), "trackerHits");
-  event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
+  const auto& trackerHitPlanes = event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
   event.put(
     createTracks(
       test_config::nTracks,

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -35,7 +35,7 @@ namespace podio {
 namespace test_config {
   constexpr static int nMCParticles = 5; ///< The number of MCParticles to generate
 
-  using IdxPair = std::pair<std::size_t, std::size_t>;
+  using IdxPair = std::pair<int, int>;
   /// How to create the MC particle hierarchy, e.g. {4, 0} means that mc[4] will
   /// have mc[0] as a parent, and mc[0] will get mc[4] as a daughter
   const static std::vector<IdxPair> mcpParentIdcs = {{4, 0}, {4, 1}, {3, 2}, {3, 0}, {3, 1}, {2, 1}};
@@ -61,7 +61,7 @@ namespace test_config {
   constexpr static int nCaloHitContributions = 4; ///< The number of CalorimeterHit Contributions
   /// idcs to setup relations between SimCalorimeterHits, CaloHitContributions
   /// and MCParticles (in this order)
-  using CaloContIdx = std::tuple<std::size_t, std::size_t, std::size_t>;
+  using CaloContIdx = std::tuple<int, int, int>;
   /// The index values to use for setting up the relations
   const static std::vector<CaloContIdx> simCaloHitMCIdcs = {
     {0, 0, 0},


### PR DESCRIPTION
BEGINRELEASENOTES
- Add compiler warnings to the build process
- Fix compiler warnings

ENDRELEASENOTES

- [x] Check where this breaks downstream (nowhere if old overloads are properly deprecated)
