### PR TITLE
Fix typo in k4Lcio2EDM4hepConv.cpp

### DIFF
--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -145,7 +145,7 @@ namespace LCIO2EDM4hepConv {
   {
     podio::Frame runHeaderFrame;
     runHeaderFrame.putParameter("runNumber", rheader->getRunNumber());
-    runHeaderFrame.putParameter("detectoName", rheader->getDetectorName());
+    runHeaderFrame.putParameter("detectorName", rheader->getDetectorName());
     runHeaderFrame.putParameter("description", rheader->getDescription());
     auto subdetectors = rheader->getActiveSubdetectors();
     runHeaderFrame.putParameter("activeSubdetectors", *subdetectors);


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix typo in run header parameter `detectoName` to `detectorName` in k4Lcio2EDM4hepConv.cpp

ENDRELEASENOTES
