### PR TITLE
Fix deprecation warnings from EDM4hep changes

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -224,7 +224,7 @@ namespace EDM4hep2LCIOConv {
         lcio_strh->setProducedBySecondary(edm_strh.isProducedBySecondary());
 
         // Link converted MCParticle to the SimTrackerHit if found
-        const auto edm_strh_mcp = edm_strh.getMCParticle();
+        const auto edm_strh_mcp = edm_strh.getParticle();
         if (edm_strh_mcp.isAvailable()) {
           if (const auto& lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_strh_mcp, mcparticles_vec)) {
             lcio_strh->setMCParticle(lcio_mcp.value());
@@ -541,7 +541,7 @@ namespace EDM4hep2LCIOConv {
     for (const auto& edm_rp : (*recos_coll)) {
       auto* lcio_recp = new lcio::ReconstructedParticleImpl;
       if (edm_rp.isAvailable()) {
-        lcio_recp->setType(edm_rp.getType());
+        lcio_recp->setType(edm_rp.getPDG());
         float m[3] = {edm_rp.getMomentum()[0], edm_rp.getMomentum()[1], edm_rp.getMomentum()[2]};
         lcio_recp->setMomentum(m);
         lcio_recp->setEnergy(edm_rp.getEnergy());
@@ -839,7 +839,7 @@ namespace EDM4hep2LCIOConv {
     for (auto& [lcio_strh, edm_strh] : update_pairs.simTrackerHits) {
       const auto lcio_strh_mcp = lcio_strh->getMCParticle();
       if (lcio_strh_mcp == nullptr) {
-        const auto edm_strh_mcp = edm_strh.getMCParticle();
+        const auto edm_strh_mcp = edm_strh.getParticle();
         if (const auto lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_strh_mcp, lookup_pairs.mcParticles)) {
           lcio_strh->setMCParticle(lcio_mcp.value());
         }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -100,8 +100,8 @@ namespace LCIO2EDM4hepConv {
       lval.setColorFlow(edm4hep::Vector2i(rval->getColorFlow()));
       lval.setVertex(edm4hep::Vector3d(rval->getVertex()));
       lval.setEndpoint(edm4hep::Vector3d(rval->getEndpoint()));
-      lval.setMomentum(Vector3fFrom(rval->getMomentum()));
-      lval.setMomentumAtEndpoint(Vector3fFrom(rval->getMomentumAtEndpoint()));
+      lval.setMomentum(rval->getMomentum());
+      lval.setMomentumAtEndpoint(rval->getMomentumAtEndpoint());
 
       const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, mcparticlesMap);
       if (!inserted) {
@@ -135,7 +135,7 @@ namespace LCIO2EDM4hepConv {
       lval.setMass(rval->getMass());
       lval.setMomentum(Vector3fFrom(rval->getMomentum()));
       lval.setReferencePoint(rval->getReferencePoint());
-      lval.setType(rval->getType());
+      lval.setPDG(rval->getType());
 
       const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, recoparticlesMap);
       if (!inserted) {
@@ -657,7 +657,7 @@ namespace LCIO2EDM4hepConv {
         continue;
       }
       if (const auto edmP = k4EDM4hep2LcioConv::detail::mapLookupTo(mcps, mcparticlesMap)) {
-        edm.setMCParticle(edmP.value());
+        edm.setParticle(edmP.value());
       }
       else {
         std::cerr << "Cannot find corresponding EDM4hep MCParticle for the LCIO MCParticle, "

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -180,7 +180,7 @@ bool compare(
   const edm4hep::ReconstructedParticle& edm4hepElem,
   const ObjectMappings& objectMaps)
 {
-  ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in ReconstructedParticle");
+  ASSERT_COMPARE_VALS(lcioElem->getType(), edm4hepElem.getPDG(), "type/PDG in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentum, "momentum in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getReferencePoint, "referencePoint in ReconstructedParticle");
@@ -298,7 +298,10 @@ bool compare(
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentum, "momentum in SimTrackerHit");
 
-  ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getMCParticle, objectMaps.mcParticles, "MCParticle in SimTrackerHit");
+  if (!compareRelation(
+        lcioElem->getMCParticle(), edm4hepElem.getParticle(), objectMaps.mcParticles, "MC particle in SimTrackerHit")) {
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to non-deprecated access methods after original methods have been deprecated in [EDM4hep#267](https://github.com/key4hep/EDM4hep/pull/267), [EDM4hep#256](https://github.com/key4hep/EDM4hep/pull/256) and [EDM4hep#273](https://github.com/key4hep/EDM4hep/pull/273)

ENDRELEASENOTES
