### PR TITLE
Refactor the EDM4hep to LCIO conversion to make it more consistent with the other direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ auto* lcio_converted_sim_tracker_hit_ptr = convSimTrackerHits(
 // Some collections that need to be linked to other collections may be converted
 // after these are linked. Running this function after all conversions guarantees correct links
 // between collections.
-FillMissingCollections(collection_pairs);
+resolveRelations(collection_pairs);
 ```

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -402,9 +402,16 @@ namespace EDM4hep2LCIOConv {
   /**
    * Convert an edm4hep event to an LCEvent
    */
-  std::unique_ptr<lcio::LCEventImpl> convEvent(
+  std::unique_ptr<lcio::LCEventImpl> convertEvent(
     const podio::Frame& edmEvent,
     const podio::Frame& metadata = podio::Frame {});
+
+  [[deprecated("Use convertEvent")]] std::unique_ptr<lcio::LCEventImpl> convEvent(
+    const podio::Frame& edmEvent,
+    const podio::Frame& metadata = podio::Frame {})
+  {
+    return convertEvent(edmEvent, metadata);
+  }
 
 } // namespace EDM4hep2LCIOConv
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -349,6 +349,12 @@ namespace EDM4hep2LCIOConv {
     const ClusterMapT& clusterMap,
     const TrackMapT& trackMap);
 
+  /**
+   * Resolve the relations for Clusters
+   */
+  template<typename ClusterMapT, typename CaloHitMapT>
+  void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
+
   template<typename ObjectMappingT>
   void FillMissingCollections(ObjectMappingT& update_pairs);
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -267,11 +267,21 @@ namespace EDM4hep2LCIOConv {
     return convClusters(cluster_coll, cluster_vec);
   }
 
+  /**
+   * Convert EDM4hep Vertices to LCIO. Simultaneously populate mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename VertexMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertVertices(
+    const edm4hep::VertexCollection* const edmCollection,
+    VertexMapT& vertexMap);
+
   template<typename VertexMapT, typename RecoPartMapT>
-  lcio::LCCollectionVec* convVertices(
-    const edm4hep::VertexCollection* const vertex_coll,
-    VertexMapT& vertex_vec,
-    const RecoPartMapT& recoparticles_vec);
+  [[deprecated("Use convertVertices instead")]] lcio::LCCollectionVec*
+  convVertices(const edm4hep::VertexCollection* const vertex_coll, VertexMapT& vertex_vec, const RecoPartMapT&)
+  {
+    return convertVertices(vertex_coll, vertex_vec).release();
+  }
 
   template<typename RecoPartMapT, typename TrackMapT, typename VertexMapT, typename ClusterMapT>
   lcio::LCCollectionVec* convReconstructedParticles(
@@ -303,6 +313,12 @@ namespace EDM4hep2LCIOConv {
    */
   template<typename SimTrHitMapT, typename MCParticleMapT>
   void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap);
+
+  /**
+   * Resolve the relations for Vertex
+   */
+  template<typename VertexMapT, typename RecoParticleMapT>
+  void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
 
   template<typename ObjectMappingT>
   void FillMissingCollections(ObjectMappingT& update_pairs);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -304,11 +304,22 @@ namespace EDM4hep2LCIOConv {
     return convertReconstructedParticles(recos_coll, recoparticles_vec).release();
   }
 
+  /**
+   * Convert EDM4hep MCParticles to LCIO. Simultaneously populate mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
   template<typename MCPartMapT>
-  lcio::LCCollectionVec* convMCParticles(
-    const edm4hep::MCParticleCollection* const mcparticle_coll,
-    MCPartMapT& mc_particles_vec);
+  std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(
+    const edm4hep::MCParticleCollection* const edmCollection,
+    MCPartMapT& mcParticleMap);
 
+  template<typename MCPartMapT>
+  [[deprecated("Use convertMCParticles")]] lcio::LCCollectionVec* convMCParticles(
+    const edm4hep::MCParticleCollection* const mcparticle_coll,
+    MCPartMapT& mc_particles_vec)
+  {
+    return convertMCParticles(mcparticle_coll, mc_particles_vec).release();
+  }
 
   /**
    * Convert EDM4hep EventHeader to LCIO. This will directly populate the
@@ -320,6 +331,12 @@ namespace EDM4hep2LCIOConv {
   [[deprecated("Use convertEventheader instead")]] void convEventHeader(
     const edm4hep::EventHeaderCollection* const header_coll,
     lcio::LCEventImpl* const lcio_event);
+
+  /**
+   * Resolve the relations for MCParticles
+   */
+  template<typename MCParticleMapT, typename MCParticleLookupMapT>
+  void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap);
 
   /**
    * Resolve the relations for Tracks

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -283,13 +283,26 @@ namespace EDM4hep2LCIOConv {
     return convertVertices(vertex_coll, vertex_vec).release();
   }
 
+  /**
+   * Convert EDM4hep ReconstructedParticles to LCIO. Simultaneously populate
+   * mapping from EDM4hep to LCIO objects for relation resolving in a second
+   * step.
+   */
+  template<typename RecoParticleMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertReconstructedParticles(
+    const edm4hep::ReconstructedParticleCollection* const edmCollection,
+    RecoParticleMapT& recoParticleMap);
+
   template<typename RecoPartMapT, typename TrackMapT, typename VertexMapT, typename ClusterMapT>
-  lcio::LCCollectionVec* convReconstructedParticles(
+  [[deprecated("Use convertReconstructedParticle instead")]] lcio::LCCollectionVec* convReconstructedParticles(
     const edm4hep::ReconstructedParticleCollection* const recos_coll,
     RecoPartMapT& recoparticles_vec,
-    const TrackMapT& tracks_vec,
-    const VertexMapT& vertex_vec,
-    const ClusterMapT& clusters_vec);
+    const TrackMapT&,
+    const VertexMapT&,
+    const ClusterMapT&)
+  {
+    return convertReconstructedParticles(recos_coll, recoparticles_vec).release();
+  }
 
   template<typename MCPartMapT>
   lcio::LCCollectionVec* convMCParticles(
@@ -319,6 +332,22 @@ namespace EDM4hep2LCIOConv {
    */
   template<typename VertexMapT, typename RecoParticleMapT>
   void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
+
+  /**
+   * Resolve the relations for ReconstructedParticles
+   */
+  template<
+    typename RecoParticleMapT,
+    typename RecoParticleLookupMapT,
+    typename VertexMapT,
+    typename ClusterMapT,
+    typename TrackMapT>
+  void resolveRelationsRecoParticles(
+    RecoParticleMapT& recoParticleMap,
+    const RecoParticleLookupMapT& recoLookupMap,
+    const VertexMapT& vertexMap,
+    const ClusterMapT& clusterMap,
+    const TrackMapT& trackMap);
 
   template<typename ObjectMappingT>
   void FillMissingCollections(ObjectMappingT& update_pairs);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -334,6 +334,13 @@ namespace EDM4hep2LCIOConv {
   void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
 
   /**
+   * Resolve the relations for SimCalorimeterHit. This is also the step where
+   * the LCIO SimCalorimeterHits get their contributions attached.
+   */
+  template<typename SimCaloHitMapT, typename MCParticleMapT>
+  void resolveRelationsSimCaloHit(SimCaloHitMapT& simCaloHitMap, const MCParticleMapT& mcParticleMap);
+
+  /**
    * Resolve the relations for ReconstructedParticles
    */
   template<

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -103,17 +103,43 @@ namespace EDM4hep2LCIOConv {
     return convertTracks(tracks_coll, tracks_vec).release();
   }
 
+  /**
+   * Convert EDM4hep TrackerHits to LCIO. Simultaneously populate mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
   template<typename TrackerHitMapT>
-  lcio::LCCollectionVec* convTrackerHits(
+  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(
+    const edm4hep::TrackerHit3DCollection* const edmCollection,
+    const std::string& cellIDStr,
+    TrackerHitMapT& trackerHitMap);
+
+  template<typename TrackerHitMapT>
+  [[deprecated("Use convertTrackerHits instead")]] lcio::LCCollectionVec* convTrackerHits(
     const edm4hep::TrackerHit3DCollection* const trackerhits_coll,
     const std::string& cellIDstr,
-    TrackerHitMapT& trackerhits_vec);
+    TrackerHitMapT& trackerhits_vec)
+  {
+    return convertTrackerHits(trackerhits_coll, cellIDstr, trackerhits_vec).release();
+  }
+
+  /**
+   * Convert EDM4hep TrackerHitPlanes to LCIO. Simultaneously populate mapping
+   * from EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename TrackerHitPlaneMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHitPlanes(
+    const edm4hep::TrackerHitPlaneCollection* const edmCollection,
+    const std::string& cellIDstr,
+    TrackerHitPlaneMapT& trackerHitsMap);
 
   template<typename TrackerHitPlaneMapT>
-  lcio::LCCollectionVec* convTrackerHitPlanes(
+  [[deprecated("Use convertTrackerHitPlanes instead")]] lcio::LCCollectionVec* convTrackerHitPlanes(
     const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll,
     const std::string& cellIDstr,
-    TrackerHitPlaneMapT& trackerhits_vec);
+    TrackerHitPlaneMapT& trackerhits_vec)
+  {
+    return convertTrackerHitPlanes(trackerhits_coll, cellIDstr, trackerhits_vec).release();
+  }
 
   template<typename SimTrHitMapT, typename MCParticleMapT>
   lcio::LCCollectionVec* convSimTrackerHits(
@@ -122,22 +148,60 @@ namespace EDM4hep2LCIOConv {
     SimTrHitMapT& simtrackerhits_vec,
     const MCParticleMapT& mcparticles_vec);
 
+  /**
+   * Convert EDM4hep CalorimeterHits to LCIO. Simultaneously populate mapping
+   * from EDM4hep to LCIO objects for relation resolving in a second step.
+   */
   template<typename CaloHitMapT>
-  lcio::LCCollectionVec* convCalorimeterHits(
+  std::unique_ptr<lcio::LCCollectionVec> convertCalorimeterHits(
+    const edm4hep::CalorimeterHitCollection* const edmCollection,
+    const std::string& cellIDstr,
+    CaloHitMapT& caloHitMap);
+
+  template<typename CaloHitMapT>
+  [[deprecated("Use convertCalorimeterHits instead")]] lcio::LCCollectionVec* convCalorimeterHits(
     const edm4hep::CalorimeterHitCollection* const calohit_coll,
     const std::string& cellIDstr,
-    CaloHitMapT& calo_hits_vec);
+    CaloHitMapT& calo_hits_vec)
+  {
+    return convertCalorimeterHits(calohit_coll, cellIDstr, calo_hits_vec).release();
+  }
+
+  /**
+   * Convert EDM4hep RawCalorimeterHits to LCIO. Simultaneously populate mapping
+   * from EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename RawCaloHitMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertRawCalorimeterHits(
+    const edm4hep::RawCalorimeterHitCollection* const edmCollection,
+    RawCaloHitMapT& rawCaloHitMap);
 
   template<typename RawCaloHitMapT>
-  lcio::LCCollectionVec* convRawCalorimeterHits(
+  [[deprecated("use convertRawCalorimeterHits instead")]] lcio::LCCollectionVec* convRawCalorimeterHits(
     const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
-    RawCaloHitMapT& raw_calo_hits_vec);
+    RawCaloHitMapT& raw_calo_hits_vec)
+  {
+    return convertRawCalorimeterHits(rawcalohit_coll, raw_calo_hits_vec).release();
+  }
+
+  /**
+   * Convert EDM4hep SimCalorimeterHits to LCIO. Simultaneously populate mapping
+   * from EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename SimCaloHitMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertSimCalorimeterHits(
+    const edm4hep::SimCalorimeterHitCollection* const edmCollection,
+    const std::string& cellIDstr,
+    SimCaloHitMapT& simCaloHitMap);
 
   template<typename SimCaloHitMapT>
   lcio::LCCollectionVec* convSimCalorimeterHits(
     const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
     const std::string& cellIDstr,
-    SimCaloHitMapT& sim_calo_hits_vec);
+    SimCaloHitMapT& sim_calo_hits_vec)
+  {
+    return convertSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec).release();
+  }
 
   template<typename SimCaloHitMapT, typename MCParticleMapT>
   [[deprecated("remove MCParticleMap argument since it is unused")]] lcio::LCCollectionVec* convSimCalorimeterHits(
@@ -149,13 +213,39 @@ namespace EDM4hep2LCIOConv {
     return convSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec);
   }
 
+  /**
+   * Convert EDM4hep TPC Hits to LCIO. Simultaneously populate mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
   template<typename TPCHitMapT>
-  lcio::LCCollectionVec* convTPCHits(
+  std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(
+    const edm4hep::RawTimeSeriesCollection* const edmCollection,
+    TPCHitMapT& tpcHitMap);
+
+  template<typename TPCHitMapT>
+  [[deprecated("Use convertTPCHits instead")]] lcio::LCCollectionVec* convTPCHits(
     const edm4hep::RawTimeSeriesCollection* const tpchit_coll,
-    TPCHitMapT& tpc_hits_vec);
+    TPCHitMapT& tpc_hits_vec)
+  {
+    return convertTPCHits(tpchit_coll, tpc_hits_vec).release();
+  }
+
+  /**
+   * Convert EDM4hep Clusters to LCIO. Simultaneously populate mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename ClusterMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertClusters(
+    const edm4hep::ClusterCollection* const edmCollection,
+    ClusterMapT& clusterMap);
 
   template<typename ClusterMapT>
-  lcio::LCCollectionVec* convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec);
+  [[deprecated("Use convertClusters instead")]] lcio::LCCollectionVec* convClusters(
+    const edm4hep::ClusterCollection* const cluster_coll,
+    ClusterMapT& cluster_vec)
+  {
+    return convertClusters(cluster_coll, cluster_vec).release();
+  }
 
   template<typename ClusterMapT, typename CaloHitMapT>
   [[deprecated("remove CaloHitMap argument since it is unused")]] lcio::LCCollectionVec*

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -341,12 +341,12 @@ namespace EDM4hep2LCIOConv {
   /**
    * Resolve the relations for Tracks
    */
-  template<typename TrackMapT, typename TrackHitMapT, typename TPCHitMapT, typename THPlaneHitMapT>
+  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
   void resolveRelationsTracks(
     TrackMapT& tracksMap,
     const TrackHitMapT& trackerHitMap,
-    const TPCHitMapT&,
-    const THPlaneHitMapT&);
+    const THPlaneHitMapT& trackerHiPlaneMap,
+    const TPCHitMapT&);
 
   /**
    * Resolve the relations for SimTrackerHits

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -87,11 +87,21 @@ namespace EDM4hep2LCIOConv {
     ObjectMapT<lcio::MCParticleImpl*, edm4hep::MCParticle> mcParticles {};
   };
 
+  /**
+   * Convert EDM4hep Tracks to LCIO. Simultaneously populate the mapping from
+   * EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename TrackMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertTracks(
+    const edm4hep::TrackCollection* const edmCollection,
+    TrackMapT& trackMap);
+
   template<typename TrackMapT, typename TrackerHitMapT>
-  lcio::LCCollectionVec* convTracks(
-    const edm4hep::TrackCollection* const tracks_coll,
-    TrackMapT& tracks_vec,
-    const TrackerHitMapT& trackerhits_vec);
+  [[deprecated("Use convertTracks instead")]] lcio::LCCollectionVec*
+  convTracks(const edm4hep::TrackCollection* const tracks_coll, TrackMapT& tracks_vec, const TrackerHitMapT&)
+  {
+    return convertTracks(tracks_coll, tracks_vec).release();
+  }
 
   template<typename TrackerHitMapT>
   lcio::LCCollectionVec* convTrackerHits(
@@ -174,6 +184,16 @@ namespace EDM4hep2LCIOConv {
     MCPartMapT& mc_particles_vec);
 
   void convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
+
+  /**
+   * Resolve the relations for Tracks
+   */
+  template<typename TrackMapT, typename TrackHitMapT, typename TPCHitMapT, typename THPlaneHitMapT>
+  void resolveRelationsTracks(
+    TrackMapT& tracksMap,
+    const TrackHitMapT& trackerHitMap,
+    const TPCHitMapT&,
+    const THPlaneHitMapT&);
 
   template<typename ObjectMappingT>
   void FillMissingCollections(ObjectMappingT& update_pairs);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -141,12 +141,25 @@ namespace EDM4hep2LCIOConv {
     return convertTrackerHitPlanes(trackerhits_coll, cellIDstr, trackerhits_vec).release();
   }
 
+  /**
+   * Convert EDM4hep SimTrackerHits to LCIO. Simultaneously populate mapping
+   * from EDM4hep to LCIO objects for relation resolving in a second step.
+   */
+  template<typename SimTrHitMapT>
+  std::unique_ptr<lcio::LCCollectionVec> convertSimTrackerHits(
+    const edm4hep::SimTrackerHitCollection* const edmCollection,
+    const std::string& cellIDstr,
+    SimTrHitMapT& simTrHitMap);
+
   template<typename SimTrHitMapT, typename MCParticleMapT>
-  lcio::LCCollectionVec* convSimTrackerHits(
+  [[deprecated("Use convertSimTrackerHits instead")]] lcio::LCCollectionVec* convSimTrackerHits(
     const edm4hep::SimTrackerHitCollection* const simtrackerhits_coll,
     const std::string& cellIDstr,
     SimTrHitMapT& simtrackerhits_vec,
-    const MCParticleMapT& mcparticles_vec);
+    const MCParticleMapT&)
+  {
+    return convertSimTrackerHits(simtrackerhits_coll, cellIDstr, simtrackerhits_vec).release();
+  }
 
   /**
    * Convert EDM4hep CalorimeterHits to LCIO. Simultaneously populate mapping
@@ -284,6 +297,12 @@ namespace EDM4hep2LCIOConv {
     const TrackHitMapT& trackerHitMap,
     const TPCHitMapT&,
     const THPlaneHitMapT&);
+
+  /**
+   * Resolve the relations for SimTrackerHits
+   */
+  template<typename SimTrHitMapT, typename MCParticleMapT>
+  void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap);
 
   template<typename ObjectMappingT>
   void FillMissingCollections(ObjectMappingT& update_pairs);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -389,13 +389,30 @@ namespace EDM4hep2LCIOConv {
   template<typename ClusterMapT, typename CaloHitMapT>
   void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
 
+  /**
+   * Resolve all relations in all converted objects that are held in the map.
+   * Dispatch to the correpsonding implementation for all the types that have
+   * relations
+   */
   template<typename ObjectMappingT>
-  void FillMissingCollections(ObjectMappingT& update_pairs);
+  void resolveRelations(ObjectMappingT& typeMapping);
 
-  /// Update the relations of the objects in the update_pairs map, by linking
-  /// them according to the contents of the lookup_pairs map
   template<typename ObjectMappingT, typename ObjectMappingU>
-  void FillMissingCollections(ObjectMappingT& update_pairs, const ObjectMappingU& lookup_pairs);
+  void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
+
+  template<typename ObjectMappingT>
+  [[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs)
+  {
+    resolveRelations(update_pairs);
+  }
+
+  template<typename ObjectMappingT, typename ObjectMappingU>
+  [[deprecated("Use resolveRelations instead")]] void FillMissingCollections(
+    ObjectMappingT& update_pairs,
+    const ObjectMappingU& lookup_pairs)
+  {
+    resolveRelations(update_pairs, lookup_pairs);
+  }
 
   bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -309,7 +309,17 @@ namespace EDM4hep2LCIOConv {
     const edm4hep::MCParticleCollection* const mcparticle_coll,
     MCPartMapT& mc_particles_vec);
 
-  void convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
+
+  /**
+   * Convert EDM4hep EventHeader to LCIO. This will directly populate the
+   * corresponding information in the passed LCEvent. The input collection needs
+   * to be of length 1!
+   */
+  void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
+
+  [[deprecated("Use convertEventheader instead")]] void convEventHeader(
+    const edm4hep::EventHeaderCollection* const header_coll,
+    lcio::LCEventImpl* const lcio_event);
 
   /**
    * Resolve the relations for Tracks

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -302,7 +302,7 @@ namespace EDM4hep2LCIOConv {
           edm_sim_calohit.getPosition()[0], edm_sim_calohit.getPosition()[1], edm_sim_calohit.getPosition()[2]};
         lcio_simcalohit->setPosition(positions.data());
 
-        // Contributions are converted in FillMissingCollections to make it a higher probability that we have the
+        // Contributions are converted in resolveRelations to make it a higher probability that we have the
         // MCParticles converted
 
         // Save Sim Calorimeter Hits LCIO and EDM4hep collections
@@ -760,16 +760,16 @@ namespace EDM4hep2LCIOConv {
   }
 
   template<typename ObjectMappingT>
-  void FillMissingCollections(ObjectMappingT& collection_pairs)
+  void resolveRelations(ObjectMappingT& collection_pairs)
   {
-    FillMissingCollections(collection_pairs, collection_pairs);
+    resolveRelations(collection_pairs, collection_pairs);
   }
 
   // Depending on the order of the collections in the parameters,
   // and for the mutual dependencies between some collections,
   // go over the possible missing associated collections and fill them.
   template<typename ObjectMappingT, typename ObjectMappingU>
-  void FillMissingCollections(ObjectMappingT& update_pairs, const ObjectMappingU& lookup_pairs)
+  void resolveRelations(ObjectMappingT& update_pairs, const ObjectMappingU& lookup_pairs)
   {
     resolveRelationsMCParticles(update_pairs.mcParticles, lookup_pairs.mcParticles);
     resolveRelationsTracks(

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -72,23 +72,20 @@ namespace EDM4hep2LCIOConv {
     return tracks;
   }
 
-  // Convert EDM4hep TrackerHits to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add LCIO Collection Vector to LCIO event
   template<typename TrackerHitMapT>
-  lcio::LCCollectionVec* convTrackerHits(
-    const edm4hep::TrackerHit3DCollection* const trackerhits_coll,
+  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(
+    const edm4hep::TrackerHit3DCollection* const edmColection,
     const std::string& cellIDstr,
-    TrackerHitMapT& trackerhits_vec)
+    TrackerHitMapT& trackerHitMap)
   {
-    auto* trackerhits = new lcio::LCCollectionVec(lcio::LCIO::TRACKERHIT);
+    auto trackerhits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHIT);
 
     if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerhits);
+      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerhits.get());
     }
 
     // Loop over EDM4hep trackerhits converting them to lcio trackerhits
-    for (const auto& edm_trh : (*trackerhits_coll)) {
+    for (const auto& edm_trh : (*edmColection)) {
       if (edm_trh.isAvailable()) {
         auto* lcio_trh = new lcio::TrackerHitImpl();
 
@@ -106,7 +103,7 @@ namespace EDM4hep2LCIOConv {
         lcio_trh->setQuality(edm_trh.getQuality());
 
         // Save intermediate trackerhits ref
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerhits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitMap);
 
         // Add to lcio trackerhits collection
         trackerhits->addElement(lcio_trh);
@@ -117,18 +114,18 @@ namespace EDM4hep2LCIOConv {
   }
 
   template<typename TrackerHitPlaneMapT>
-  lcio::LCCollectionVec* convTrackerHitPlanes(
-    const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll,
+  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHitPlanes(
+    const edm4hep::TrackerHitPlaneCollection* const edmCollection,
     const std::string& cellIDstr,
-    TrackerHitPlaneMapT& trackerhits_vec)
+    TrackerHitPlaneMapT& trackerHitsMap)
   {
-    auto* trackerHitPlanes = new lcio::LCCollectionVec(lcio::LCIO::TRACKERHITPLANE);
+    auto trackerHitPlanes = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHITPLANE);
 
     if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerHitPlanes);
+      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerHitPlanes.get());
     }
 
-    for (const auto& edm_trh : (*trackerhits_coll)) {
+    for (const auto& edm_trh : (*edmCollection)) {
       if (edm_trh.isAvailable()) {
         auto* lcio_trh = new lcio::TrackerHitPlaneImpl();
 
@@ -153,7 +150,7 @@ namespace EDM4hep2LCIOConv {
         lcio_trh->setV(posV.data());
         lcio_trh->setdV(edm_trh.getDv());
 
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerhits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitsMap);
 
         trackerHitPlanes->addElement(lcio_trh);
       }
@@ -226,18 +223,18 @@ namespace EDM4hep2LCIOConv {
   // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
   // Add converted LCIO Collection Vector to LCIO event
   template<typename CaloHitMapT>
-  lcio::LCCollectionVec* convCalorimeterHits(
-    const edm4hep::CalorimeterHitCollection* const calohit_coll,
+  std::unique_ptr<lcio::LCCollectionVec> convertCalorimeterHits(
+    const edm4hep::CalorimeterHitCollection* const edmCollection,
     const std::string& cellIDstr,
-    CaloHitMapT& calo_hits_vec)
+    CaloHitMapT& caloHitMap)
   {
-    auto* calohits = new lcio::LCCollectionVec(lcio::LCIO::CALORIMETERHIT);
+    auto calohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CALORIMETERHIT);
 
     if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, calohits);
+      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, calohits.get());
     }
 
-    for (const auto& edm_calohit : (*calohit_coll)) {
+    for (const auto& edm_calohit : (*edmCollection)) {
       if (edm_calohit.isAvailable()) {
         auto* lcio_calohit = new lcio::CalorimeterHitImpl();
 
@@ -257,7 +254,7 @@ namespace EDM4hep2LCIOConv {
         // lcio_calohit->setRawHit(EVENT::LCObject* rawHit );
 
         // Save Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_calohit, edm_calohit, calo_hits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_calohit, edm_calohit, caloHitMap);
 
         // Add to lcio tracks collection
         calohits->addElement(lcio_calohit);
@@ -267,17 +264,14 @@ namespace EDM4hep2LCIOConv {
     return calohits;
   }
 
-  // Convert EDM4hep RAW Calorimeter Hits to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add converted LCIO Collection Vector to LCIO event
   template<typename RawCaloHitMapT>
-  lcio::LCCollectionVec* convRawCalorimeterHits(
-    const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
-    RawCaloHitMapT& raw_calo_hits_vec)
+  std::unique_ptr<lcio::LCCollectionVec> convertRawCalorimeterHits(
+    const edm4hep::RawCalorimeterHitCollection* const edmCollection,
+    RawCaloHitMapT& rawCaloHitMap)
   {
-    auto* rawcalohits = new lcio::LCCollectionVec(lcio::LCIO::RAWCALORIMETERHIT);
+    auto rawcalohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::RAWCALORIMETERHIT);
 
-    for (const auto& edm_raw_calohit : (*rawcalohit_coll)) {
+    for (const auto& edm_raw_calohit : (*edmCollection)) {
       if (edm_raw_calohit.isAvailable()) {
         auto* lcio_rawcalohit = new lcio::RawCalorimeterHitImpl();
 
@@ -289,7 +283,7 @@ namespace EDM4hep2LCIOConv {
         lcio_rawcalohit->setTimeStamp(edm_raw_calohit.getTimeStamp());
 
         // Save Raw Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_rawcalohit, edm_raw_calohit, raw_calo_hits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_rawcalohit, edm_raw_calohit, rawCaloHitMap);
 
         // Add to lcio tracks collection
         rawcalohits->addElement(lcio_rawcalohit);
@@ -299,22 +293,19 @@ namespace EDM4hep2LCIOConv {
     return rawcalohits;
   }
 
-  // Convert EDM4hep Sim Calorimeter Hits to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add converted LCIO Collection Vector to LCIO event
   template<typename SimCaloHitMapT>
-  lcio::LCCollectionVec* convSimCalorimeterHits(
-    const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
+  std::unique_ptr<lcio::LCCollectionVec> convertSimCalorimeterHits(
+    const edm4hep::SimCalorimeterHitCollection* const edmCollection,
     const std::string& cellIDstr,
-    SimCaloHitMapT& sim_calo_hits_vec)
+    SimCaloHitMapT& simCaloHitMap)
   {
-    auto* simcalohits = new lcio::LCCollectionVec(lcio::LCIO::SIMCALORIMETERHIT);
+    auto simcalohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::SIMCALORIMETERHIT);
 
     if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, simcalohits);
+      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, simcalohits.get());
     }
 
-    for (const auto& edm_sim_calohit : (*simcalohit_coll)) {
+    for (const auto& edm_sim_calohit : (*edmCollection)) {
       if (edm_sim_calohit.isAvailable()) {
         auto* lcio_simcalohit = new lcio::SimCalorimeterHitImpl();
 
@@ -331,7 +322,7 @@ namespace EDM4hep2LCIOConv {
         // MCParticles converted
 
         // Save Sim Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_simcalohit, edm_sim_calohit, sim_calo_hits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_simcalohit, edm_sim_calohit, simCaloHitMap);
 
         // Add to sim calo hits collection
         simcalohits->addElement(lcio_simcalohit);
@@ -341,17 +332,14 @@ namespace EDM4hep2LCIOConv {
     return simcalohits;
   }
 
-  // Convert EDM4hep TPC Hits to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add converted LCIO Collection Vector to LCIO event
   template<typename TPCHitMapT>
-  lcio::LCCollectionVec* convTPCHits(
-    const edm4hep::RawTimeSeriesCollection* const tpchit_coll,
-    TPCHitMapT& tpc_hits_vec)
+  std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(
+    const edm4hep::RawTimeSeriesCollection* const edmCollection,
+    TPCHitMapT& tpcHitMap)
   {
-    auto* tpchits = new lcio::LCCollectionVec(lcio::LCIO::TPCHIT);
+    auto tpchits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TPCHIT);
 
-    for (const auto& edm_tpchit : (*tpchit_coll)) {
+    for (const auto& edm_tpchit : (*edmCollection)) {
       if (edm_tpchit.isAvailable()) {
         auto* lcio_tpchit = new lcio::TPCHitImpl();
 
@@ -369,7 +357,7 @@ namespace EDM4hep2LCIOConv {
         lcio_tpchit->setRawData(rawdata.data(), edm_tpchit.adcCounts_size());
 
         // Save TPC Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_tpchit, edm_tpchit, tpc_hits_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_tpchit, edm_tpchit, tpcHitMap);
 
         // Add to lcio tracks collection
         tpchits->addElement(lcio_tpchit);
@@ -379,16 +367,15 @@ namespace EDM4hep2LCIOConv {
     return tpchits;
   }
 
-  // Convert EDM4hep Clusters to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add converted LCIO Collection Vector to LCIO event
   template<typename ClusterMapT>
-  lcio::LCCollectionVec* convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec)
+  std::unique_ptr<lcio::LCCollectionVec> convertClusters(
+    const edm4hep::ClusterCollection* const edmCollection,
+    ClusterMapT& clusterMap)
   {
-    auto* clusters = new lcio::LCCollectionVec(lcio::LCIO::CLUSTER);
+    auto clusters = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CLUSTER);
 
     // Loop over EDM4hep clusters converting them to lcio clusters
-    for (const auto& edm_cluster : (*cluster_coll)) {
+    for (const auto& edm_cluster : (*edmCollection)) {
       if (edm_cluster.isAvailable()) {
         auto* lcio_cluster = new lcio::ClusterImpl();
 
@@ -439,7 +426,7 @@ namespace EDM4hep2LCIOConv {
         }
 
         // Add LCIO and EDM4hep pair collections to vec
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_cluster, edm_cluster, cluster_vec);
+        k4EDM4hep2LcioConv::detail::mapInsert(lcio_cluster, edm_cluster, clusterMap);
 
         // Add to lcio tracks collection
         clusters->addElement(lcio_cluster);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -590,12 +590,12 @@ namespace EDM4hep2LCIOConv {
     }
   }
 
-  template<typename TrackMapT, typename TrackHitMapT, typename TPCHitMapT, typename THPlaneHitMapT>
+  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
   void resolveRelationsTracks(
     TrackMapT& tracksMap,
     const TrackHitMapT& trackerHitMap,
-    const TPCHitMapT&,
-    const THPlaneHitMapT&)
+    const THPlaneHitMapT& trackerHitPlaneMap,
+    const TPCHitMapT&)
   {
     for (auto& [lcio_tr, edm_tr] : tracksMap) {
       auto tracks = edm_tr.getTracks();
@@ -614,6 +614,9 @@ namespace EDM4hep2LCIOConv {
           continue;
         }
         if (const auto hit = k4EDM4hep2LcioConv::detail::mapLookupFrom(th, trackerHitMap)) {
+          lcio_tr->addHit(hit.value());
+        }
+        else if (const auto hit = k4EDM4hep2LcioConv::detail::mapLookupFrom(th, trackerHitPlaneMap)) {
           lcio_tr->addHit(hit.value());
         }
       }
@@ -773,7 +776,7 @@ namespace EDM4hep2LCIOConv {
   {
     resolveRelationsMCParticles(update_pairs.mcParticles, lookup_pairs.mcParticles);
     resolveRelationsTracks(
-      update_pairs.tracks, lookup_pairs.trackerHits, lookup_pairs.tpcHits, lookup_pairs.trackerHitPlanes);
+      update_pairs.tracks, lookup_pairs.trackerHits, lookup_pairs.trackerHitPlanes, lookup_pairs.tpcHits);
     resolveRelationsRecoParticles(
       update_pairs.recoParticles,
       lookup_pairs.recoParticles,

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -627,7 +627,7 @@ namespace EDM4hep2LCIOConv {
   void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap)
   {
     for (auto& [lcio_strh, edm_strh] : simTrHitMap) {
-      auto edm_strh_mcp = edm_strh.getMCParticle();
+      auto edm_strh_mcp = edm_strh.getParticle();
       if (edm_strh_mcp.isAvailable()) {
         if (const auto lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_strh_mcp, mcParticleMap)) {
           lcio_strh->setMCParticle(lcio_mcp.value());

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -110,7 +110,7 @@ namespace EDM4hep2LCIOConv {
       }
     }
 
-    FillMissingCollections(objectMappings);
+    resolveRelations(objectMappings);
 
     return lcioEvent;
   }

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -50,8 +50,8 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::SimTrackerHitCollection*>(edmCollection)) {
-        auto lcColl = convSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits, objectMappings.mcParticles);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::CalorimeterHitCollection*>(edmCollection)) {
         auto lcColl = convertCalorimeterHits(coll, cellIDStr, objectMappings.caloHits);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -38,8 +38,8 @@ namespace EDM4hep2LCIOConv {
         metadata.getParameter<std::string>(podio::collMetadataParamName(name, edm4hep::CellIDEncoding));
 
       if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
-        auto lcColl = convTracks(coll, objectMappings.tracks, objectMappings.trackerHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertTracks(coll, objectMappings.tracks);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::TrackerHit3DCollection*>(edmCollection)) {
         auto lcColl = convTrackerHits(coll, cellIDStr, objectMappings.trackerHits);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -29,7 +29,7 @@ namespace EDM4hep2LCIOConv {
     return std::find(coll->begin(), coll->end(), collection_name) != coll->end();
   }
 
-  std::unique_ptr<lcio::LCEventImpl> convEvent(const podio::Frame& edmEvent, const podio::Frame& metadata)
+  std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, const podio::Frame& metadata)
   {
     auto lcioEvent = std::make_unique<lcio::LCEventImpl>();
     auto objectMappings = CollectionsPairVectors {};

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -4,8 +4,12 @@
 
 namespace EDM4hep2LCIOConv {
 
-  // The EventHeaderCollection should be of length 1
   void convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event)
+  {
+    convertEventHeader(header_coll, lcio_event);
+  }
+
+  void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event)
   {
     if (header_coll->size() != 1) {
       return;
@@ -86,7 +90,7 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
-        convEventHeader(coll, lcioEvent.get());
+        convertEventHeader(coll, lcioEvent.get());
       }
       else if (
         dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection) ||

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -82,9 +82,8 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::ReconstructedParticleCollection*>(edmCollection)) {
-        auto lcColl = convReconstructedParticles(
-          coll, objectMappings.recoParticles, objectMappings.tracks, objectMappings.vertices, objectMappings.clusters);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertReconstructedParticles(coll, objectMappings.recoParticles);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
         convEventHeader(coll, lcioEvent.get());

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -82,8 +82,8 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::MCParticleCollection*>(edmCollection)) {
-        auto lcColl = convMCParticles(coll, objectMappings.mcParticles);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertMCParticles(coll, objectMappings.mcParticles);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::ReconstructedParticleCollection*>(edmCollection)) {
         auto lcColl = convertReconstructedParticles(coll, objectMappings.recoParticles);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -89,8 +89,11 @@ namespace EDM4hep2LCIOConv {
       else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
         convEventHeader(coll, lcioEvent.get());
       }
-      else if (dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
-        // "converted" as part of FillMissingCollectoins at the end
+      else if (
+        dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection) ||
+        dynamic_cast<const edm4hep::ParticleIDCollection*>(edmCollection)) {
+        // "converted" as part of FillMissingCollectoins at the end or as part
+        // of the reconstructed particle
         continue;
       }
       else {

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -74,8 +74,8 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::VertexCollection*>(edmCollection)) {
-        auto lcColl = convVertices(coll, objectMappings.vertices, objectMappings.recoParticles);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertVertices(coll, objectMappings.vertices);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::MCParticleCollection*>(edmCollection)) {
         auto lcColl = convMCParticles(coll, objectMappings.mcParticles);

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -42,36 +42,36 @@ namespace EDM4hep2LCIOConv {
         lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::TrackerHit3DCollection*>(edmCollection)) {
-        auto lcColl = convTrackerHits(coll, cellIDStr, objectMappings.trackerHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertTrackerHits(coll, cellIDStr, objectMappings.trackerHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::TrackerHitPlaneCollection*>(edmCollection)) {
-        auto lcColl = convTrackerHitPlanes(coll, cellIDStr, objectMappings.trackerHitPlanes);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertTrackerHitPlanes(coll, cellIDStr, objectMappings.trackerHitPlanes);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::SimTrackerHitCollection*>(edmCollection)) {
         auto lcColl = convSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits, objectMappings.mcParticles);
         lcioEvent->addCollection(lcColl, name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::CalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convCalorimeterHits(coll, cellIDStr, objectMappings.caloHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertCalorimeterHits(coll, cellIDStr, objectMappings.caloHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::RawCalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convRawCalorimeterHits(coll, objectMappings.rawCaloHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertRawCalorimeterHits(coll, objectMappings.rawCaloHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::SimCalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::RawTimeSeriesCollection*>(edmCollection)) {
-        auto lcColl = convTPCHits(coll, objectMappings.tpcHits);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertTPCHits(coll, objectMappings.tpcHits);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::ClusterCollection*>(edmCollection)) {
-        auto lcColl = convClusters(coll, objectMappings.clusters);
-        lcioEvent->addCollection(lcColl, name);
+        auto lcColl = convertClusters(coll, objectMappings.clusters);
+        lcioEvent->addCollection(lcColl.release(), name);
       }
       else if (auto coll = dynamic_cast<const edm4hep::VertexCollection*>(edmCollection)) {
         auto lcColl = convVertices(coll, objectMappings.vertices, objectMappings.recoParticles);

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -27,6 +27,7 @@ int main()
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHit3DCollection, "trackerHits");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");
   ASSERT_SAME_OR_ABORT(edm4hep::ClusterCollection, "clusters");
+  ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "recos");
 
   return 0;
 }

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -17,7 +17,7 @@
 int main()
 {
   const auto origEvent = createExampleEvent();
-  const auto lcioEvent = EDM4hep2LCIOConv::convEvent(origEvent);
+  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(origEvent);
   const auto roundtripEvent = LCIO2EDM4hepConv::convertEvent(lcioEvent.get());
 
   ASSERT_SAME_OR_ABORT(edm4hep::CalorimeterHitCollection, "caloHits");

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -12,7 +12,7 @@
 int main()
 {
   const auto edmEvent = createExampleEvent();
-  const auto lcioEvent = EDM4hep2LCIOConv::convEvent(edmEvent);
+  const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(edmEvent);
 
   if (!compareEventHeader(lcioEvent.get(), &edmEvent)) {
     return 1;

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -7,6 +7,7 @@
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
 
 #include <edm4hep/TrackState.h>
 #include <iostream>
@@ -273,6 +274,62 @@ bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterC
     REQUIRE_SAME(origSubdetE.size(), subdetE.size(), "sizes of subdetector energies in cluster " << i);
     for (size_t iSE = 0; iSE < origSubdetE.size(); ++iSE) {
       REQUIRE_SAME(origSubdetE[iSE], subdetE[iSE], "subdetector energy " << iSE << " in cluster " << i);
+    }
+  }
+
+  return true;
+}
+
+bool compare(
+  const edm4hep::ReconstructedParticleCollection& origColl,
+  const edm4hep::ReconstructedParticleCollection& roundtripColl)
+{
+  REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    auto origReco = origColl[i];
+    auto reco = roundtripColl[i];
+
+    REQUIRE_SAME(origReco.getCharge(), reco.getCharge(), "charge in reco particle " << i);
+    REQUIRE_SAME(origReco.getMomentum(), reco.getMomentum(), "momentum in reco particle " << i);
+
+    const auto origRelClusters = origReco.getClusters();
+    const auto relClusters = reco.getClusters();
+    REQUIRE_SAME(origRelClusters.size(), relClusters.size(), "number of related clusters in reco particle " << i);
+    for (size_t iC = 0; iC < relClusters.size(); ++iC) {
+      REQUIRE_SAME(
+        origRelClusters[iC].getObjectID(),
+        relClusters[iC].getObjectID(),
+        "related cluster " << iC << " in reco particle " << i);
+    }
+
+    const auto origRelTracks = origReco.getTracks();
+    const auto relTracks = reco.getTracks();
+    REQUIRE_SAME(origRelTracks.size(), relTracks.size(), "number of related tracks in reco particle " << i);
+    for (size_t iT = 0; iT < relTracks.size(); ++iT) {
+      REQUIRE_SAME(
+        origRelTracks[iT].getObjectID(),
+        relTracks[iT].getObjectID(),
+        "related track " << iT << " in reco particle " << i);
+    }
+
+    const auto origRelParticles = origReco.getParticles();
+    const auto relParticles = reco.getParticles();
+    REQUIRE_SAME(origRelParticles.size(), relParticles.size(), "number of related particles in reco particle " << i);
+    for (size_t iP = 0; iP < relParticles.size(); ++iP) {
+      REQUIRE_SAME(
+        origRelParticles[iP].getObjectID(),
+        relParticles[iP].getObjectID(),
+        "related particle " << iP << " in reco particle " << i);
+    }
+
+    const auto origRelPIDs = origReco.getParticleIDs();
+    const auto relPIDs = reco.getParticleIDs();
+    REQUIRE_SAME(origRelPIDs.size(), relPIDs.size(), "number of related ParticleIDs in reco particle" << i);
+    for (size_t iP = 0; iP < relPIDs.size(); ++iP) {
+      REQUIRE_SAME(
+        origRelPIDs[iP].getObjectID(),
+        relPIDs[iP].getObjectID(),
+        "related ParticleID " << iP << " in reco particle " << i);
     }
   }
 

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -21,4 +21,8 @@ bool compare(
 
 bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterCollection& roundtripColl);
 
+bool compare(
+  const edm4hep::ReconstructedParticleCollection& origColl,
+  const edm4hep::ReconstructedParticleCollection& roundtripColl);
+
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -376,7 +376,7 @@ podio::Frame createExampleEvent()
   event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
   const auto& trackerHits = event.put(createTrackerHits(test_config::nTrackerHits), "trackerHits");
   const auto& trackerHitPlanes = event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
-  event.put(
+  const auto& tracks = event.put(
     createTracks(
       test_config::nTracks,
       test_config::nSubdetectorHitNumbers,
@@ -386,6 +386,7 @@ podio::Frame createExampleEvent()
       test_config::trackTrackerHitIdcs,
       test_config::trackTrackIdcs),
     "tracks");
+
   const auto& clusters = event.put(
     createClusters(
       test_config::nClusters,

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -26,6 +26,8 @@ namespace edm4hep {
   class CaloHitContributionCollection;
   class EventHeaderCollection;
   class ClusterCollection;
+  class ReconstructedParticleCollection;
+  class ParticleIDCollection;
 } // namespace edm4hep
 
 namespace podio {
@@ -88,6 +90,29 @@ namespace test_config {
   /// cluster. First index is the cluster to which the second index cluster will
   /// be added
   const static std::vector<IdxPair> clusterClusterIdcs = {{0, 4}, {0, 3}, {0, 1}, {4, 3}, {4, 2}, {2, 3}, {1, 1}};
+
+  /// The number of reco particles to create
+  constexpr static int nRecoParticles = 6;
+  /// The related clusters that should be associated to the reco particles.
+  /// First index is the reco particle, second is the index of the cluster in
+  /// its collection
+  const static std::vector<IdxPair> recoClusterIdcs = {{0, 4}, {0, 3}, {2, 2}, {5, 1}, {5, 0}};
+
+  /// The related tracks that should be associated to the reco particles. First
+  /// index is the reco particle, second is the index of the track in its
+  /// collection
+  const static std::vector<IdxPair> recoTrackIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}};
+
+  /// The related reco partiles that should be associated to the reco particles.
+  /// First index is the reco particle, second is the index of the related reco
+  /// particle
+  const static std::vector<IdxPair> recoRecoIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}, {1, 2}, {2, 4}};
+
+  /// The ParticleIDs algorithmType that will be create for some reco particles.
+  /// The first index is the reco paritcle to which a ParticleID with algorithm
+  /// type of the second index will be attached
+  const static std::vector<IdxPair> recoPIDTypes = {{0, 1}, {0, 2}, {1, 1}, {2, 1}, {2, 2}, {3, 1}, {4, 2}};
+
 } // namespace test_config
 
 /**
@@ -151,6 +176,15 @@ edm4hep::ClusterCollection createClusters(
   const std::vector<test_config::IdxPair>& clusterHitIdcs,
   const std::vector<test_config::IdxPair>& clusterClusterIdcs);
 
+std::tuple<edm4hep::ReconstructedParticleCollection, edm4hep::ParticleIDCollection> createRecoParticles(
+  const int nRecos,
+  const edm4hep::TrackCollection& tracks,
+  const std::vector<test_config::IdxPair>& trackIdcs,
+  const edm4hep::ClusterCollection& clusters,
+  const std::vector<test_config::IdxPair>& clusterIdcs,
+  const std::vector<test_config::IdxPair>& recIdcs,
+  const std::vector<test_config::IdxPair>& pidAlgTypes);
+
 /**
  * Create an example event that can be used to test the converter.
  *
@@ -159,16 +193,19 @@ edm4hep::ClusterCollection createClusters(
  * The following table gives an overview of the contents. The arguments for
  * calling the individual creation functions are taken from the test_config
  * namespace.
- * | Name                 | Data type           | comment                  |
- * |----------------------+---------------------+--------------------------|
- * | mcParticles          | MCParticle          | createMCParticles        |
- * | caloHits             | CalorimeterHit      | createCalorimeterHits    |
- * | rawCaloHits          | RawCalorimeterHit   | createRawCalorimeterHits |
- * | tpcHits              | RawTimeSeries       | createTPCHits            |
- * | trackerHits          | TrackerHit          | createTrackerHits        |
- * | simCaloHits          | SimCalorimeterHit   | createSimCalorimeterHits |
- * | caloHitContributions | CaloHitContribution | createSimCalorimeterHits |
- * | clusters             | ClusterCollection   | createClusters           |
+ *
+ * | Name                 | Data type                       | comment                  |
+ * |----------------------|---------------------------------|--------------------------|
+ * | mcParticles          | MCParticle                      | createMCParticles        |
+ * | caloHits             | CalorimeterHit                  | createCalorimeterHits    |
+ * | rawCaloHits          | RawCalorimeterHit               | createRawCalorimeterHits |
+ * | tpcHits              | RawTimeSeries                   | createTPCHits            |
+ * | trackerHits          | TrackerHit                      | createTrackerHits        |
+ * | simCaloHits          | SimCalorimeterHit               | createSimCalorimeterHits |
+ * | caloHitContributions | CaloHitContribution             | createSimCalorimeterHits |
+ * | clusters             | ClusterCollection               | createClusters           |
+ * | recos                | ReconstructedParticleCollection | createRecoParticles      |
+ * | recos_particleIDs    | ParticleIDCollection            | createRecoParticles      |
  */
 podio::Frame createExampleEvent();
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename all `convXYZ` methods to `convertXYZ` and deprecate the former versions for the EDM4hep to LCIO direction to make it more consistent with the other direction.
- Cleanly split the EDM4hep to LCIO conversion into two steps, doing data conversion only in the first step and relation resolving in a second step.
  - Introduce `resolveXYZRelations` functions for all types where it is necessary and remove preliminary relation resolving from data conversion functions
  - All `convertXYZ` functions now only take one map that is populated as they no longer have to do any relation resolving
- Add roundtrip tests for ReconstructedParticle conversion
  - Fix issue that was lurking here in passing by cleanly splitting conversion process into two steps

ENDRELEASENOTES

This is mainly a preparatory step to make #51 a bit easier to do and to have a bit more consistency between the different conversion directions.

- [x] Includes #53 