### PR TITLE
Fix narrowing in Cov3f

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
@@ -58,8 +58,7 @@ namespace k4EDM4hep2LcioConv {
     /// Helper struct to determine the key and mapped types for map-like types or
     /// maps
     template<typename T, typename IsMap = std::bool_constant<is_map_v<T>>>
-    struct map_t_helper {
-    };
+    struct map_t_helper {};
 
     template<typename T>
     struct map_t_helper<T, std::bool_constant<true>> {
@@ -89,8 +88,7 @@ namespace k4EDM4hep2LcioConv {
     /// Helper struct to determine the Mutable type for a user facing type
     /// NOTE: Not SFINAE safe for anything that is not a podio generated class
     template<typename T, typename IsMutable = std::bool_constant<is_mutable_v<T>>>
-    struct mutable_t_helper {
-    };
+    struct mutable_t_helper {};
 
     template<typename T>
     struct mutable_t_helper<T, std::bool_constant<true>> {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
@@ -58,7 +58,8 @@ namespace k4EDM4hep2LcioConv {
     /// Helper struct to determine the key and mapped types for map-like types or
     /// maps
     template<typename T, typename IsMap = std::bool_constant<is_map_v<T>>>
-    struct map_t_helper {};
+    struct map_t_helper {
+    };
 
     template<typename T>
     struct map_t_helper<T, std::bool_constant<true>> {
@@ -88,7 +89,8 @@ namespace k4EDM4hep2LcioConv {
     /// Helper struct to determine the Mutable type for a user facing type
     /// NOTE: Not SFINAE safe for anything that is not a podio generated class
     template<typename T, typename IsMutable = std::bool_constant<is_mutable_v<T>>>
-    struct mutable_t_helper {};
+    struct mutable_t_helper {
+    };
 
     template<typename T>
     struct mutable_t_helper<T, std::bool_constant<true>> {

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -76,7 +76,7 @@ namespace LCIO2EDM4hepConv {
   std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl)
   {
     std::vector<edm4hep::utils::ParticleIDMeta> pidInfos {};
-    const auto pidHandler = UTIL::PIDHandler(recoColl);
+    auto pidHandler = UTIL::PIDHandler(recoColl);
     for (const auto id : pidHandler.getAlgorithmIDs()) {
       pidInfos.emplace_back(pidHandler.getAlgorithmName(id), id, pidHandler.getParameterNames(id));
     }

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -21,27 +21,9 @@ namespace LCIO2EDM4hepConv {
     edmtrackState.referencePoint = Vector3fFrom({refPoint[0], refPoint[1], refPoint[2]});
     const auto& covMatrix = trackState->getCovMatrix();
     edmtrackState.covMatrix = {
-      covMatrix[0],
-      covMatrix[1],
-      covMatrix[2],
-      covMatrix[3],
-      covMatrix[4],
-      covMatrix[5],
-      covMatrix[6],
-      covMatrix[7],
-      covMatrix[8],
-      covMatrix[9],
-      covMatrix[10],
-      covMatrix[11],
-      covMatrix[12],
-      covMatrix[13],
-      covMatrix[14],
-      0.f,
-      0.f,
-      0.f,
-      0.f,
-      0.f,
-      0.f};
+      covMatrix[0],  covMatrix[1], covMatrix[2], covMatrix[3],  covMatrix[4],  covMatrix[5],  covMatrix[6],
+      covMatrix[7],  covMatrix[8], covMatrix[9], covMatrix[10], covMatrix[11], covMatrix[12], covMatrix[13],
+      covMatrix[14], 0.f,          0.f,          0.f,           0.f,           0.f,           0.f};
 
     return edmtrackState;
   }

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -36,12 +36,12 @@ namespace LCIO2EDM4hepConv {
       covMatrix[12],
       covMatrix[13],
       covMatrix[14],
-      0,
-      0,
-      0,
-      0,
-      0,
-      0};
+      0.f,
+      0.f,
+      0.f,
+      0.f,
+      0.f,
+      0.f};
 
     return edmtrackState;
   }

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -98,7 +98,7 @@ bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg)
                                                                       >;
 
   if constexpr (isVectorLike) {
-    const auto vecSize = [&edm4hepV]() -> std::size_t {
+    const auto vecSize = [](EDM4hepT& edm4hepV) -> std::size_t {
       if constexpr (has_size_method<EDM4hepT>::value) {
         return edm4hepV.size();
       }
@@ -109,7 +109,7 @@ bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg)
         return 2;
       }
       return 0;
-    }();
+    }(edm4hepV);
     for (size_t i = 0; i < vecSize; ++i) {
       if (!nanSafeComp(lcioV[i], edm4hepV[i])) {
         std::cerr << msg << " at index " << i << ": (LCIO: " << (lcioV) << ", EDM4hep: " << (edm4hepV) << ")"

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -1,8 +1,11 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
 #define K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
 
-#include <unordered_map>
+#include <edm4hep/ParticleID.h>
+
 #include "podio/ObjectID.h"
+
+#include <unordered_map>
 
 namespace EVENT {
   class Track;
@@ -25,10 +28,6 @@ namespace podio {
   class Frame;
 } // namespace podio
 
-namespace edm4hep {
-  class ParticleID;
-}
-
 struct ObjectMappings {
   template<typename K>
   using Map = std::unordered_map<K, podio::ObjectID>;
@@ -46,7 +45,7 @@ struct ObjectMappings {
   Map<const EVENT::TPCHit*> tpcHits {};
   Map<const EVENT::Vertex*> vertices {};
 
-  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs;
+  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs {};
 
   static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
 };


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix narrowing in Cov3f from int to float. This triggers a warning in GCC 13 and a compiler error in Clang 17. 
- Fix a compiler error and a warning with Clang. The first one about constness of the LCIO pid handler and the other one about a lambda parameter not being used

ENDRELEASENOTES

The narrowing could be fixed in EDM4hep by doing `static_cast<float>` first but then there is no info when there is a narrowing conversion and there is possibly loss of some information because the destination type (float for CovNf) can't represent all the values of the original type. What I don't like is that it's a bit inconsistent in GCC (warning) and Clang (error).

The LCIO PID handler one is:

```/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp:80:26: error: 'this' argument to member function 'getAlgorithmIDs' has type 'const UTIL::PIDHandler', but function is not marked const
   80 |     for (const auto id : pidHandler.getAlgorithmIDs()) {
      |                          ^~~~~~~~~~
/LCIO/src/cpp/include/UTIL/PIDHandler.h:104:26: note: 'getAlgorithmIDs' declared here
  104 |     const EVENT::IntVec& getAlgorithmIDs() ;

```