### PR TITLE
Transparently introduce CovMatrix components

### DIFF
--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -7,6 +7,12 @@
 #include "edm4hep/Vector2i.h"
 #include "edm4hep/Vector3d.h"
 #include "edm4hep/Vector3f.h"
+#if __has_include("edm4hep/CovMatrix3f.h")
+#include <edm4hep/CovMatrix3f.h>
+#include <edm4hep/CovMatrix2f.h>
+#include <edm4hep/CovMatrix4f.h>
+#include <edm4hep/CovMatrix6f.h>
+#endif
 
 #include "UTIL/LCIterator.h"
 #include "EVENT/LCCollection.h"
@@ -74,9 +80,22 @@ constexpr bool isAnyOf = (std::is_same_v<T, Ts> || ...);
 template<typename LCIO, typename EDM4hepT>
 bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg)
 {
-  constexpr auto isVectorLike =
-    has_size_method<EDM4hepT>::value ||
-    isAnyOf<EDM4hepT, edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f, edm4hep::Vector2i>;
+  constexpr auto isVectorLike = has_size_method<EDM4hepT>::value || isAnyOf<
+                                                                      EDM4hepT,
+                                                                      edm4hep::Vector3f,
+                                                                      edm4hep::Vector3d,
+                                                                      edm4hep::Vector2f,
+                                                                      edm4hep::Vector2i
+#if __has_include("edm4hep/CovMatrix3f.h")
+                                                                      ,
+                                                                      // These also effectively behave like vectors for
+                                                                      // the purposes of this function
+                                                                      edm4hep::CovMatrix2f,
+                                                                      edm4hep::CovMatrix3f,
+                                                                      edm4hep::CovMatrix4f,
+                                                                      edm4hep::CovMatrix6f
+#endif
+                                                                      >;
 
   if constexpr (isVectorLike) {
     const auto vecSize = [&edm4hepV]() -> std::size_t {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the introduction of covariance matrix [key4hep/EDM4hep#287](https://github.com/key4hep/EDM4hep/pull/287) components transparent

ENDRELEASENOTES
