### PR TITLE
Synchronize clang-format configuration with Key4hep default

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,67 +1,236 @@
-Language: Cpp
-# Refer to documentation https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: true
-AlignOperands: true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortIfStatementsOnASingleLine: true
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: false
-BinPackParameters: false
-BreakBeforeBraces: Custom
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
 BraceWrapping:
-  AfterClass: false
-  AfterControlStatement: false
-  AfterEnum: false
-  AfterFunction: true
-  AfterNamespace: false
-  AfterStruct: false
-  BeforeElse: true
-  SplitEmptyFunction: false
-BreakBeforeTernaryOperators: false
-BreakConstructorInitializers: AfterColon
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-ColumnLimit: 120
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 2
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-IndentWidth: 2
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: All
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments: true
-SortIncludes: false
-SpaceAfterCStyleCast: true
-SpaceAfterTemplateKeyword: false
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
 SpacesInSquareBrackets: false
-Standard: Cpp11
-TabWidth: 2
-UseTab: Never
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,19 +6,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v3
-      with:
-        release-platform: LCG_102/x86_64-centos7-clang12-opt
-        run: |
-          echo "::group::Setup"
-          export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
-          export PATH=/root/.local/bin:$PATH
-          pip install pre-commit
-          # Use virtualenv from the LCG release
-          pip uninstall --yes virtualenv
-          echo "::group::ClangFormat"
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Run pre-commit
+      run: |
+        source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+        cd ${GITHUB_WORKSPACE}
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
@@ -1,254 +1,243 @@
 #ifndef K4EDM4HEP2LCIOCONV_MAPPINGUTILS_H
 #define K4EDM4HEP2LCIOCONV_MAPPINGUTILS_H
 
-#include <optional>
 #include <algorithm>
-#include <vector>
+#include <optional>
 #include <tuple>
-#include <unordered_map>
 #include <type_traits>
+#include <unordered_map>
+#include <vector>
 
 #if __has_include("experimental/type_traits.h")
 #include <experimental/type_traits>
 namespace det {
-  using namespace std::experimental;
+using namespace std::experimental;
 }
 #else
 // Implement the minimal feature set we need
 namespace det {
-  namespace detail {
-    template<typename DefT, typename AlwaysVoidT, template<typename...> typename Op, typename... Args>
-    struct detector {
-      using value_t = std::false_type;
-      using type = DefT;
-    };
-
-    template<typename DefT, template<typename...> typename Op, typename... Args>
-    struct detector<DefT, std::void_t<Op<Args...>>, Op, Args...> {
-      using value_t = std::true_type;
-      using type = Op<Args...>;
-    };
-  } // namespace detail
-
-  struct nonesuch {
-    ~nonesuch() = delete;
-    nonesuch(const nonesuch&) = delete;
-    void operator=(const nonesuch&) = delete;
+namespace detail {
+  template <typename DefT, typename AlwaysVoidT, template <typename...> typename Op, typename... Args>
+  struct detector {
+    using value_t = std::false_type;
+    using type = DefT;
   };
 
-  template<template<typename...> typename Op, typename... Args>
-  using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+  template <typename DefT, template <typename...> typename Op, typename... Args>
+  struct detector<DefT, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+  };
+} // namespace detail
 
-  template<template<typename...> typename Op, typename... Args>
-  static constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+struct nonesuch {
+  ~nonesuch() = delete;
+  nonesuch(const nonesuch&) = delete;
+  void operator=(const nonesuch&) = delete;
+};
+
+template <template <typename...> typename Op, typename... Args>
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+template <template <typename...> typename Op, typename... Args>
+static constexpr bool is_detected_v = is_detected<Op, Args...>::value;
 } // namespace det
 #endif
 
 namespace k4EDM4hep2LcioConv {
 
-  namespace detail {
-    /// Very minimal detector for whether T is a map or not. We simply assume that
-    /// if it has a key_type we can also call find on T.
-    template<typename T>
-    using has_key_t = typename T::key_type;
+namespace detail {
+  /// Very minimal detector for whether T is a map or not. We simply assume that
+  /// if it has a key_type we can also call find on T.
+  template <typename T>
+  using has_key_t = typename T::key_type;
 
-    template<typename T>
-    constexpr static bool is_map_v = det::is_detected_v<has_key_t, T>;
+  template <typename T>
+  constexpr static bool is_map_v = det::is_detected_v<has_key_t, T>;
 
-    /// Helper struct to determine the key and mapped types for map-like types or
-    /// maps
-    template<typename T, typename IsMap = std::bool_constant<is_map_v<T>>>
-    struct map_t_helper {
-    };
+  /// Helper struct to determine the key and mapped types for map-like types or
+  /// maps
+  template <typename T, typename IsMap = std::bool_constant<is_map_v<T>>>
+  struct map_t_helper {};
 
-    template<typename T>
-    struct map_t_helper<T, std::bool_constant<true>> {
-      using key_type = typename T::key_type;
-      using mapped_type = typename T::mapped_type;
-    };
+  template <typename T>
+  struct map_t_helper<T, std::bool_constant<true>> {
+    using key_type = typename T::key_type;
+    using mapped_type = typename T::mapped_type;
+  };
 
-    template<typename T>
-    struct map_t_helper<T, std::bool_constant<false>> {
-      using key_type = typename std::tuple_element<0, typename T::value_type>::type;
-      using mapped_type = typename std::tuple_element<1, typename T::value_type>::type;
-    };
+  template <typename T>
+  struct map_t_helper<T, std::bool_constant<false>> {
+    using key_type = typename std::tuple_element<0, typename T::value_type>::type;
+    using mapped_type = typename std::tuple_element<1, typename T::value_type>::type;
+  };
 
-    template<typename T>
-    using key_t = typename map_t_helper<T>::key_type;
+  template <typename T>
+  using key_t = typename map_t_helper<T>::key_type;
 
-    template<typename T>
-    using mapped_t = typename map_t_helper<T>::mapped_type;
+  template <typename T>
+  using mapped_t = typename map_t_helper<T>::mapped_type;
 
-    template<typename T>
-    using has_object_type = typename T::object_type;
+  template <typename T>
+  using has_object_type = typename T::object_type;
 
-    /// Detector for whether a type T is a Mutable user facing type.
-    template<typename T>
-    constexpr static bool is_mutable_v = det::is_detected_v<has_object_type, T>;
+  /// Detector for whether a type T is a Mutable user facing type.
+  template <typename T>
+  constexpr static bool is_mutable_v = det::is_detected_v<has_object_type, T>;
 
-    /// Helper struct to determine the Mutable type for a user facing type
-    /// NOTE: Not SFINAE safe for anything that is not a podio generated class
-    template<typename T, typename IsMutable = std::bool_constant<is_mutable_v<T>>>
-    struct mutable_t_helper {
-    };
+  /// Helper struct to determine the Mutable type for a user facing type
+  /// NOTE: Not SFINAE safe for anything that is not a podio generated class
+  template <typename T, typename IsMutable = std::bool_constant<is_mutable_v<T>>>
+  struct mutable_t_helper {};
 
-    template<typename T>
-    struct mutable_t_helper<T, std::bool_constant<true>> {
-      using type = T;
-    };
+  template <typename T>
+  struct mutable_t_helper<T, std::bool_constant<true>> {
+    using type = T;
+  };
 
-    template<typename T>
-    struct mutable_t_helper<T, std::bool_constant<false>> {
-      using type = typename T::mutable_type;
-    };
+  template <typename T>
+  struct mutable_t_helper<T, std::bool_constant<false>> {
+    using type = typename T::mutable_type;
+  };
 
-    template<typename T>
-    using mutable_t = typename mutable_t_helper<T>::type;
+  template <typename T>
+  using mutable_t = typename mutable_t_helper<T>::type;
 
-    /// bool constant to determine whether type T is a valid type to be used as
-    /// a key in the generic mapping functionality defined below. In this case
-    /// it checks for type equality or makes sure that KeyT is a base of T or
-    /// vice versa. This is designed specifically for the uses cases here, where
-    /// the LCIO types (pointers) are used as key types.
-    template<typename T, typename KeyT>
-    constexpr static bool is_valid_key_type_v =
+  /// bool constant to determine whether type T is a valid type to be used as
+  /// a key in the generic mapping functionality defined below. In this case
+  /// it checks for type equality or makes sure that KeyT is a base of T or
+  /// vice versa. This is designed specifically for the uses cases here, where
+  /// the LCIO types (pointers) are used as key types.
+  template <typename T, typename KeyT>
+  constexpr static bool is_valid_key_type_v =
       std::is_same_v<T, KeyT> || std::is_base_of_v<std::remove_pointer_t<T>, std::remove_pointer_t<KeyT>> ||
       std::is_base_of_v<std::remove_pointer_t<KeyT>, std::remove_pointer_t<T>>;
 
-    /// Detector and corresponding bool constant to detect whether two types are
-    /// equality comparable. c++20 would have a concept for this.
-    template<typename T, typename U>
-    using has_operator_eq = decltype(std::declval<T>() == std::declval<U>());
+  /// Detector and corresponding bool constant to detect whether two types are
+  /// equality comparable. c++20 would have a concept for this.
+  template <typename T, typename U>
+  using has_operator_eq = decltype(std::declval<T>() == std::declval<U>());
 
-    template<typename T, typename U>
-    constexpr static bool is_eq_comparable = det::is_detected_v<has_operator_eq, T, U>;
+  template <typename T, typename U>
+  constexpr static bool is_eq_comparable = det::is_detected_v<has_operator_eq, T, U>;
 
-    /// bool constant to determine whether a type T is a valid type to be used
-    /// as a mapped type in the generic mapping functionality defined below. In
-    /// this case this it checks T is equality copmarable with MappedT
-    template<typename T, typename MappedT>
-    constexpr static bool is_valid_mapped_type_v = is_eq_comparable<T, MappedT>;
+  /// bool constant to determine whether a type T is a valid type to be used
+  /// as a mapped type in the generic mapping functionality defined below. In
+  /// this case this it checks T is equality copmarable with MappedT
+  template <typename T, typename MappedT>
+  constexpr static bool is_valid_mapped_type_v = is_eq_comparable<T, MappedT>;
 
-    /**
-     * Find the mapped-to object in a map provided a key object
-     *
-     * NOTE: This will use a potentially more efficient lookup for actual map
-     * types (i.e. MapT::find). In that case it will have the time complexity of
-     * that. In case of a "map-like" (e.g. vector<tuple<K, V>>) it will be O(N).
-     */
-    template<typename FromT, typename MapT, typename = std::enable_if_t<is_valid_key_type_v<FromT, key_t<MapT>>>>
-    auto mapLookupTo(FromT keyObj, const MapT& map) -> std::optional<mapped_t<MapT>>
-    {
-      if constexpr (is_map_v<MapT>) {
-        if (const auto& it = map.find(keyObj); it != map.end()) {
-          return it->second;
-        }
+  /**
+   * Find the mapped-to object in a map provided a key object
+   *
+   * NOTE: This will use a potentially more efficient lookup for actual map
+   * types (i.e. MapT::find). In that case it will have the time complexity of
+   * that. In case of a "map-like" (e.g. vector<tuple<K, V>>) it will be O(N).
+   */
+  template <typename FromT, typename MapT, typename = std::enable_if_t<is_valid_key_type_v<FromT, key_t<MapT>>>>
+  auto mapLookupTo(FromT keyObj, const MapT& map) -> std::optional<mapped_t<MapT>> {
+    if constexpr (is_map_v<MapT>) {
+      if (const auto& it = map.find(keyObj); it != map.end()) {
+        return it->second;
       }
-      else {
-        if (const auto& it = std::find_if(
-              map.begin(), map.end(), [&keyObj](const auto& mapElem) { return std::get<0>(mapElem) == keyObj; });
-            it != map.end()) {
-          return std::get<1>(*it);
-        }
-      }
-
-      return std::nullopt;
-    }
-
-    /**
-     * Find the mapped-from (or key object) in a "map" provided a mapped-to object
-     *
-     * NOTE: This will always loop over potentially all elements in the provided
-     * map, so it is definitely O(N) regardless of the provided map type
-     */
-    template<typename ToT, typename MapT, typename = std::enable_if_t<is_valid_mapped_type_v<ToT, mapped_t<MapT>>>>
-    auto mapLookupFrom(ToT mappedObj, const MapT& map) -> std::optional<key_t<MapT>>
-    {
-      // In this case we cannot use a potential find method for an actual map, but
-      // looping over the map and doing the actual comparison will work
-      if (const auto& it = std::find_if(
-            map.begin(), map.end(), [&mappedObj](const auto& mapElem) { return std::get<1>(mapElem) == mappedObj; });
+    } else {
+      if (const auto& it = std::find_if(map.begin(), map.end(),
+                                        [&keyObj](const auto& mapElem) { return std::get<0>(mapElem) == keyObj; });
           it != map.end()) {
-        return std::get<0>(*it);
-      }
-
-      return std::nullopt;
-    }
-
-    enum class InsertMode { Unchecked, Checked };
-
-    /**
-     * Insert a key-value pair into a "map"
-     *
-     * The InsertMode argument can be use to check whether the Key already
-     * exists in the map before inserting. This is only useful for maps using a
-     * vector as backing, since the usual emplace already does this check and
-     * does not insert if a key already exists
-     */
-    template<typename MapT, typename KeyT = key_t<MapT>, typename MappedT = mapped_t<MapT>>
-    auto mapInsert(KeyT&& key, MappedT&& mapped, MapT& map, InsertMode insertMode = InsertMode::Unchecked)
-    {
-      if constexpr (is_map_v<MapT>) {
-        return map.emplace(std::forward<KeyT>(key), std::forward<MappedT>(mapped));
-      }
-      else {
-        if (insertMode == InsertMode::Checked) {
-          if (auto existing = mapLookupTo(key, map)) {
-            // Explicitly casting to the actual key type here to make return
-            // type deductoin work even in cases where we have a Map<Base*, V>
-            // but the KeyT has been deduced as Derived*
-            return std::make_pair(std::make_tuple(key_t<MapT>(key), existing.value()), false);
-          }
-        }
-        return std::make_pair(map.emplace_back(std::forward<KeyT>(key), std::forward<MappedT>(mapped)), true);
-      }
-    }
-
-    /// Helper type alias that can be used to detect whether a T can be used
-    /// with std::get directly or whether it has to be dereferenced first
-    template<typename T>
-    using std_get_usable = decltype(std::get<0>(std::declval<T>()));
-
-    /**
-     * Helper function to get the Key from an Iterator (e.g. returned by
-     * mapInsert). This is necessary because map::emplace returns an iterator,
-     * while vector::emplace_back returns a reference to the inserted element.
-     * Simply providing two overloads here does the trick.
-     */
-    template<typename It>
-    auto getKey(const It& it)
-    {
-      if constexpr (det::is_detected_v<std_get_usable, It>) {
-        return std::get<0>(it);
-      }
-      else {
-        return std::get<0>(*it);
-      }
-    }
-
-    /**
-     * Helper function to get the Value from an Iterator (e.g. returned by
-     * mapInsert). This is necessary because map::emplace returns an iterator,
-     * while vector::emplace_back returns a reference to the inserted element.
-     * Simply providing two overloads here does the trick.
-     */
-    template<typename It>
-    auto getMapped(const It& it)
-    {
-      if constexpr (det::is_detected_v<std_get_usable, It>) {
-        return std::get<1>(it);
-      }
-      else {
         return std::get<1>(*it);
       }
     }
-  } // namespace detail
 
-  template<typename K, typename V>
-  using MapT = std::unordered_map<K, V>;
+    return std::nullopt;
+  }
 
-  template<typename K, typename V>
-  using VecMapT = std::vector<std::tuple<K, V>>;
+  /**
+   * Find the mapped-from (or key object) in a "map" provided a mapped-to object
+   *
+   * NOTE: This will always loop over potentially all elements in the provided
+   * map, so it is definitely O(N) regardless of the provided map type
+   */
+  template <typename ToT, typename MapT, typename = std::enable_if_t<is_valid_mapped_type_v<ToT, mapped_t<MapT>>>>
+  auto mapLookupFrom(ToT mappedObj, const MapT& map) -> std::optional<key_t<MapT>> {
+    // In this case we cannot use a potential find method for an actual map, but
+    // looping over the map and doing the actual comparison will work
+    if (const auto& it = std::find_if(map.begin(), map.end(),
+                                      [&mappedObj](const auto& mapElem) { return std::get<1>(mapElem) == mappedObj; });
+        it != map.end()) {
+      return std::get<0>(*it);
+    }
+
+    return std::nullopt;
+  }
+
+  enum class InsertMode { Unchecked, Checked };
+
+  /**
+   * Insert a key-value pair into a "map"
+   *
+   * The InsertMode argument can be use to check whether the Key already
+   * exists in the map before inserting. This is only useful for maps using a
+   * vector as backing, since the usual emplace already does this check and
+   * does not insert if a key already exists
+   */
+  template <typename MapT, typename KeyT = key_t<MapT>, typename MappedT = mapped_t<MapT>>
+  auto mapInsert(KeyT&& key, MappedT&& mapped, MapT& map, InsertMode insertMode = InsertMode::Unchecked) {
+    if constexpr (is_map_v<MapT>) {
+      return map.emplace(std::forward<KeyT>(key), std::forward<MappedT>(mapped));
+    } else {
+      if (insertMode == InsertMode::Checked) {
+        if (auto existing = mapLookupTo(key, map)) {
+          // Explicitly casting to the actual key type here to make return
+          // type deductoin work even in cases where we have a Map<Base*, V>
+          // but the KeyT has been deduced as Derived*
+          return std::make_pair(std::make_tuple(key_t<MapT>(key), existing.value()), false);
+        }
+      }
+      return std::make_pair(map.emplace_back(std::forward<KeyT>(key), std::forward<MappedT>(mapped)), true);
+    }
+  }
+
+  /// Helper type alias that can be used to detect whether a T can be used
+  /// with std::get directly or whether it has to be dereferenced first
+  template <typename T>
+  using std_get_usable = decltype(std::get<0>(std::declval<T>()));
+
+  /**
+   * Helper function to get the Key from an Iterator (e.g. returned by
+   * mapInsert). This is necessary because map::emplace returns an iterator,
+   * while vector::emplace_back returns a reference to the inserted element.
+   * Simply providing two overloads here does the trick.
+   */
+  template <typename It>
+  auto getKey(const It& it) {
+    if constexpr (det::is_detected_v<std_get_usable, It>) {
+      return std::get<0>(it);
+    } else {
+      return std::get<0>(*it);
+    }
+  }
+
+  /**
+   * Helper function to get the Value from an Iterator (e.g. returned by
+   * mapInsert). This is necessary because map::emplace returns an iterator,
+   * while vector::emplace_back returns a reference to the inserted element.
+   * Simply providing two overloads here does the trick.
+   */
+  template <typename It>
+  auto getMapped(const It& it) {
+    if constexpr (det::is_detected_v<std_get_usable, It>) {
+      return std::get<1>(it);
+    } else {
+      return std::get<1>(*it);
+    }
+  }
+} // namespace detail
+
+template <typename K, typename V>
+using MapT = std::unordered_map<K, V>;
+
+template <typename K, typename V>
+using VecMapT = std::vector<std::tuple<K, V>>;
 
 } // namespace k4EDM4hep2LcioConv
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -16,19 +16,19 @@
 #include <edm4hep/MCRecoTrackerAssociationCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
+#include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/RecoParticleVertexAssociationCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
-#include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/TrackCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-  using TrackerHit3D = edm4hep::TrackerHit;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3D = edm4hep::TrackerHit;
 } // namespace edm4hep
 #endif
 #include <edm4hep/TrackerHitPlaneCollection.h>
@@ -68,418 +68,359 @@ namespace edm4hep {
 
 namespace EDM4hep2LCIOConv {
 
-  template<typename T1, typename T2>
-  using ObjectMapT = k4EDM4hep2LcioConv::VecMapT<T1, T2>;
+template <typename T1, typename T2>
+using ObjectMapT = k4EDM4hep2LcioConv::VecMapT<T1, T2>;
 
-  template<typename T1, typename T2>
-  using vec_pair [[deprecated("Use a more descriptive alias")]] = ObjectMapT<T1, T2>;
+template <typename T1, typename T2>
+using vec_pair [[deprecated("Use a more descriptive alias")]] = ObjectMapT<T1, T2>;
 
-  struct CollectionsPairVectors {
-    ObjectMapT<lcio::TrackImpl*, edm4hep::Track> tracks {};
-    ObjectMapT<lcio::TrackerHitImpl*, edm4hep::TrackerHit3D> trackerHits {};
-    ObjectMapT<lcio::TrackerHitPlaneImpl*, edm4hep::TrackerHitPlane> trackerHitPlanes {};
-    ObjectMapT<lcio::SimTrackerHitImpl*, edm4hep::SimTrackerHit> simTrackerHits {};
-    ObjectMapT<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit> caloHits {};
-    ObjectMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalorimeterHit> rawCaloHits {};
-    ObjectMapT<lcio::SimCalorimeterHitImpl*, edm4hep::SimCalorimeterHit> simCaloHits {};
-    ObjectMapT<lcio::TPCHitImpl*, edm4hep::RawTimeSeries> tpcHits {};
-    ObjectMapT<lcio::ClusterImpl*, edm4hep::Cluster> clusters {};
-    ObjectMapT<lcio::VertexImpl*, edm4hep::Vertex> vertices {};
-    ObjectMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle> recoParticles {};
-    ObjectMapT<lcio::MCParticleImpl*, edm4hep::MCParticle> mcParticles {};
-    ObjectMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID> particleIDs {};
-  };
+struct CollectionsPairVectors {
+  ObjectMapT<lcio::TrackImpl*, edm4hep::Track> tracks{};
+  ObjectMapT<lcio::TrackerHitImpl*, edm4hep::TrackerHit3D> trackerHits{};
+  ObjectMapT<lcio::TrackerHitPlaneImpl*, edm4hep::TrackerHitPlane> trackerHitPlanes{};
+  ObjectMapT<lcio::SimTrackerHitImpl*, edm4hep::SimTrackerHit> simTrackerHits{};
+  ObjectMapT<lcio::CalorimeterHitImpl*, edm4hep::CalorimeterHit> caloHits{};
+  ObjectMapT<lcio::RawCalorimeterHitImpl*, edm4hep::RawCalorimeterHit> rawCaloHits{};
+  ObjectMapT<lcio::SimCalorimeterHitImpl*, edm4hep::SimCalorimeterHit> simCaloHits{};
+  ObjectMapT<lcio::TPCHitImpl*, edm4hep::RawTimeSeries> tpcHits{};
+  ObjectMapT<lcio::ClusterImpl*, edm4hep::Cluster> clusters{};
+  ObjectMapT<lcio::VertexImpl*, edm4hep::Vertex> vertices{};
+  ObjectMapT<lcio::ReconstructedParticleImpl*, edm4hep::ReconstructedParticle> recoParticles{};
+  ObjectMapT<lcio::MCParticleImpl*, edm4hep::MCParticle> mcParticles{};
+  ObjectMapT<lcio::ParticleIDImpl*, edm4hep::ParticleID> particleIDs{};
+};
 
-  /// The minimal necessary information to do late conversions of ParticleIDs,
-  /// which is necessary to have consistent algorithmType information in the
-  /// conversion
-  struct ParticleIDConvData {
-    std::string name;
-    const edm4hep::ParticleIDCollection* coll;
-    std::optional<edm4hep::utils::ParticleIDMeta> metadata;
-  };
+/// The minimal necessary information to do late conversions of ParticleIDs,
+/// which is necessary to have consistent algorithmType information in the
+/// conversion
+struct ParticleIDConvData {
+  std::string name;
+  const edm4hep::ParticleIDCollection* coll;
+  std::optional<edm4hep::utils::ParticleIDMeta> metadata;
+};
 
-  /// Sort the ParticleIDs according to their algorithmType.
-  ///
-  /// This sorting allows for a fully consistent roundtrip conversion under the
-  /// following conditions:
-  /// - All ParticleIDs are converted (where all means all that belong to a
-  /// given ReconstructedParticle collection)
-  /// - All of these conversions had the necessary metadata available
-  ///
-  /// In case these conditions are not met, the assigned algorithmTypes might
-  /// differ between LCIO and EDM4hep, but the metadata that is set will be
-  /// consistent for usage.
-  void sortParticleIDs(std::vector<ParticleIDConvData>& pidCollections);
+/// Sort the ParticleIDs according to their algorithmType.
+///
+/// This sorting allows for a fully consistent roundtrip conversion under the
+/// following conditions:
+/// - All ParticleIDs are converted (where all means all that belong to a
+/// given ReconstructedParticle collection)
+/// - All of these conversions had the necessary metadata available
+///
+/// In case these conditions are not met, the assigned algorithmTypes might
+/// differ between LCIO and EDM4hep, but the metadata that is set will be
+/// consistent for usage.
+void sortParticleIDs(std::vector<ParticleIDConvData>& pidCollections);
 
-  /// Attach the meta information for one ParticleID collection to the passed
-  /// LCIO Event
-  ///
-  /// This returns the algorithmID according to the PIDHandler that is used to
-  /// attach the information to the LCIO reconstructed particle collection. If
-  /// there is no fitting reconstructed particle collection to attach this to
-  /// but the meta data in the ParticleIDConvData is valid, the algoType of that
-  /// will be returned. If there is no reconstructed particle collection or the
-  /// meta data is invalid an empty optional is returned.
-  std::optional<int32_t> attachParticleIDMetaData(
-    IMPL::LCEventImpl* lcEvent,
-    const podio::Frame& edmEvent,
-    const ParticleIDConvData& pidCollMetaInfo);
+/// Attach the meta information for one ParticleID collection to the passed
+/// LCIO Event
+///
+/// This returns the algorithmID according to the PIDHandler that is used to
+/// attach the information to the LCIO reconstructed particle collection. If
+/// there is no fitting reconstructed particle collection to attach this to
+/// but the meta data in the ParticleIDConvData is valid, the algoType of that
+/// will be returned. If there is no reconstructed particle collection or the
+/// meta data is invalid an empty optional is returned.
+std::optional<int32_t> attachParticleIDMetaData(IMPL::LCEventImpl* lcEvent, const podio::Frame& edmEvent,
+                                                const ParticleIDConvData& pidCollMetaInfo);
 
-  /**
-   * Convert EDM4hep Tracks to LCIO. Simultaneously populate the mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename TrackMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTracks(
-    const edm4hep::TrackCollection* const edmCollection,
-    TrackMapT& trackMap);
+/**
+ * Convert EDM4hep Tracks to LCIO. Simultaneously populate the mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename TrackMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollection* const edmCollection,
+                                                     TrackMapT& trackMap);
 
-  template<typename TrackMapT, typename TrackerHitMapT>
-  [[deprecated("Use convertTracks instead")]] lcio::LCCollectionVec*
-  convTracks(const edm4hep::TrackCollection* const tracks_coll, TrackMapT& tracks_vec, const TrackerHitMapT&)
-  {
-    return convertTracks(tracks_coll, tracks_vec).release();
-  }
+template <typename TrackMapT, typename TrackerHitMapT>
+[[deprecated("Use convertTracks instead")]] lcio::LCCollectionVec*
+convTracks(const edm4hep::TrackCollection* const tracks_coll, TrackMapT& tracks_vec, const TrackerHitMapT&) {
+  return convertTracks(tracks_coll, tracks_vec).release();
+}
 
-  /**
-   * Convert EDM4hep TrackerHits to LCIO. Simultaneously populate mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename TrackerHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(
-    const edm4hep::TrackerHit3DCollection* const edmCollection,
-    const std::string& cellIDStr,
-    TrackerHitMapT& trackerHitMap);
+/**
+ * Convert EDM4hep TrackerHits to LCIO. Simultaneously populate mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename TrackerHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(const edm4hep::TrackerHit3DCollection* const edmCollection,
+                                                          const std::string& cellIDStr, TrackerHitMapT& trackerHitMap);
 
-  template<typename TrackerHitMapT>
-  [[deprecated("Use convertTrackerHits instead")]] lcio::LCCollectionVec* convTrackerHits(
-    const edm4hep::TrackerHit3DCollection* const trackerhits_coll,
-    const std::string& cellIDstr,
-    TrackerHitMapT& trackerhits_vec)
-  {
-    return convertTrackerHits(trackerhits_coll, cellIDstr, trackerhits_vec).release();
-  }
+template <typename TrackerHitMapT>
+[[deprecated("Use convertTrackerHits instead")]] lcio::LCCollectionVec*
+convTrackerHits(const edm4hep::TrackerHit3DCollection* const trackerhits_coll, const std::string& cellIDstr,
+                TrackerHitMapT& trackerhits_vec) {
+  return convertTrackerHits(trackerhits_coll, cellIDstr, trackerhits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep TrackerHitPlanes to LCIO. Simultaneously populate mapping
-   * from EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename TrackerHitPlaneMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHitPlanes(
-    const edm4hep::TrackerHitPlaneCollection* const edmCollection,
-    const std::string& cellIDstr,
-    TrackerHitPlaneMapT& trackerHitsMap);
+/**
+ * Convert EDM4hep TrackerHitPlanes to LCIO. Simultaneously populate mapping
+ * from EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename TrackerHitPlaneMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertTrackerHitPlanes(const edm4hep::TrackerHitPlaneCollection* const edmCollection, const std::string& cellIDstr,
+                        TrackerHitPlaneMapT& trackerHitsMap);
 
-  template<typename TrackerHitPlaneMapT>
-  [[deprecated("Use convertTrackerHitPlanes instead")]] lcio::LCCollectionVec* convTrackerHitPlanes(
-    const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll,
-    const std::string& cellIDstr,
-    TrackerHitPlaneMapT& trackerhits_vec)
-  {
-    return convertTrackerHitPlanes(trackerhits_coll, cellIDstr, trackerhits_vec).release();
-  }
+template <typename TrackerHitPlaneMapT>
+[[deprecated("Use convertTrackerHitPlanes instead")]] lcio::LCCollectionVec*
+convTrackerHitPlanes(const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll, const std::string& cellIDstr,
+                     TrackerHitPlaneMapT& trackerhits_vec) {
+  return convertTrackerHitPlanes(trackerhits_coll, cellIDstr, trackerhits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep SimTrackerHits to LCIO. Simultaneously populate mapping
-   * from EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename SimTrHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertSimTrackerHits(
-    const edm4hep::SimTrackerHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    SimTrHitMapT& simTrHitMap);
+/**
+ * Convert EDM4hep SimTrackerHits to LCIO. Simultaneously populate mapping
+ * from EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename SimTrHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertSimTrackerHits(const edm4hep::SimTrackerHitCollection* const edmCollection, const std::string& cellIDstr,
+                      SimTrHitMapT& simTrHitMap);
 
-  template<typename SimTrHitMapT, typename MCParticleMapT>
-  [[deprecated("Use convertSimTrackerHits instead")]] lcio::LCCollectionVec* convSimTrackerHits(
-    const edm4hep::SimTrackerHitCollection* const simtrackerhits_coll,
-    const std::string& cellIDstr,
-    SimTrHitMapT& simtrackerhits_vec,
-    const MCParticleMapT&)
-  {
-    return convertSimTrackerHits(simtrackerhits_coll, cellIDstr, simtrackerhits_vec).release();
-  }
+template <typename SimTrHitMapT, typename MCParticleMapT>
+[[deprecated("Use convertSimTrackerHits instead")]] lcio::LCCollectionVec*
+convSimTrackerHits(const edm4hep::SimTrackerHitCollection* const simtrackerhits_coll, const std::string& cellIDstr,
+                   SimTrHitMapT& simtrackerhits_vec, const MCParticleMapT&) {
+  return convertSimTrackerHits(simtrackerhits_coll, cellIDstr, simtrackerhits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep CalorimeterHits to LCIO. Simultaneously populate mapping
-   * from EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename CaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertCalorimeterHits(
-    const edm4hep::CalorimeterHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    CaloHitMapT& caloHitMap);
+/**
+ * Convert EDM4hep CalorimeterHits to LCIO. Simultaneously populate mapping
+ * from EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename CaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertCalorimeterHits(const edm4hep::CalorimeterHitCollection* const edmCollection, const std::string& cellIDstr,
+                       CaloHitMapT& caloHitMap);
 
-  template<typename CaloHitMapT>
-  [[deprecated("Use convertCalorimeterHits instead")]] lcio::LCCollectionVec* convCalorimeterHits(
-    const edm4hep::CalorimeterHitCollection* const calohit_coll,
-    const std::string& cellIDstr,
-    CaloHitMapT& calo_hits_vec)
-  {
-    return convertCalorimeterHits(calohit_coll, cellIDstr, calo_hits_vec).release();
-  }
+template <typename CaloHitMapT>
+[[deprecated("Use convertCalorimeterHits instead")]] lcio::LCCollectionVec*
+convCalorimeterHits(const edm4hep::CalorimeterHitCollection* const calohit_coll, const std::string& cellIDstr,
+                    CaloHitMapT& calo_hits_vec) {
+  return convertCalorimeterHits(calohit_coll, cellIDstr, calo_hits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep RawCalorimeterHits to LCIO. Simultaneously populate mapping
-   * from EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename RawCaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertRawCalorimeterHits(
-    const edm4hep::RawCalorimeterHitCollection* const edmCollection,
-    RawCaloHitMapT& rawCaloHitMap);
+/**
+ * Convert EDM4hep RawCalorimeterHits to LCIO. Simultaneously populate mapping
+ * from EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename RawCaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertRawCalorimeterHits(const edm4hep::RawCalorimeterHitCollection* const edmCollection,
+                          RawCaloHitMapT& rawCaloHitMap);
 
-  template<typename RawCaloHitMapT>
-  [[deprecated("use convertRawCalorimeterHits instead")]] lcio::LCCollectionVec* convRawCalorimeterHits(
-    const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
-    RawCaloHitMapT& raw_calo_hits_vec)
-  {
-    return convertRawCalorimeterHits(rawcalohit_coll, raw_calo_hits_vec).release();
-  }
+template <typename RawCaloHitMapT>
+[[deprecated("use convertRawCalorimeterHits instead")]] lcio::LCCollectionVec*
+convRawCalorimeterHits(const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
+                       RawCaloHitMapT& raw_calo_hits_vec) {
+  return convertRawCalorimeterHits(rawcalohit_coll, raw_calo_hits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep SimCalorimeterHits to LCIO. Simultaneously populate mapping
-   * from EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename SimCaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertSimCalorimeterHits(
-    const edm4hep::SimCalorimeterHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    SimCaloHitMapT& simCaloHitMap);
+/**
+ * Convert EDM4hep SimCalorimeterHits to LCIO. Simultaneously populate mapping
+ * from EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename SimCaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const edmCollection, const std::string& cellIDstr,
+                          SimCaloHitMapT& simCaloHitMap);
 
-  template<typename SimCaloHitMapT>
-  lcio::LCCollectionVec* convSimCalorimeterHits(
-    const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
-    const std::string& cellIDstr,
-    SimCaloHitMapT& sim_calo_hits_vec)
-  {
-    return convertSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec).release();
-  }
+template <typename SimCaloHitMapT>
+lcio::LCCollectionVec* convSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
+                                              const std::string& cellIDstr, SimCaloHitMapT& sim_calo_hits_vec) {
+  return convertSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec).release();
+}
 
-  template<typename SimCaloHitMapT, typename MCParticleMapT>
-  [[deprecated("remove MCParticleMap argument since it is unused")]] lcio::LCCollectionVec* convSimCalorimeterHits(
-    const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
-    const std::string& cellIDstr,
-    SimCaloHitMapT& sim_calo_hits_vec,
-    const MCParticleMapT&)
-  {
-    return convSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec);
-  }
+template <typename SimCaloHitMapT, typename MCParticleMapT>
+[[deprecated("remove MCParticleMap argument since it is unused")]] lcio::LCCollectionVec*
+convSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll, const std::string& cellIDstr,
+                       SimCaloHitMapT& sim_calo_hits_vec, const MCParticleMapT&) {
+  return convSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec);
+}
 
-  /**
-   * Convert EDM4hep TPC Hits to LCIO. Simultaneously populate mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename TPCHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(
-    const edm4hep::RawTimeSeriesCollection* const edmCollection,
-    TPCHitMapT& tpcHitMap);
+/**
+ * Convert EDM4hep TPC Hits to LCIO. Simultaneously populate mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename TPCHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(const edm4hep::RawTimeSeriesCollection* const edmCollection,
+                                                      TPCHitMapT& tpcHitMap);
 
-  template<typename TPCHitMapT>
-  [[deprecated("Use convertTPCHits instead")]] lcio::LCCollectionVec* convTPCHits(
-    const edm4hep::RawTimeSeriesCollection* const tpchit_coll,
-    TPCHitMapT& tpc_hits_vec)
-  {
-    return convertTPCHits(tpchit_coll, tpc_hits_vec).release();
-  }
+template <typename TPCHitMapT>
+[[deprecated("Use convertTPCHits instead")]] lcio::LCCollectionVec*
+convTPCHits(const edm4hep::RawTimeSeriesCollection* const tpchit_coll, TPCHitMapT& tpc_hits_vec) {
+  return convertTPCHits(tpchit_coll, tpc_hits_vec).release();
+}
 
-  /**
-   * Convert EDM4hep Clusters to LCIO. Simultaneously populate mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename ClusterMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertClusters(
-    const edm4hep::ClusterCollection* const edmCollection,
-    ClusterMapT& clusterMap);
+/**
+ * Convert EDM4hep Clusters to LCIO. Simultaneously populate mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename ClusterMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertClusters(const edm4hep::ClusterCollection* const edmCollection,
+                                                       ClusterMapT& clusterMap);
 
-  template<typename ClusterMapT>
-  [[deprecated("Use convertClusters instead")]] lcio::LCCollectionVec* convClusters(
-    const edm4hep::ClusterCollection* const cluster_coll,
-    ClusterMapT& cluster_vec)
-  {
-    return convertClusters(cluster_coll, cluster_vec).release();
-  }
+template <typename ClusterMapT>
+[[deprecated("Use convertClusters instead")]] lcio::LCCollectionVec*
+convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec) {
+  return convertClusters(cluster_coll, cluster_vec).release();
+}
 
-  template<typename ClusterMapT, typename CaloHitMapT>
-  [[deprecated("remove CaloHitMap argument since it is unused")]] lcio::LCCollectionVec*
-  convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec, const CaloHitMapT&)
-  {
-    return convClusters(cluster_coll, cluster_vec);
-  }
+template <typename ClusterMapT, typename CaloHitMapT>
+[[deprecated("remove CaloHitMap argument since it is unused")]] lcio::LCCollectionVec*
+convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec, const CaloHitMapT&) {
+  return convClusters(cluster_coll, cluster_vec);
+}
 
-  /**
-   * Convert EDM4hep Vertices to LCIO. Simultaneously populate mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename VertexMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertVertices(
-    const edm4hep::VertexCollection* const edmCollection,
-    VertexMapT& vertexMap);
+/**
+ * Convert EDM4hep Vertices to LCIO. Simultaneously populate mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename VertexMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertVertices(const edm4hep::VertexCollection* const edmCollection,
+                                                       VertexMapT& vertexMap);
 
-  template<typename VertexMapT, typename RecoPartMapT>
-  [[deprecated("Use convertVertices instead")]] lcio::LCCollectionVec*
-  convVertices(const edm4hep::VertexCollection* const vertex_coll, VertexMapT& vertex_vec, const RecoPartMapT&)
-  {
-    return convertVertices(vertex_coll, vertex_vec).release();
-  }
+template <typename VertexMapT, typename RecoPartMapT>
+[[deprecated("Use convertVertices instead")]] lcio::LCCollectionVec*
+convVertices(const edm4hep::VertexCollection* const vertex_coll, VertexMapT& vertex_vec, const RecoPartMapT&) {
+  return convertVertices(vertex_coll, vertex_vec).release();
+}
 
-  /**
-   * Convert EDM4hep ReconstructedParticles to LCIO. Simultaneously populate
-   * mapping from EDM4hep to LCIO objects for relation resolving in a second
-   * step.
-   */
-  template<typename RecoParticleMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertReconstructedParticles(
-    const edm4hep::ReconstructedParticleCollection* const edmCollection,
-    RecoParticleMapT& recoParticleMap);
+/**
+ * Convert EDM4hep ReconstructedParticles to LCIO. Simultaneously populate
+ * mapping from EDM4hep to LCIO objects for relation resolving in a second
+ * step.
+ */
+template <typename RecoParticleMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertReconstructedParticles(const edm4hep::ReconstructedParticleCollection* const edmCollection,
+                              RecoParticleMapT& recoParticleMap);
 
-  template<typename RecoPartMapT, typename TrackMapT, typename VertexMapT, typename ClusterMapT>
-  [[deprecated("Use convertReconstructedParticle instead")]] lcio::LCCollectionVec* convReconstructedParticles(
-    const edm4hep::ReconstructedParticleCollection* const recos_coll,
-    RecoPartMapT& recoparticles_vec,
-    const TrackMapT&,
-    const VertexMapT&,
-    const ClusterMapT&)
-  {
-    return convertReconstructedParticles(recos_coll, recoparticles_vec).release();
-  }
+template <typename RecoPartMapT, typename TrackMapT, typename VertexMapT, typename ClusterMapT>
+[[deprecated("Use convertReconstructedParticle instead")]] lcio::LCCollectionVec*
+convReconstructedParticles(const edm4hep::ReconstructedParticleCollection* const recos_coll,
+                           RecoPartMapT& recoparticles_vec, const TrackMapT&, const VertexMapT&, const ClusterMapT&) {
+  return convertReconstructedParticles(recos_coll, recoparticles_vec).release();
+}
 
-  /**
-   * Convert EDM4hep MCParticles to LCIO. Simultaneously populate mapping from
-   * EDM4hep to LCIO objects for relation resolving in a second step.
-   */
-  template<typename MCPartMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(
-    const edm4hep::MCParticleCollection* const edmCollection,
-    MCPartMapT& mcParticleMap);
+/**
+ * Convert EDM4hep MCParticles to LCIO. Simultaneously populate mapping from
+ * EDM4hep to LCIO objects for relation resolving in a second step.
+ */
+template <typename MCPartMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(const edm4hep::MCParticleCollection* const edmCollection,
+                                                          MCPartMapT& mcParticleMap);
 
-  template<typename MCPartMapT>
-  [[deprecated("Use convertMCParticles")]] lcio::LCCollectionVec* convMCParticles(
-    const edm4hep::MCParticleCollection* const mcparticle_coll,
-    MCPartMapT& mc_particles_vec)
-  {
-    return convertMCParticles(mcparticle_coll, mc_particles_vec).release();
-  }
+template <typename MCPartMapT>
+[[deprecated("Use convertMCParticles")]] lcio::LCCollectionVec*
+convMCParticles(const edm4hep::MCParticleCollection* const mcparticle_coll, MCPartMapT& mc_particles_vec) {
+  return convertMCParticles(mcparticle_coll, mc_particles_vec).release();
+}
 
-  /**
-   * Convert EDM4hep ParticleIDs to LCIO. NOTE: Since ParticleIDs cannot live in
-   * their own collections in LCIO this simply populates the pidMap that maps
-   * LCIO to EDM4hep particleIDs. **This just converts the data it is crucial to
-   * also resolve the relations afterwards!**
-   */
-  template<typename PidMapT>
-  void convertParticleIDs(const edm4hep::ParticleIDCollection* const edmCollection, PidMapT& pidMap, const int algoId);
+/**
+ * Convert EDM4hep ParticleIDs to LCIO. NOTE: Since ParticleIDs cannot live in
+ * their own collections in LCIO this simply populates the pidMap that maps
+ * LCIO to EDM4hep particleIDs. **This just converts the data it is crucial to
+ * also resolve the relations afterwards!**
+ */
+template <typename PidMapT>
+void convertParticleIDs(const edm4hep::ParticleIDCollection* const edmCollection, PidMapT& pidMap, const int algoId);
 
-  /**
-   * Convert EDM4hep EventHeader to LCIO. This will directly populate the
-   * corresponding information in the passed LCEvent. The input collection needs
-   * to be of length 1!
-   */
-  void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
+/**
+ * Convert EDM4hep EventHeader to LCIO. This will directly populate the
+ * corresponding information in the passed LCEvent. The input collection needs
+ * to be of length 1!
+ */
+void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
 
-  [[deprecated("Use convertEventheader instead")]] void convEventHeader(
-    const edm4hep::EventHeaderCollection* const header_coll,
-    lcio::LCEventImpl* const lcio_event);
+[[deprecated("Use convertEventheader instead")]] void
+convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
 
-  /**
-   * Resolve the relations for MCParticles
-   */
-  template<typename MCParticleMapT, typename MCParticleLookupMapT>
-  void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap);
+/**
+ * Resolve the relations for MCParticles
+ */
+template <typename MCParticleMapT, typename MCParticleLookupMapT>
+void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap);
 
-  /**
-   * Resolve the relations for Tracks
-   */
-  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
-  void resolveRelationsTracks(
-    TrackMapT& tracksMap,
-    const TrackHitMapT& trackerHitMap,
-    const THPlaneHitMapT& trackerHiPlaneMap,
-    const TPCHitMapT&);
+/**
+ * Resolve the relations for Tracks
+ */
+template <typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
+void resolveRelationsTracks(TrackMapT& tracksMap, const TrackHitMapT& trackerHitMap,
+                            const THPlaneHitMapT& trackerHiPlaneMap, const TPCHitMapT&);
 
-  /**
-   * Resolve the relations for SimTrackerHits
-   */
-  template<typename SimTrHitMapT, typename MCParticleMapT>
-  void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap);
+/**
+ * Resolve the relations for SimTrackerHits
+ */
+template <typename SimTrHitMapT, typename MCParticleMapT>
+void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap);
 
-  /**
-   * Resolve the relations for Vertex
-   */
-  template<typename VertexMapT, typename RecoParticleMapT>
-  void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
+/**
+ * Resolve the relations for Vertex
+ */
+template <typename VertexMapT, typename RecoParticleMapT>
+void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
 
-  /**
-   * Resolve the relations for SimCalorimeterHit. This is also the step where
-   * the LCIO SimCalorimeterHits get their contributions attached.
-   */
-  template<typename SimCaloHitMapT, typename MCParticleMapT>
-  void resolveRelationsSimCaloHit(SimCaloHitMapT& simCaloHitMap, const MCParticleMapT& mcParticleMap);
+/**
+ * Resolve the relations for SimCalorimeterHit. This is also the step where
+ * the LCIO SimCalorimeterHits get their contributions attached.
+ */
+template <typename SimCaloHitMapT, typename MCParticleMapT>
+void resolveRelationsSimCaloHit(SimCaloHitMapT& simCaloHitMap, const MCParticleMapT& mcParticleMap);
 
-  /**
-   * Resolve the relations for ReconstructedParticles
-   */
-  template<
-    typename RecoParticleMapT,
-    typename RecoParticleLookupMapT,
-    typename VertexMapT,
-    typename ClusterMapT,
-    typename TrackMapT>
-  void resolveRelationsRecoParticles(
-    RecoParticleMapT& recoParticleMap,
-    const RecoParticleLookupMapT& recoLookupMap,
-    const VertexMapT& vertexMap,
-    const ClusterMapT& clusterMap,
-    const TrackMapT& trackMap);
+/**
+ * Resolve the relations for ReconstructedParticles
+ */
+template <typename RecoParticleMapT, typename RecoParticleLookupMapT, typename VertexMapT, typename ClusterMapT,
+          typename TrackMapT>
+void resolveRelationsRecoParticles(RecoParticleMapT& recoParticleMap, const RecoParticleLookupMapT& recoLookupMap,
+                                   const VertexMapT& vertexMap, const ClusterMapT& clusterMap,
+                                   const TrackMapT& trackMap);
 
-  /**
-   * Resolve the relations for Clusters
-   */
-  template<typename ClusterMapT, typename CaloHitMapT>
-  void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
+/**
+ * Resolve the relations for Clusters
+ */
+template <typename ClusterMapT, typename CaloHitMapT>
+void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
 
-  template<typename PidMapT, typename RecoParticleMapT>
-  void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap);
+template <typename PidMapT, typename RecoParticleMapT>
+void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap);
 
-  /**
-   * Resolve all relations in all converted objects that are held in the map.
-   * Dispatch to the correpsonding implementation for all the types that have
-   * relations
-   */
-  template<typename ObjectMappingT>
-  void resolveRelations(ObjectMappingT& typeMapping);
+/**
+ * Resolve all relations in all converted objects that are held in the map.
+ * Dispatch to the correpsonding implementation for all the types that have
+ * relations
+ */
+template <typename ObjectMappingT>
+void resolveRelations(ObjectMappingT& typeMapping);
 
-  template<typename ObjectMappingT, typename ObjectMappingU>
-  void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
+template <typename ObjectMappingT, typename ObjectMappingU>
+void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
-  template<typename ObjectMappingT>
-  [[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs)
-  {
-    resolveRelations(update_pairs);
-  }
+template <typename ObjectMappingT>
+[[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs) {
+  resolveRelations(update_pairs);
+}
 
-  template<typename ObjectMappingT, typename ObjectMappingU>
-  [[deprecated("Use resolveRelations instead")]] void FillMissingCollections(
-    ObjectMappingT& update_pairs,
-    const ObjectMappingU& lookup_pairs)
-  {
-    resolveRelations(update_pairs, lookup_pairs);
-  }
+template <typename ObjectMappingT, typename ObjectMappingU>
+[[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs,
+                                                                           const ObjectMappingU& lookup_pairs) {
+  resolveRelations(update_pairs, lookup_pairs);
+}
 
-  bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);
+bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);
 
-  /**
-   * Convert an edm4hep event to an LCEvent
-   */
-  std::unique_ptr<lcio::LCEventImpl> convertEvent(
-    const podio::Frame& edmEvent,
-    const podio::Frame& metadata = podio::Frame {});
+/**
+ * Convert an edm4hep event to an LCEvent
+ */
+std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent,
+                                                const podio::Frame& metadata = podio::Frame{});
 
-  [[deprecated("Use convertEvent")]] std::unique_ptr<lcio::LCEventImpl> convEvent(
-    const podio::Frame& edmEvent,
-    const podio::Frame& metadata = podio::Frame {})
-  {
-    return convertEvent(edmEvent, metadata);
-  }
+[[deprecated("Use convertEvent")]] std::unique_ptr<lcio::LCEventImpl>
+convEvent(const podio::Frame& edmEvent, const podio::Frame& metadata = podio::Frame{}) {
+  return convertEvent(edmEvent, metadata);
+}
 
 } // namespace EDM4hep2LCIOConv
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -4,766 +4,813 @@
 
 namespace EDM4hep2LCIOConv {
 
-  template<typename TrackMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTracks(
-    const edm4hep::TrackCollection* const edmCollection,
-    TrackMapT& trackMap)
-  {
-    auto tracks = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACK);
-    // Loop over EDM4hep tracks converting them to lcio tracks.
-    for (const auto& edm_tr : (*edmCollection)) {
-      if (edm_tr.isAvailable()) {
-        auto* lcio_tr = new lcio::TrackImpl();
-        // The Type of the Tracks need to be set bitwise in LCIO since the setType(int) function is private for the LCIO
-        // TrackImpl and only a setTypeBit(bitnumber) function can be used to set the Type bit by bit.
-        int type = edm_tr.getType();
-        for (auto i = 0u; i < sizeof(int) * 8; i++) {
-          lcio_tr->setTypeBit(i, type & (1 << i));
+template <typename TrackMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertTracks(const edm4hep::TrackCollection *const edmCollection,
+              TrackMapT &trackMap) {
+  auto tracks = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACK);
+  // Loop over EDM4hep tracks converting them to lcio tracks.
+  for (const auto &edm_tr : (*edmCollection)) {
+    if (edm_tr.isAvailable()) {
+      auto *lcio_tr = new lcio::TrackImpl();
+      // The Type of the Tracks need to be set bitwise in LCIO since the
+      // setType(int) function is private for the LCIO TrackImpl and only a
+      // setTypeBit(bitnumber) function can be used to set the Type bit by bit.
+      int type = edm_tr.getType();
+      for (auto i = 0u; i < sizeof(int) * 8; i++) {
+        lcio_tr->setTypeBit(i, type & (1 << i));
+      }
+      lcio_tr->setChi2(edm_tr.getChi2());
+      lcio_tr->setNdf(edm_tr.getNdf());
+      lcio_tr->setdEdx(edm_tr.getDEdx());
+      lcio_tr->setdEdxError(edm_tr.getDEdxError());
+      lcio_tr->setRadiusOfInnermostHit(edm_tr.getRadiusOfInnermostHit());
+
+      // Loop over the hit Numbers in the track
+      lcio_tr->subdetectorHitNumbers().resize(
+          edm_tr.subdetectorHitNumbers_size());
+      for (auto i = 0u; i < edm_tr.subdetectorHitNumbers_size(); ++i) {
+        lcio_tr->subdetectorHitNumbers()[i] =
+            edm_tr.getSubdetectorHitNumbers(i);
+      }
+
+      // Pad until 50 hitnumbers are resized
+      const int hit_number_limit = 50;
+      if (edm_tr.subdetectorHitNumbers_size() < hit_number_limit) {
+        lcio_tr->subdetectorHitNumbers().resize(hit_number_limit);
+        for (auto i = edm_tr.subdetectorHitNumbers_size(); i < hit_number_limit;
+             ++i) {
+          lcio_tr->subdetectorHitNumbers()[i] = 0;
         }
-        lcio_tr->setChi2(edm_tr.getChi2());
-        lcio_tr->setNdf(edm_tr.getNdf());
-        lcio_tr->setdEdx(edm_tr.getDEdx());
-        lcio_tr->setdEdxError(edm_tr.getDEdxError());
-        lcio_tr->setRadiusOfInnermostHit(edm_tr.getRadiusOfInnermostHit());
-
-        // Loop over the hit Numbers in the track
-        lcio_tr->subdetectorHitNumbers().resize(edm_tr.subdetectorHitNumbers_size());
-        for (auto i = 0u; i < edm_tr.subdetectorHitNumbers_size(); ++i) {
-          lcio_tr->subdetectorHitNumbers()[i] = edm_tr.getSubdetectorHitNumbers(i);
-        }
-
-        // Pad until 50 hitnumbers are resized
-        const int hit_number_limit = 50;
-        if (edm_tr.subdetectorHitNumbers_size() < hit_number_limit) {
-          lcio_tr->subdetectorHitNumbers().resize(hit_number_limit);
-          for (auto i = edm_tr.subdetectorHitNumbers_size(); i < hit_number_limit; ++i) {
-            lcio_tr->subdetectorHitNumbers()[i] = 0;
-          }
-        }
-
-        // Loop over the track states in the track
-        const auto edm_track_states = edm_tr.getTrackStates();
-        for (const auto& tr_state : edm_track_states) {
-          const auto& cov = tr_state.covMatrix;
-          std::array<float, 3> refP = {tr_state.referencePoint.x, tr_state.referencePoint.y, tr_state.referencePoint.z};
-
-          auto* lcio_tr_state = new lcio::TrackStateImpl(
-            tr_state.location,
-            tr_state.D0,
-            tr_state.phi,
-            tr_state.omega,
-            tr_state.Z0,
-            tr_state.tanLambda,
-            cov.data(),
-            refP.data());
-
-          lcio_tr->addTrackState(lcio_tr_state);
-        }
-
-        // Save intermediate tracks ref
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_tr, edm_tr, trackMap);
-
-        // Add to lcio tracks collection
-        tracks->addElement(lcio_tr);
       }
-    }
 
-    return tracks;
+      // Loop over the track states in the track
+      const auto edm_track_states = edm_tr.getTrackStates();
+      for (const auto &tr_state : edm_track_states) {
+        const auto &cov = tr_state.covMatrix;
+        std::array<float, 3> refP = {tr_state.referencePoint.x,
+                                     tr_state.referencePoint.y,
+                                     tr_state.referencePoint.z};
+
+        auto *lcio_tr_state = new lcio::TrackStateImpl(
+            tr_state.location, tr_state.D0, tr_state.phi, tr_state.omega,
+            tr_state.Z0, tr_state.tanLambda, cov.data(), refP.data());
+
+        lcio_tr->addTrackState(lcio_tr_state);
+      }
+
+      // Save intermediate tracks ref
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_tr, edm_tr, trackMap);
+
+      // Add to lcio tracks collection
+      tracks->addElement(lcio_tr);
+    }
   }
 
-  template<typename TrackerHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(
-    const edm4hep::TrackerHit3DCollection* const edmColection,
-    const std::string& cellIDstr,
-    TrackerHitMapT& trackerHitMap)
-  {
-    auto trackerhits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHIT);
+  return tracks;
+}
 
-    if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerhits.get());
-    }
+template <typename TrackerHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertTrackerHits(const edm4hep::TrackerHit3DCollection *const edmColection,
+                   const std::string &cellIDstr,
+                   TrackerHitMapT &trackerHitMap) {
+  auto trackerhits =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHIT);
 
-    // Loop over EDM4hep trackerhits converting them to lcio trackerhits
-    for (const auto& edm_trh : (*edmColection)) {
-      if (edm_trh.isAvailable()) {
-        auto* lcio_trh = new lcio::TrackerHitImpl();
-
-        uint64_t combined_value = edm_trh.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_trh->setCellID0(combined_value_ptr[0]);
-        lcio_trh->setCellID1(combined_value_ptr[1]);
-        lcio_trh->setType(edm_trh.getType());
-        std::array<double, 3> positions {edm_trh.getPosition()[0], edm_trh.getPosition()[1], edm_trh.getPosition()[2]};
-        lcio_trh->setPosition(positions.data());
-        lcio_trh->setCovMatrix(edm_trh.getCovMatrix().data());
-        lcio_trh->setEDep(edm_trh.getEDep());
-        lcio_trh->setEDepError(edm_trh.getEDepError());
-        lcio_trh->setTime(edm_trh.getTime());
-        lcio_trh->setQuality(edm_trh.getQuality());
-
-        // Save intermediate trackerhits ref
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitMap);
-
-        // Add to lcio trackerhits collection
-        trackerhits->addElement(lcio_trh);
-      }
-    }
-
-    return trackerhits;
+  if (cellIDstr != "") {
+    lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr,
+                                                           trackerhits.get());
   }
 
-  template<typename TrackerHitPlaneMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTrackerHitPlanes(
-    const edm4hep::TrackerHitPlaneCollection* const edmCollection,
-    const std::string& cellIDstr,
-    TrackerHitPlaneMapT& trackerHitsMap)
-  {
-    auto trackerHitPlanes = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHITPLANE);
+  // Loop over EDM4hep trackerhits converting them to lcio trackerhits
+  for (const auto &edm_trh : (*edmColection)) {
+    if (edm_trh.isAvailable()) {
+      auto *lcio_trh = new lcio::TrackerHitImpl();
 
-    if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, trackerHitPlanes.get());
+      uint64_t combined_value = edm_trh.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_trh->setCellID0(combined_value_ptr[0]);
+      lcio_trh->setCellID1(combined_value_ptr[1]);
+      lcio_trh->setType(edm_trh.getType());
+      std::array<double, 3> positions{edm_trh.getPosition()[0],
+                                      edm_trh.getPosition()[1],
+                                      edm_trh.getPosition()[2]};
+      lcio_trh->setPosition(positions.data());
+      lcio_trh->setCovMatrix(edm_trh.getCovMatrix().data());
+      lcio_trh->setEDep(edm_trh.getEDep());
+      lcio_trh->setEDepError(edm_trh.getEDepError());
+      lcio_trh->setTime(edm_trh.getTime());
+      lcio_trh->setQuality(edm_trh.getQuality());
+
+      // Save intermediate trackerhits ref
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitMap);
+
+      // Add to lcio trackerhits collection
+      trackerhits->addElement(lcio_trh);
     }
-
-    for (const auto& edm_trh : (*edmCollection)) {
-      if (edm_trh.isAvailable()) {
-        auto* lcio_trh = new lcio::TrackerHitPlaneImpl();
-
-        uint64_t combined_value = edm_trh.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_trh->setCellID0(combined_value_ptr[0]);
-        lcio_trh->setCellID1(combined_value_ptr[1]);
-        lcio_trh->setType(edm_trh.getType());
-        const std::array positions {edm_trh.getPosition()[0], edm_trh.getPosition()[1], edm_trh.getPosition()[2]};
-        lcio_trh->setPosition(positions.data());
-        // No public setter in LCIO
-        // lcio_trh->setCovMatrix(edm_trh.getCovMatrix().data());
-        lcio_trh->setEDep(edm_trh.getEDep());
-        lcio_trh->setEDepError(edm_trh.getEDepError());
-        lcio_trh->setTime(edm_trh.getTime());
-        lcio_trh->setQuality(edm_trh.getQuality());
-
-        const std::array posU {edm_trh.getU()[0], edm_trh.getU()[1]};
-        lcio_trh->setU(posU.data());
-        lcio_trh->setdU(edm_trh.getDu());
-        const std::array posV {edm_trh.getV()[0], edm_trh.getV()[1]};
-        lcio_trh->setV(posV.data());
-        lcio_trh->setdV(edm_trh.getDv());
-
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitsMap);
-
-        trackerHitPlanes->addElement(lcio_trh);
-      }
-    }
-
-    return trackerHitPlanes;
   }
 
-  template<typename SimTrHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertSimTrackerHits(
-    const edm4hep::SimTrackerHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    SimTrHitMapT& simTrHitMap)
-  {
-    auto simtrackerhits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::SIMTRACKERHIT);
+  return trackerhits;
+}
 
-    if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimTrackerHitImpl> idEnc(cellIDstr, simtrackerhits.get());
-    }
+template <typename TrackerHitPlaneMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertTrackerHitPlanes(
+    const edm4hep::TrackerHitPlaneCollection *const edmCollection,
+    const std::string &cellIDstr, TrackerHitPlaneMapT &trackerHitsMap) {
+  auto trackerHitPlanes =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TRACKERHITPLANE);
 
-    // Loop over EDM4hep simtrackerhits converting them to LCIO simtrackerhits
-    for (const auto& edm_strh : (*edmCollection)) {
-      if (edm_strh.isAvailable()) {
-        auto* lcio_strh = new lcio::SimTrackerHitImpl();
-
-        uint64_t combined_value = edm_strh.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_strh->setCellID0(combined_value_ptr[0]);
-        lcio_strh->setCellID1(combined_value_ptr[1]);
-        std::array<double, 3> positions {
-          edm_strh.getPosition()[0], edm_strh.getPosition()[1], edm_strh.getPosition()[2]};
-        lcio_strh->setPosition(positions.data());
-        lcio_strh->setEDep(edm_strh.getEDep());
-        lcio_strh->setTime(edm_strh.getTime());
-        lcio_strh->setMomentum(edm_strh.getMomentum()[0], edm_strh.getMomentum()[1], edm_strh.getMomentum()[2]);
-        lcio_strh->setPathLength(edm_strh.getPathLength());
-        lcio_strh->setQuality(edm_strh.getQuality());
-        // lcio_strh->setQualityBit( int bit , bool val=true ) ;
-        lcio_strh->setOverlay(edm_strh.isOverlay());
-        lcio_strh->setProducedBySecondary(edm_strh.isProducedBySecondary());
-
-        // Save intermediate simtrackerhits ref
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_strh, edm_strh, simTrHitMap);
-
-        // Add to lcio simtrackerhits collection
-        simtrackerhits->addElement(lcio_strh);
-      }
-    }
-
-    return simtrackerhits;
+  if (cellIDstr != "") {
+    lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(
+        cellIDstr, trackerHitPlanes.get());
   }
 
-  // Convert EDM4hep Calorimeter Hits to LCIO
-  // Add converted LCIO ptr and original EDM4hep collection to vector of pairs
-  // Add converted LCIO Collection Vector to LCIO event
-  template<typename CaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertCalorimeterHits(
-    const edm4hep::CalorimeterHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    CaloHitMapT& caloHitMap)
-  {
-    auto calohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CALORIMETERHIT);
+  for (const auto &edm_trh : (*edmCollection)) {
+    if (edm_trh.isAvailable()) {
+      auto *lcio_trh = new lcio::TrackerHitPlaneImpl();
 
-    if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, calohits.get());
+      uint64_t combined_value = edm_trh.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_trh->setCellID0(combined_value_ptr[0]);
+      lcio_trh->setCellID1(combined_value_ptr[1]);
+      lcio_trh->setType(edm_trh.getType());
+      const std::array positions{edm_trh.getPosition()[0],
+                                 edm_trh.getPosition()[1],
+                                 edm_trh.getPosition()[2]};
+      lcio_trh->setPosition(positions.data());
+      // No public setter in LCIO
+      // lcio_trh->setCovMatrix(edm_trh.getCovMatrix().data());
+      lcio_trh->setEDep(edm_trh.getEDep());
+      lcio_trh->setEDepError(edm_trh.getEDepError());
+      lcio_trh->setTime(edm_trh.getTime());
+      lcio_trh->setQuality(edm_trh.getQuality());
+
+      const std::array posU{edm_trh.getU()[0], edm_trh.getU()[1]};
+      lcio_trh->setU(posU.data());
+      lcio_trh->setdU(edm_trh.getDu());
+      const std::array posV{edm_trh.getV()[0], edm_trh.getV()[1]};
+      lcio_trh->setV(posV.data());
+      lcio_trh->setdV(edm_trh.getDv());
+
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_trh, edm_trh, trackerHitsMap);
+
+      trackerHitPlanes->addElement(lcio_trh);
     }
-
-    for (const auto& edm_calohit : (*edmCollection)) {
-      if (edm_calohit.isAvailable()) {
-        auto* lcio_calohit = new lcio::CalorimeterHitImpl();
-
-        uint64_t combined_value = edm_calohit.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_calohit->setCellID0(combined_value_ptr[0]);
-        lcio_calohit->setCellID1(combined_value_ptr[1]);
-        lcio_calohit->setEnergy(edm_calohit.getEnergy());
-        lcio_calohit->setEnergyError(edm_calohit.getEnergyError());
-        lcio_calohit->setTime(edm_calohit.getTime());
-        std::array<float, 3> positions {
-          edm_calohit.getPosition()[0], edm_calohit.getPosition()[1], edm_calohit.getPosition()[2]};
-        lcio_calohit->setPosition(positions.data());
-        lcio_calohit->setType(edm_calohit.getType());
-
-        // TODO
-        // lcio_calohit->setRawHit(EVENT::LCObject* rawHit );
-
-        // Save Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_calohit, edm_calohit, caloHitMap);
-
-        // Add to lcio tracks collection
-        calohits->addElement(lcio_calohit);
-      }
-    }
-
-    return calohits;
   }
 
-  template<typename RawCaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertRawCalorimeterHits(
-    const edm4hep::RawCalorimeterHitCollection* const edmCollection,
-    RawCaloHitMapT& rawCaloHitMap)
-  {
-    auto rawcalohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::RAWCALORIMETERHIT);
+  return trackerHitPlanes;
+}
 
-    for (const auto& edm_raw_calohit : (*edmCollection)) {
-      if (edm_raw_calohit.isAvailable()) {
-        auto* lcio_rawcalohit = new lcio::RawCalorimeterHitImpl();
+template <typename SimTrHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertSimTrackerHits(
+    const edm4hep::SimTrackerHitCollection *const edmCollection,
+    const std::string &cellIDstr, SimTrHitMapT &simTrHitMap) {
+  auto simtrackerhits =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::SIMTRACKERHIT);
 
-        uint64_t combined_value = edm_raw_calohit.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_rawcalohit->setCellID0(combined_value_ptr[0]);
-        lcio_rawcalohit->setCellID1(combined_value_ptr[1]);
-        lcio_rawcalohit->setAmplitude(edm_raw_calohit.getAmplitude());
-        lcio_rawcalohit->setTimeStamp(edm_raw_calohit.getTimeStamp());
-
-        // Save Raw Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_rawcalohit, edm_raw_calohit, rawCaloHitMap);
-
-        // Add to lcio tracks collection
-        rawcalohits->addElement(lcio_rawcalohit);
-      }
-    }
-
-    return rawcalohits;
+  if (cellIDstr != "") {
+    lcio::CellIDEncoder<lcio::SimTrackerHitImpl> idEnc(cellIDstr,
+                                                       simtrackerhits.get());
   }
 
-  template<typename SimCaloHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertSimCalorimeterHits(
-    const edm4hep::SimCalorimeterHitCollection* const edmCollection,
-    const std::string& cellIDstr,
-    SimCaloHitMapT& simCaloHitMap)
-  {
-    auto simcalohits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::SIMCALORIMETERHIT);
+  // Loop over EDM4hep simtrackerhits converting them to LCIO simtrackerhits
+  for (const auto &edm_strh : (*edmCollection)) {
+    if (edm_strh.isAvailable()) {
+      auto *lcio_strh = new lcio::SimTrackerHitImpl();
 
-    if (cellIDstr != "") {
-      lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr, simcalohits.get());
+      uint64_t combined_value = edm_strh.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_strh->setCellID0(combined_value_ptr[0]);
+      lcio_strh->setCellID1(combined_value_ptr[1]);
+      std::array<double, 3> positions{edm_strh.getPosition()[0],
+                                      edm_strh.getPosition()[1],
+                                      edm_strh.getPosition()[2]};
+      lcio_strh->setPosition(positions.data());
+      lcio_strh->setEDep(edm_strh.getEDep());
+      lcio_strh->setTime(edm_strh.getTime());
+      lcio_strh->setMomentum(edm_strh.getMomentum()[0],
+                             edm_strh.getMomentum()[1],
+                             edm_strh.getMomentum()[2]);
+      lcio_strh->setPathLength(edm_strh.getPathLength());
+      lcio_strh->setQuality(edm_strh.getQuality());
+      // lcio_strh->setQualityBit( int bit , bool val=true ) ;
+      lcio_strh->setOverlay(edm_strh.isOverlay());
+      lcio_strh->setProducedBySecondary(edm_strh.isProducedBySecondary());
+
+      // Save intermediate simtrackerhits ref
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_strh, edm_strh, simTrHitMap);
+
+      // Add to lcio simtrackerhits collection
+      simtrackerhits->addElement(lcio_strh);
     }
-
-    for (const auto& edm_sim_calohit : (*edmCollection)) {
-      if (edm_sim_calohit.isAvailable()) {
-        auto* lcio_simcalohit = new lcio::SimCalorimeterHitImpl();
-
-        uint64_t combined_value = edm_sim_calohit.getCellID();
-        uint32_t* combined_value_ptr = reinterpret_cast<uint32_t*>(&combined_value);
-        lcio_simcalohit->setCellID0(combined_value_ptr[0]);
-        lcio_simcalohit->setCellID1(combined_value_ptr[1]);
-        lcio_simcalohit->setEnergy(edm_sim_calohit.getEnergy());
-        std::array<float, 3> positions {
-          edm_sim_calohit.getPosition()[0], edm_sim_calohit.getPosition()[1], edm_sim_calohit.getPosition()[2]};
-        lcio_simcalohit->setPosition(positions.data());
-
-        // Contributions are converted in resolveRelations to make it a higher probability that we have the
-        // MCParticles converted
-
-        // Save Sim Calorimeter Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_simcalohit, edm_sim_calohit, simCaloHitMap);
-
-        // Add to sim calo hits collection
-        simcalohits->addElement(lcio_simcalohit);
-      }
-    }
-
-    return simcalohits;
   }
 
-  template<typename TPCHitMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(
-    const edm4hep::RawTimeSeriesCollection* const edmCollection,
-    TPCHitMapT& tpcHitMap)
-  {
-    auto tpchits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TPCHIT);
+  return simtrackerhits;
+}
 
-    for (const auto& edm_tpchit : (*edmCollection)) {
-      if (edm_tpchit.isAvailable()) {
-        auto* lcio_tpchit = new lcio::TPCHitImpl();
+// Convert EDM4hep Calorimeter Hits to LCIO
+// Add converted LCIO ptr and original EDM4hep collection to vector of pairs
+// Add converted LCIO Collection Vector to LCIO event
+template <typename CaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertCalorimeterHits(
+    const edm4hep::CalorimeterHitCollection *const edmCollection,
+    const std::string &cellIDstr, CaloHitMapT &caloHitMap) {
+  auto calohits =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CALORIMETERHIT);
+
+  if (cellIDstr != "") {
+    lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr,
+                                                           calohits.get());
+  }
+
+  for (const auto &edm_calohit : (*edmCollection)) {
+    if (edm_calohit.isAvailable()) {
+      auto *lcio_calohit = new lcio::CalorimeterHitImpl();
+
+      uint64_t combined_value = edm_calohit.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_calohit->setCellID0(combined_value_ptr[0]);
+      lcio_calohit->setCellID1(combined_value_ptr[1]);
+      lcio_calohit->setEnergy(edm_calohit.getEnergy());
+      lcio_calohit->setEnergyError(edm_calohit.getEnergyError());
+      lcio_calohit->setTime(edm_calohit.getTime());
+      std::array<float, 3> positions{edm_calohit.getPosition()[0],
+                                     edm_calohit.getPosition()[1],
+                                     edm_calohit.getPosition()[2]};
+      lcio_calohit->setPosition(positions.data());
+      lcio_calohit->setType(edm_calohit.getType());
+
+      // TODO
+      // lcio_calohit->setRawHit(EVENT::LCObject* rawHit );
+
+      // Save Calorimeter Hits LCIO and EDM4hep collections
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_calohit, edm_calohit,
+                                            caloHitMap);
+
+      // Add to lcio tracks collection
+      calohits->addElement(lcio_calohit);
+    }
+  }
+
+  return calohits;
+}
+
+template <typename RawCaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertRawCalorimeterHits(
+    const edm4hep::RawCalorimeterHitCollection *const edmCollection,
+    RawCaloHitMapT &rawCaloHitMap) {
+  auto rawcalohits =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::RAWCALORIMETERHIT);
+
+  for (const auto &edm_raw_calohit : (*edmCollection)) {
+    if (edm_raw_calohit.isAvailable()) {
+      auto *lcio_rawcalohit = new lcio::RawCalorimeterHitImpl();
+
+      uint64_t combined_value = edm_raw_calohit.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_rawcalohit->setCellID0(combined_value_ptr[0]);
+      lcio_rawcalohit->setCellID1(combined_value_ptr[1]);
+      lcio_rawcalohit->setAmplitude(edm_raw_calohit.getAmplitude());
+      lcio_rawcalohit->setTimeStamp(edm_raw_calohit.getTimeStamp());
+
+      // Save Raw Calorimeter Hits LCIO and EDM4hep collections
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_rawcalohit, edm_raw_calohit,
+                                            rawCaloHitMap);
+
+      // Add to lcio tracks collection
+      rawcalohits->addElement(lcio_rawcalohit);
+    }
+  }
+
+  return rawcalohits;
+}
+
+template <typename SimCaloHitMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertSimCalorimeterHits(
+    const edm4hep::SimCalorimeterHitCollection *const edmCollection,
+    const std::string &cellIDstr, SimCaloHitMapT &simCaloHitMap) {
+  auto simcalohits =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::SIMCALORIMETERHIT);
+
+  if (cellIDstr != "") {
+    lcio::CellIDEncoder<lcio::SimCalorimeterHitImpl> idEnc(cellIDstr,
+                                                           simcalohits.get());
+  }
+
+  for (const auto &edm_sim_calohit : (*edmCollection)) {
+    if (edm_sim_calohit.isAvailable()) {
+      auto *lcio_simcalohit = new lcio::SimCalorimeterHitImpl();
+
+      uint64_t combined_value = edm_sim_calohit.getCellID();
+      uint32_t *combined_value_ptr =
+          reinterpret_cast<uint32_t *>(&combined_value);
+      lcio_simcalohit->setCellID0(combined_value_ptr[0]);
+      lcio_simcalohit->setCellID1(combined_value_ptr[1]);
+      lcio_simcalohit->setEnergy(edm_sim_calohit.getEnergy());
+      std::array<float, 3> positions{edm_sim_calohit.getPosition()[0],
+                                     edm_sim_calohit.getPosition()[1],
+                                     edm_sim_calohit.getPosition()[2]};
+      lcio_simcalohit->setPosition(positions.data());
+
+      // Contributions are converted in resolveRelations to make it a higher
+      // probability that we have the MCParticles converted
+
+      // Save Sim Calorimeter Hits LCIO and EDM4hep collections
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_simcalohit, edm_sim_calohit,
+                                            simCaloHitMap);
+
+      // Add to sim calo hits collection
+      simcalohits->addElement(lcio_simcalohit);
+    }
+  }
+
+  return simcalohits;
+}
+
+template <typename TPCHitMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertTPCHits(const edm4hep::RawTimeSeriesCollection *const edmCollection,
+               TPCHitMapT &tpcHitMap) {
+  auto tpchits = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::TPCHIT);
+
+  for (const auto &edm_tpchit : (*edmCollection)) {
+    if (edm_tpchit.isAvailable()) {
+      auto *lcio_tpchit = new lcio::TPCHitImpl();
 
 #warning "unsigned long long conversion to int"
-        lcio_tpchit->setCellID(edm_tpchit.getCellID());
-        lcio_tpchit->setTime(edm_tpchit.getTime());
-        lcio_tpchit->setCharge(edm_tpchit.getCharge());
-        lcio_tpchit->setQuality(edm_tpchit.getQuality());
+      lcio_tpchit->setCellID(edm_tpchit.getCellID());
+      lcio_tpchit->setTime(edm_tpchit.getTime());
+      lcio_tpchit->setCharge(edm_tpchit.getCharge());
+      lcio_tpchit->setQuality(edm_tpchit.getQuality());
 
-        std::vector<int> rawdata;
-        for (auto i = 0u; i < edm_tpchit.adcCounts_size(); ++i) {
-          rawdata.push_back(edm_tpchit.getAdcCounts(i));
-        }
-
-        lcio_tpchit->setRawData(rawdata.data(), edm_tpchit.adcCounts_size());
-
-        // Save TPC Hits LCIO and EDM4hep collections
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_tpchit, edm_tpchit, tpcHitMap);
-
-        // Add to lcio tracks collection
-        tpchits->addElement(lcio_tpchit);
+      std::vector<int> rawdata;
+      for (auto i = 0u; i < edm_tpchit.adcCounts_size(); ++i) {
+        rawdata.push_back(edm_tpchit.getAdcCounts(i));
       }
-    }
 
-    return tpchits;
-  }
+      lcio_tpchit->setRawData(rawdata.data(), edm_tpchit.adcCounts_size());
 
-  template<typename ClusterMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertClusters(
-    const edm4hep::ClusterCollection* const edmCollection,
-    ClusterMapT& clusterMap)
-  {
-    auto clusters = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CLUSTER);
+      // Save TPC Hits LCIO and EDM4hep collections
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_tpchit, edm_tpchit, tpcHitMap);
 
-    // Loop over EDM4hep clusters converting them to lcio clusters
-    for (const auto& edm_cluster : (*edmCollection)) {
-      if (edm_cluster.isAvailable()) {
-        auto* lcio_cluster = new lcio::ClusterImpl();
-
-        std::bitset<sizeof(uint32_t)> type_bits = edm_cluster.getType();
-        for (auto j = 0u; j < sizeof(uint32_t); j++) {
-          lcio_cluster->setTypeBit(j, (type_bits[j] == 0) ? false : true);
-        }
-        lcio_cluster->setEnergy(edm_cluster.getEnergy());
-        lcio_cluster->setEnergyError(edm_cluster.getEnergyError());
-
-        std::array<float, 3> edm_cluster_pos = {
-          edm_cluster.getPosition().x, edm_cluster.getPosition().y, edm_cluster.getPosition().z};
-        lcio_cluster->setPosition(edm_cluster_pos.data());
-
-        lcio_cluster->setPositionError(edm_cluster.getPositionError().data());
-        lcio_cluster->setITheta(edm_cluster.getITheta());
-        lcio_cluster->setIPhi(edm_cluster.getPhi());
-        std::array<float, 3> edm_cluster_dir_err = {
-          edm_cluster.getPosition().x, edm_cluster.getPosition().y, edm_cluster.getPosition().z};
-        lcio_cluster->setDirectionError(edm_cluster_dir_err.data());
-
-        EVENT::FloatVec shape_vec {};
-        for (auto& param : edm_cluster.getShapeParameters()) {
-          shape_vec.push_back(param);
-        }
-        lcio_cluster->setShape(shape_vec);
-
-        auto& subdetEnergies = lcio_cluster->subdetectorEnergies();
-        for (const auto edmEnergy : edm_cluster.getSubdetectorEnergies()) {
-          subdetEnergies.push_back(edmEnergy);
-        }
-
-        // Add LCIO and EDM4hep pair collections to vec
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_cluster, edm_cluster, clusterMap);
-
-        // Add to lcio tracks collection
-        clusters->addElement(lcio_cluster);
-      }
-    }
-
-    return clusters;
-  }
-
-  template<typename VertexMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertVertices(
-    const edm4hep::VertexCollection* const edmCollection,
-    VertexMapT& vertexMap)
-  {
-    auto vertices = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::VERTEX);
-
-    // Loop over EDM4hep vertex converting them to lcio vertex
-    for (const auto& edm_vertex : (*edmCollection)) {
-      if (edm_vertex.isAvailable()) {
-        auto* lcio_vertex = new lcio::VertexImpl();
-        lcio_vertex->setPrimary(edm_vertex.getPrimary());
-        lcio_vertex->setAlgorithmType(std::to_string(edm_vertex.getAlgorithmType()));
-        lcio_vertex->setChi2(edm_vertex.getChi2());
-        lcio_vertex->setProbability(edm_vertex.getProbability());
-        lcio_vertex->setPosition(edm_vertex.getPosition()[0], edm_vertex.getPosition()[1], edm_vertex.getPosition()[2]);
-        lcio_vertex->setCovMatrix(edm_vertex.getCovMatrix().data());
-
-        for (auto& param : edm_vertex.getParameters()) {
-          lcio_vertex->addParameter(param);
-        }
-
-        // Add LCIO and EDM4hep pair collections to vec
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_vertex, edm_vertex, vertexMap);
-
-        // Add to lcio tracks collection
-        vertices->addElement(lcio_vertex);
-      }
-    }
-
-    return vertices;
-  }
-
-  template<typename RecoPartMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertReconstructedParticles(
-    const edm4hep::ReconstructedParticleCollection* const recos_coll,
-    RecoPartMapT& recoparticles_vec)
-  {
-    auto recops = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::RECONSTRUCTEDPARTICLE);
-
-    for (const auto& edm_rp : (*recos_coll)) {
-      auto* lcio_recp = new lcio::ReconstructedParticleImpl;
-      if (edm_rp.isAvailable()) {
-        lcio_recp->setType(edm_rp.getPDG());
-        float m[3] = {edm_rp.getMomentum()[0], edm_rp.getMomentum()[1], edm_rp.getMomentum()[2]};
-        lcio_recp->setMomentum(m);
-        lcio_recp->setEnergy(edm_rp.getEnergy());
-        lcio_recp->setCovMatrix(edm_rp.getCovMatrix().data()); // TODO Check lower or upper
-        lcio_recp->setMass(edm_rp.getMass());
-        lcio_recp->setCharge(edm_rp.getCharge());
-        float rp[3] = {edm_rp.getReferencePoint()[0], edm_rp.getReferencePoint()[1], edm_rp.getReferencePoint()[2]};
-        lcio_recp->setReferencePoint(rp);
-        lcio_recp->setGoodnessOfPID(edm_rp.getGoodnessOfPID());
-        // Add LCIO and EDM4hep pair collections to vec
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_recp, edm_rp, recoparticles_vec);
-
-        // Add to reconstructed particles collection
-        recops->addElement(lcio_recp);
-      }
-    }
-
-    return recops;
-  }
-
-  template<typename MCPartMapT>
-  std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(
-    const edm4hep::MCParticleCollection* const edmCollection,
-    MCPartMapT& mcParticleMap)
-  {
-    auto mcparticles = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::MCPARTICLE);
-
-    for (const auto& edm_mcp : (*edmCollection)) {
-      auto* lcio_mcp = new lcio::MCParticleImpl;
-      if (edm_mcp.isAvailable()) {
-        lcio_mcp->setPDG(edm_mcp.getPDG());
-        lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
-        // Note LCIO sets some Bits during writing which makes a trivial integer conversion afterwards not work
-        int status = edm_mcp.getSimulatorStatus();
-        lcio_mcp->setSimulatorStatus(status);
-
-        double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1], edm_mcp.getVertex()[2]};
-        lcio_mcp->setVertex(vertex);
-        lcio_mcp->setTime(edm_mcp.getTime());
-        double endpoint[3] = {edm_mcp.getEndpoint()[0], edm_mcp.getEndpoint()[1], edm_mcp.getEndpoint()[2]};
-        lcio_mcp->setEndpoint(endpoint);
-        double momentum[3] = {edm_mcp.getMomentum()[0], edm_mcp.getMomentum()[1], edm_mcp.getMomentum()[2]};
-        lcio_mcp->setMomentum(momentum);
-        double momentumEndpoint[3] = {
-          edm_mcp.getMomentumAtEndpoint()[0], edm_mcp.getMomentumAtEndpoint()[1], edm_mcp.getMomentumAtEndpoint()[2]};
-        lcio_mcp->setMomentumAtEndpoint(momentumEndpoint);
-        lcio_mcp->setMass(edm_mcp.getMass());
-        lcio_mcp->setCharge(edm_mcp.getCharge());
-        float spin[3] = {edm_mcp.getSpin()[0], edm_mcp.getSpin()[1], edm_mcp.getSpin()[2]};
-        lcio_mcp->setSpin(spin);
-        int colorflow[2] = {edm_mcp.getColorFlow()[0], edm_mcp.getColorFlow()[1]};
-        lcio_mcp->setColorFlow(colorflow);
-
-        lcio_mcp->setCreatedInSimulation(edm_mcp.isCreatedInSimulation());
-        lcio_mcp->setBackscatter(edm_mcp.isBackscatter());
-        lcio_mcp->setVertexIsNotEndpointOfParent(edm_mcp.vertexIsNotEndpointOfParent());
-        lcio_mcp->setDecayedInTracker(edm_mcp.isDecayedInTracker());
-        lcio_mcp->setDecayedInCalorimeter(edm_mcp.isDecayedInCalorimeter());
-        lcio_mcp->setHasLeftDetector(edm_mcp.hasLeftDetector());
-        lcio_mcp->setStopped(edm_mcp.isStopped());
-        lcio_mcp->setOverlay(edm_mcp.isOverlay());
-
-        // Add LCIO and EDM4hep pair collections to vec
-        k4EDM4hep2LcioConv::detail::mapInsert(lcio_mcp, edm_mcp, mcParticleMap);
-
-        // Add to reconstructed particles collection
-        mcparticles->addElement(lcio_mcp);
-      }
-    }
-
-    return mcparticles;
-  }
-
-  template<typename PidMapT>
-  void convertParticleIDs(const edm4hep::ParticleIDCollection* const edmCollection, PidMapT& pidMap, const int algoId)
-  {
-    for (const auto& edmPid : (*edmCollection)) {
-      auto [lcioPid, _] = k4EDM4hep2LcioConv::detail::mapInsert(new lcio::ParticleIDImpl(), edmPid, pidMap).first;
-
-      lcioPid->setType(edmPid.getType());
-      lcioPid->setPDG(edmPid.getPDG());
-      lcioPid->setLikelihood(edmPid.getLikelihood());
-      lcioPid->setAlgorithmType(algoId);
-      for (const auto& param : edmPid.getParameters()) {
-        lcioPid->addParameter(param);
-      }
+      // Add to lcio tracks collection
+      tpchits->addElement(lcio_tpchit);
     }
   }
 
-  template<typename MCParticleMapT, typename MCParticleLookupMapT>
-  void resolveRelationsMCParticles(MCParticleMapT& mcParticlesMap, const MCParticleLookupMapT& lookupMap)
-  {
-    // Add parent MCParticles after converting all MCparticles
-    for (auto& [lcio_mcp, edm_mcp] : mcParticlesMap) {
-      for (const auto& emd_parent_mcp : edm_mcp.getParents()) {
-        if (emd_parent_mcp.isAvailable()) {
-          // Search for the parent mcparticle in the converted vector
-          if (const auto lcio_mcp_linked = k4EDM4hep2LcioConv::detail::mapLookupFrom(emd_parent_mcp, lookupMap)) {
-            lcio_mcp->addParent(lcio_mcp_linked.value());
-          }
-        }
+  return tpchits;
+}
+
+template <typename ClusterMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertClusters(const edm4hep::ClusterCollection *const edmCollection,
+                ClusterMapT &clusterMap) {
+  auto clusters = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::CLUSTER);
+
+  // Loop over EDM4hep clusters converting them to lcio clusters
+  for (const auto &edm_cluster : (*edmCollection)) {
+    if (edm_cluster.isAvailable()) {
+      auto *lcio_cluster = new lcio::ClusterImpl();
+
+      std::bitset<sizeof(uint32_t)> type_bits = edm_cluster.getType();
+      for (auto j = 0u; j < sizeof(uint32_t); j++) {
+        lcio_cluster->setTypeBit(j, (type_bits[j] == 0) ? false : true);
       }
+      lcio_cluster->setEnergy(edm_cluster.getEnergy());
+      lcio_cluster->setEnergyError(edm_cluster.getEnergyError());
+
+      std::array<float, 3> edm_cluster_pos = {edm_cluster.getPosition().x,
+                                              edm_cluster.getPosition().y,
+                                              edm_cluster.getPosition().z};
+      lcio_cluster->setPosition(edm_cluster_pos.data());
+
+      lcio_cluster->setPositionError(edm_cluster.getPositionError().data());
+      lcio_cluster->setITheta(edm_cluster.getITheta());
+      lcio_cluster->setIPhi(edm_cluster.getPhi());
+      std::array<float, 3> edm_cluster_dir_err = {edm_cluster.getPosition().x,
+                                                  edm_cluster.getPosition().y,
+                                                  edm_cluster.getPosition().z};
+      lcio_cluster->setDirectionError(edm_cluster_dir_err.data());
+
+      EVENT::FloatVec shape_vec{};
+      for (auto &param : edm_cluster.getShapeParameters()) {
+        shape_vec.push_back(param);
+      }
+      lcio_cluster->setShape(shape_vec);
+
+      auto &subdetEnergies = lcio_cluster->subdetectorEnergies();
+      for (const auto edmEnergy : edm_cluster.getSubdetectorEnergies()) {
+        subdetEnergies.push_back(edmEnergy);
+      }
+
+      // Add LCIO and EDM4hep pair collections to vec
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_cluster, edm_cluster,
+                                            clusterMap);
+
+      // Add to lcio tracks collection
+      clusters->addElement(lcio_cluster);
     }
   }
 
-  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
-  void resolveRelationsTracks(
-    TrackMapT& tracksMap,
-    const TrackHitMapT& trackerHitMap,
-    const THPlaneHitMapT& trackerHitPlaneMap,
-    const TPCHitMapT&)
-  {
-    for (auto& [lcio_tr, edm_tr] : tracksMap) {
-      auto tracks = edm_tr.getTracks();
-      for (auto t : tracks) {
-        if (!t.isAvailable()) {
-          continue;
-        }
-        if (const auto track = k4EDM4hep2LcioConv::detail::mapLookupFrom(t, tracksMap)) {
-          lcio_tr->addTrack(track.value());
-        }
+  return clusters;
+}
+
+template <typename VertexMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertVertices(const edm4hep::VertexCollection *const edmCollection,
+                VertexMapT &vertexMap) {
+  auto vertices = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::VERTEX);
+
+  // Loop over EDM4hep vertex converting them to lcio vertex
+  for (const auto &edm_vertex : (*edmCollection)) {
+    if (edm_vertex.isAvailable()) {
+      auto *lcio_vertex = new lcio::VertexImpl();
+      lcio_vertex->setPrimary(edm_vertex.getPrimary());
+      lcio_vertex->setAlgorithmType(
+          std::to_string(edm_vertex.getAlgorithmType()));
+      lcio_vertex->setChi2(edm_vertex.getChi2());
+      lcio_vertex->setProbability(edm_vertex.getProbability());
+      lcio_vertex->setPosition(edm_vertex.getPosition()[0],
+                               edm_vertex.getPosition()[1],
+                               edm_vertex.getPosition()[2]);
+      lcio_vertex->setCovMatrix(edm_vertex.getCovMatrix().data());
+
+      for (auto &param : edm_vertex.getParameters()) {
+        lcio_vertex->addParameter(param);
       }
 
-      auto trackerHits = edm_tr.getTrackerHits();
-      for (auto th : trackerHits) {
-        if (!th.isAvailable()) {
-          continue;
-        }
-        if (const auto hit = k4EDM4hep2LcioConv::detail::mapLookupFrom(th, trackerHitMap)) {
-          lcio_tr->addHit(hit.value());
-        }
-        else if (const auto hit = k4EDM4hep2LcioConv::detail::mapLookupFrom(th, trackerHitPlaneMap)) {
-          lcio_tr->addHit(hit.value());
+      // Add LCIO and EDM4hep pair collections to vec
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_vertex, edm_vertex, vertexMap);
+
+      // Add to lcio tracks collection
+      vertices->addElement(lcio_vertex);
+    }
+  }
+
+  return vertices;
+}
+
+template <typename RecoPartMapT>
+std::unique_ptr<lcio::LCCollectionVec> convertReconstructedParticles(
+    const edm4hep::ReconstructedParticleCollection *const recos_coll,
+    RecoPartMapT &recoparticles_vec) {
+  auto recops = std::make_unique<lcio::LCCollectionVec>(
+      lcio::LCIO::RECONSTRUCTEDPARTICLE);
+
+  for (const auto &edm_rp : (*recos_coll)) {
+    auto *lcio_recp = new lcio::ReconstructedParticleImpl;
+    if (edm_rp.isAvailable()) {
+      lcio_recp->setType(edm_rp.getPDG());
+      float m[3] = {edm_rp.getMomentum()[0], edm_rp.getMomentum()[1],
+                    edm_rp.getMomentum()[2]};
+      lcio_recp->setMomentum(m);
+      lcio_recp->setEnergy(edm_rp.getEnergy());
+      lcio_recp->setCovMatrix(
+          edm_rp.getCovMatrix().data()); // TODO Check lower or upper
+      lcio_recp->setMass(edm_rp.getMass());
+      lcio_recp->setCharge(edm_rp.getCharge());
+      float rp[3] = {edm_rp.getReferencePoint()[0],
+                     edm_rp.getReferencePoint()[1],
+                     edm_rp.getReferencePoint()[2]};
+      lcio_recp->setReferencePoint(rp);
+      lcio_recp->setGoodnessOfPID(edm_rp.getGoodnessOfPID());
+      // Add LCIO and EDM4hep pair collections to vec
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_recp, edm_rp,
+                                            recoparticles_vec);
+
+      // Add to reconstructed particles collection
+      recops->addElement(lcio_recp);
+    }
+  }
+
+  return recops;
+}
+
+template <typename MCPartMapT>
+std::unique_ptr<lcio::LCCollectionVec>
+convertMCParticles(const edm4hep::MCParticleCollection *const edmCollection,
+                   MCPartMapT &mcParticleMap) {
+  auto mcparticles =
+      std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::MCPARTICLE);
+
+  for (const auto &edm_mcp : (*edmCollection)) {
+    auto *lcio_mcp = new lcio::MCParticleImpl;
+    if (edm_mcp.isAvailable()) {
+      lcio_mcp->setPDG(edm_mcp.getPDG());
+      lcio_mcp->setGeneratorStatus(edm_mcp.getGeneratorStatus());
+      // Note LCIO sets some Bits during writing which makes a trivial integer
+      // conversion afterwards not work
+      int status = edm_mcp.getSimulatorStatus();
+      lcio_mcp->setSimulatorStatus(status);
+
+      double vertex[3] = {edm_mcp.getVertex()[0], edm_mcp.getVertex()[1],
+                          edm_mcp.getVertex()[2]};
+      lcio_mcp->setVertex(vertex);
+      lcio_mcp->setTime(edm_mcp.getTime());
+      double endpoint[3] = {edm_mcp.getEndpoint()[0], edm_mcp.getEndpoint()[1],
+                            edm_mcp.getEndpoint()[2]};
+      lcio_mcp->setEndpoint(endpoint);
+      double momentum[3] = {edm_mcp.getMomentum()[0], edm_mcp.getMomentum()[1],
+                            edm_mcp.getMomentum()[2]};
+      lcio_mcp->setMomentum(momentum);
+      double momentumEndpoint[3] = {edm_mcp.getMomentumAtEndpoint()[0],
+                                    edm_mcp.getMomentumAtEndpoint()[1],
+                                    edm_mcp.getMomentumAtEndpoint()[2]};
+      lcio_mcp->setMomentumAtEndpoint(momentumEndpoint);
+      lcio_mcp->setMass(edm_mcp.getMass());
+      lcio_mcp->setCharge(edm_mcp.getCharge());
+      float spin[3] = {edm_mcp.getSpin()[0], edm_mcp.getSpin()[1],
+                       edm_mcp.getSpin()[2]};
+      lcio_mcp->setSpin(spin);
+      int colorflow[2] = {edm_mcp.getColorFlow()[0], edm_mcp.getColorFlow()[1]};
+      lcio_mcp->setColorFlow(colorflow);
+
+      lcio_mcp->setCreatedInSimulation(edm_mcp.isCreatedInSimulation());
+      lcio_mcp->setBackscatter(edm_mcp.isBackscatter());
+      lcio_mcp->setVertexIsNotEndpointOfParent(
+          edm_mcp.vertexIsNotEndpointOfParent());
+      lcio_mcp->setDecayedInTracker(edm_mcp.isDecayedInTracker());
+      lcio_mcp->setDecayedInCalorimeter(edm_mcp.isDecayedInCalorimeter());
+      lcio_mcp->setHasLeftDetector(edm_mcp.hasLeftDetector());
+      lcio_mcp->setStopped(edm_mcp.isStopped());
+      lcio_mcp->setOverlay(edm_mcp.isOverlay());
+
+      // Add LCIO and EDM4hep pair collections to vec
+      k4EDM4hep2LcioConv::detail::mapInsert(lcio_mcp, edm_mcp, mcParticleMap);
+
+      // Add to reconstructed particles collection
+      mcparticles->addElement(lcio_mcp);
+    }
+  }
+
+  return mcparticles;
+}
+
+template <typename PidMapT>
+void convertParticleIDs(
+    const edm4hep::ParticleIDCollection *const edmCollection, PidMapT &pidMap,
+    const int algoId) {
+  for (const auto &edmPid : (*edmCollection)) {
+    auto [lcioPid, _] = k4EDM4hep2LcioConv::detail::mapInsert(
+                            new lcio::ParticleIDImpl(), edmPid, pidMap)
+                            .first;
+
+    lcioPid->setType(edmPid.getType());
+    lcioPid->setPDG(edmPid.getPDG());
+    lcioPid->setLikelihood(edmPid.getLikelihood());
+    lcioPid->setAlgorithmType(algoId);
+    for (const auto &param : edmPid.getParameters()) {
+      lcioPid->addParameter(param);
+    }
+  }
+}
+
+template <typename MCParticleMapT, typename MCParticleLookupMapT>
+void resolveRelationsMCParticles(MCParticleMapT &mcParticlesMap,
+                                 const MCParticleLookupMapT &lookupMap) {
+  // Add parent MCParticles after converting all MCparticles
+  for (auto &[lcio_mcp, edm_mcp] : mcParticlesMap) {
+    for (const auto &emd_parent_mcp : edm_mcp.getParents()) {
+      if (emd_parent_mcp.isAvailable()) {
+        // Search for the parent mcparticle in the converted vector
+        if (const auto lcio_mcp_linked =
+                k4EDM4hep2LcioConv::detail::mapLookupFrom(emd_parent_mcp,
+                                                          lookupMap)) {
+          lcio_mcp->addParent(lcio_mcp_linked.value());
         }
       }
     }
   }
+}
 
-  template<typename SimTrHitMapT, typename MCParticleMapT>
-  void resolveRelationsSimTrackerHits(SimTrHitMapT& simTrHitMap, const MCParticleMapT& mcParticleMap)
-  {
-    for (auto& [lcio_strh, edm_strh] : simTrHitMap) {
-      auto edm_strh_mcp = edm_strh.getParticle();
-      if (edm_strh_mcp.isAvailable()) {
-        if (const auto lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_strh_mcp, mcParticleMap)) {
-          lcio_strh->setMCParticle(lcio_mcp.value());
+template <typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT,
+          typename TPCHitMapT>
+void resolveRelationsTracks(TrackMapT &tracksMap,
+                            const TrackHitMapT &trackerHitMap,
+                            const THPlaneHitMapT &trackerHitPlaneMap,
+                            const TPCHitMapT &) {
+  for (auto &[lcio_tr, edm_tr] : tracksMap) {
+    auto tracks = edm_tr.getTracks();
+    for (auto t : tracks) {
+      if (!t.isAvailable()) {
+        continue;
+      }
+      if (const auto track =
+              k4EDM4hep2LcioConv::detail::mapLookupFrom(t, tracksMap)) {
+        lcio_tr->addTrack(track.value());
+      }
+    }
+
+    auto trackerHits = edm_tr.getTrackerHits();
+    for (auto th : trackerHits) {
+      if (!th.isAvailable()) {
+        continue;
+      }
+      if (const auto hit =
+              k4EDM4hep2LcioConv::detail::mapLookupFrom(th, trackerHitMap)) {
+        lcio_tr->addHit(hit.value());
+      } else if (const auto hit = k4EDM4hep2LcioConv::detail::mapLookupFrom(
+                     th, trackerHitPlaneMap)) {
+        lcio_tr->addHit(hit.value());
+      }
+    }
+  }
+}
+
+template <typename SimTrHitMapT, typename MCParticleMapT>
+void resolveRelationsSimTrackerHits(SimTrHitMapT &simTrHitMap,
+                                    const MCParticleMapT &mcParticleMap) {
+  for (auto &[lcio_strh, edm_strh] : simTrHitMap) {
+    auto edm_strh_mcp = edm_strh.getParticle();
+    if (edm_strh_mcp.isAvailable()) {
+      if (const auto lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(
+              edm_strh_mcp, mcParticleMap)) {
+        lcio_strh->setMCParticle(lcio_mcp.value());
+      }
+    }
+  }
+}
+
+template <typename VertexMapT, typename RecoParticleMapT>
+void resolveRelationsVertices(VertexMapT &vertexMap,
+                              const RecoParticleMapT &recoParticleMap) {
+  for (auto &[lcio_vertex, edm_vertex] : vertexMap) {
+    const auto edm_rp = edm_vertex.getAssociatedParticle();
+    if (edm_rp.isAvailable()) {
+      if (const auto lcio_rp = k4EDM4hep2LcioConv::detail::mapLookupFrom(
+              edm_rp, recoParticleMap)) {
+        lcio_vertex->setAssociatedParticle(lcio_rp.value());
+      }
+    }
+  }
+}
+
+template <typename RecoParticleMapT, typename RecoParticleLookupMapT,
+          typename VertexMapT, typename ClusterMapT, typename TrackMapT>
+void resolveRelationsRecoParticles(RecoParticleMapT &recoParticleMap,
+                                   const RecoParticleLookupMapT &recoLookupMap,
+                                   const VertexMapT &vertexMap,
+                                   const ClusterMapT &clusterMap,
+                                   const TrackMapT &trackMap) {
+  // Link Vertex
+  for (auto &[lcio_rp, edm_rp] : recoParticleMap) {
+    const auto edmStartVtx = edm_rp.getStartVertex();
+    if (edmStartVtx.isAvailable()) {
+      if (const auto lcio_vertex = k4EDM4hep2LcioConv::detail::mapLookupFrom(
+              edmStartVtx, vertexMap)) {
+        lcio_rp->setStartVertex(lcio_vertex.value());
+      }
+    }
+
+    // Link Tracks
+    const auto edmTracks = edm_rp.getTracks();
+    for (const auto &t : edmTracks) {
+      if (t.isAvailable()) {
+        if (const auto lcio_tr =
+                k4EDM4hep2LcioConv::detail::mapLookupFrom(t, trackMap)) {
+          lcio_rp->addTrack(lcio_tr.value());
+        }
+      }
+    }
+
+    // Link Clusters
+    const auto edmClusters = edm_rp.getClusters();
+    for (const auto &c : edmClusters) {
+      if (c.isAvailable()) {
+        if (const auto lcio_cluster =
+                k4EDM4hep2LcioConv::detail::mapLookupFrom(c, clusterMap)) {
+          lcio_rp->addCluster(lcio_cluster.value());
+        }
+      }
+    }
+
+    // Link particles
+    const auto edmParticles = edm_rp.getParticles();
+    for (const auto &p : edmParticles) {
+      if (p.isAvailable()) {
+        if (const auto lcio_p =
+                k4EDM4hep2LcioConv::detail::mapLookupFrom(p, recoLookupMap)) {
+          lcio_rp->addParticle(lcio_p.value());
         }
       }
     }
   }
+}
 
-  template<typename VertexMapT, typename RecoParticleMapT>
-  void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap)
-  {
-    for (auto& [lcio_vertex, edm_vertex] : vertexMap) {
-      const auto edm_rp = edm_vertex.getAssociatedParticle();
-      if (edm_rp.isAvailable()) {
-        if (const auto lcio_rp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_rp, recoParticleMap)) {
-          lcio_vertex->setAssociatedParticle(lcio_rp.value());
+template <typename ClusterMapT, typename CaloHitMapT>
+void resolveRelationsClusters(ClusterMapT &clustersMap,
+                              const CaloHitMapT &caloHitMap) {
+  // Resolve relations for clusters
+  for (auto &[lcio_cluster, edm_cluster] : clustersMap) {
+    for (const auto &edm_linked_cluster : edm_cluster.getClusters()) {
+      if (edm_linked_cluster.isAvailable()) {
+        if (const auto lcio_cluster_linked =
+                k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_linked_cluster,
+                                                          clustersMap)) {
+          lcio_cluster->addCluster(lcio_cluster_linked.value());
+        }
+      }
+    }
+
+    for (const auto &edm_calohit : edm_cluster.getHits()) {
+      if (edm_calohit.isAvailable()) {
+        if (const auto lcio_calohit = k4EDM4hep2LcioConv::detail::mapLookupFrom(
+                edm_calohit, caloHitMap)) {
+          lcio_cluster->addHit(lcio_calohit.value(), 1.0);
         }
       }
     }
   }
+}
 
-  template<
-    typename RecoParticleMapT,
-    typename RecoParticleLookupMapT,
-    typename VertexMapT,
-    typename ClusterMapT,
-    typename TrackMapT>
-  void resolveRelationsRecoParticles(
-    RecoParticleMapT& recoParticleMap,
-    const RecoParticleLookupMapT& recoLookupMap,
-    const VertexMapT& vertexMap,
-    const ClusterMapT& clusterMap,
-    const TrackMapT& trackMap)
-  {
-    // Link Vertex
-    for (auto& [lcio_rp, edm_rp] : recoParticleMap) {
-      const auto edmStartVtx = edm_rp.getStartVertex();
-      if (edmStartVtx.isAvailable()) {
-        if (const auto lcio_vertex = k4EDM4hep2LcioConv::detail::mapLookupFrom(edmStartVtx, vertexMap)) {
-          lcio_rp->setStartVertex(lcio_vertex.value());
-        }
+template <typename SimCaloHitMapT, typename MCParticleMapT>
+void resolveRelationsSimCaloHit(SimCaloHitMapT &simCaloHitMap,
+                                const MCParticleMapT &mcParticleMap) {
+  // Fill SimCaloHit collections with contributions
+  //
+  // We loop over all pairs of lcio and edm4hep simcalo hits and add the
+  // contributions, by now MCParticle collection(s) should be converted!
+  for (auto &[lcio_sch, edm_sch] : simCaloHitMap) {
+    const auto contribs = edm_sch.getContributions();
+    for (const auto &contrib : contribs) {
+      if (not contrib.isAvailable()) {
+        // We need a logging library independent of Gaudi for this!
+        // std::cout << "WARNING: CaloHit Contribution is not available!" <<
+        // std::endl;
+        continue;
       }
+      auto edm_contrib_mcp = contrib.getParticle();
+      std::array<float, 3> step_position{contrib.getStepPosition()[0],
+                                         contrib.getStepPosition()[1],
+                                         contrib.getStepPosition()[2]};
+      EVENT::MCParticle *lcio_mcp = nullptr;
+      if (edm_contrib_mcp.isAvailable()) {
+        // if we have the MCParticle we look for its partner
+        lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_contrib_mcp,
+                                                             mcParticleMap)
+                       .value_or(nullptr);
+      }
+      // add associated Contributions (MCParticles)
+      // we add contribution with whatever lcio mc particle we found
+      lcio_sch->addMCParticleContribution(lcio_mcp, contrib.getEnergy(),
+                                          contrib.getTime(), contrib.getPDG(),
+                                          step_position.data());
+    }
+    // We need to reset the energy to the original one, because adding
+    // contributions alters the energy in LCIO
+    lcio_sch->setEnergy(edm_sch.getEnergy());
+  }
+}
 
-      // Link Tracks
-      const auto edmTracks = edm_rp.getTracks();
-      for (const auto& t : edmTracks) {
-        if (t.isAvailable()) {
-          if (const auto lcio_tr = k4EDM4hep2LcioConv::detail::mapLookupFrom(t, trackMap)) {
-            lcio_rp->addTrack(lcio_tr.value());
-          }
-        }
-      }
-
-      // Link Clusters
-      const auto edmClusters = edm_rp.getClusters();
-      for (const auto& c : edmClusters) {
-        if (c.isAvailable()) {
-          if (const auto lcio_cluster = k4EDM4hep2LcioConv::detail::mapLookupFrom(c, clusterMap)) {
-            lcio_rp->addCluster(lcio_cluster.value());
-          }
-        }
-      }
-
-      // Link particles
-      const auto edmParticles = edm_rp.getParticles();
-      for (const auto& p : edmParticles) {
-        if (p.isAvailable()) {
-          if (const auto lcio_p = k4EDM4hep2LcioConv::detail::mapLookupFrom(p, recoLookupMap)) {
-            lcio_rp->addParticle(lcio_p.value());
-          }
-        }
-      }
+template <typename PidMapT, typename RecoParticleMapT>
+void resolveRelationsParticleIDs(PidMapT &pidMap,
+                                 const RecoParticleMapT &recoMap) {
+  for (auto &[lcioPid, edmPid] : pidMap) {
+    const auto edmReco = edmPid.getParticle();
+    const auto lcioReco =
+        k4EDM4hep2LcioConv::detail::mapLookupFrom(edmReco, recoMap);
+    if (lcioReco) {
+      lcioReco.value()->addParticleID(lcioPid);
+    } else {
+      std::cerr
+          << "Cannot find a reconstructed particle to attach a ParticleID to"
+          << std::endl;
     }
   }
+}
 
-  template<typename ClusterMapT, typename CaloHitMapT>
-  void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap)
-  {
-    // Resolve relations for clusters
-    for (auto& [lcio_cluster, edm_cluster] : clustersMap) {
-      for (const auto& edm_linked_cluster : edm_cluster.getClusters()) {
-        if (edm_linked_cluster.isAvailable()) {
-          if (
-            const auto lcio_cluster_linked =
-              k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_linked_cluster, clustersMap)) {
-            lcio_cluster->addCluster(lcio_cluster_linked.value());
-          }
-        }
-      }
+template <typename ObjectMappingT>
+void resolveRelations(ObjectMappingT &collection_pairs) {
+  resolveRelations(collection_pairs, collection_pairs);
+}
 
-      for (const auto& edm_calohit : edm_cluster.getHits()) {
-        if (edm_calohit.isAvailable()) {
-          if (const auto lcio_calohit = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_calohit, caloHitMap)) {
-            lcio_cluster->addHit(lcio_calohit.value(), 1.0);
-          }
-        }
-      }
-    }
-  }
-
-  template<typename SimCaloHitMapT, typename MCParticleMapT>
-  void resolveRelationsSimCaloHit(SimCaloHitMapT& simCaloHitMap, const MCParticleMapT& mcParticleMap)
-  {
-    // Fill SimCaloHit collections with contributions
-    //
-    // We loop over all pairs of lcio and edm4hep simcalo hits and add the
-    // contributions, by now MCParticle collection(s) should be converted!
-    for (auto& [lcio_sch, edm_sch] : simCaloHitMap) {
-      const auto contribs = edm_sch.getContributions();
-      for (const auto& contrib : contribs) {
-        if (not contrib.isAvailable()) {
-          // We need a logging library independent of Gaudi for this!
-          // std::cout << "WARNING: CaloHit Contribution is not available!" << std::endl;
-          continue;
-        }
-        auto edm_contrib_mcp = contrib.getParticle();
-        std::array<float, 3> step_position {
-          contrib.getStepPosition()[0], contrib.getStepPosition()[1], contrib.getStepPosition()[2]};
-        EVENT::MCParticle* lcio_mcp = nullptr;
-        if (edm_contrib_mcp.isAvailable()) {
-          // if we have the MCParticle we look for its partner
-          lcio_mcp = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm_contrib_mcp, mcParticleMap).value_or(nullptr);
-        }
-        // add associated Contributions (MCParticles)
-        // we add contribution with whatever lcio mc particle we found
-        lcio_sch->addMCParticleContribution(
-          lcio_mcp, contrib.getEnergy(), contrib.getTime(), contrib.getPDG(), step_position.data());
-      }
-      // We need to reset the energy to the original one, because adding
-      // contributions alters the energy in LCIO
-      lcio_sch->setEnergy(edm_sch.getEnergy());
-    }
-  }
-
-  template<typename PidMapT, typename RecoParticleMapT>
-  void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap)
-  {
-    for (auto& [lcioPid, edmPid] : pidMap) {
-      const auto edmReco = edmPid.getParticle();
-      const auto lcioReco = k4EDM4hep2LcioConv::detail::mapLookupFrom(edmReco, recoMap);
-      if (lcioReco) {
-        lcioReco.value()->addParticleID(lcioPid);
-      }
-      else {
-        std::cerr << "Cannot find a reconstructed particle to attach a ParticleID to" << std::endl;
-      }
-    }
-  }
-
-  template<typename ObjectMappingT>
-  void resolveRelations(ObjectMappingT& collection_pairs)
-  {
-    resolveRelations(collection_pairs, collection_pairs);
-  }
-
-  // Depending on the order of the collections in the parameters,
-  // and for the mutual dependencies between some collections,
-  // go over the possible missing associated collections and fill them.
-  template<typename ObjectMappingT, typename ObjectMappingU>
-  void resolveRelations(ObjectMappingT& update_pairs, const ObjectMappingU& lookup_pairs)
-  {
-    resolveRelationsMCParticles(update_pairs.mcParticles, lookup_pairs.mcParticles);
-    resolveRelationsTracks(
-      update_pairs.tracks, lookup_pairs.trackerHits, lookup_pairs.trackerHitPlanes, lookup_pairs.tpcHits);
-    resolveRelationsRecoParticles(
-      update_pairs.recoParticles,
-      lookup_pairs.recoParticles,
-      lookup_pairs.vertices,
-      lookup_pairs.clusters,
-      lookup_pairs.tracks);
-    resolveRelationsParticleIDs(lookup_pairs.particleIDs, update_pairs.recoParticles);
-    resolveRelationsVertices(update_pairs.vertices, lookup_pairs.recoParticles);
-    resolveRelationsSimCaloHit(update_pairs.simCaloHits, lookup_pairs.mcParticles);
-    resolveRelationsSimTrackerHits(update_pairs.simTrackerHits, lookup_pairs.mcParticles);
-    resolveRelationsClusters(update_pairs.clusters, lookup_pairs.caloHits);
-  }
+// Depending on the order of the collections in the parameters,
+// and for the mutual dependencies between some collections,
+// go over the possible missing associated collections and fill them.
+template <typename ObjectMappingT, typename ObjectMappingU>
+void resolveRelations(ObjectMappingT &update_pairs,
+                      const ObjectMappingU &lookup_pairs) {
+  resolveRelationsMCParticles(update_pairs.mcParticles,
+                              lookup_pairs.mcParticles);
+  resolveRelationsTracks(update_pairs.tracks, lookup_pairs.trackerHits,
+                         lookup_pairs.trackerHitPlanes, lookup_pairs.tpcHits);
+  resolveRelationsRecoParticles(
+      update_pairs.recoParticles, lookup_pairs.recoParticles,
+      lookup_pairs.vertices, lookup_pairs.clusters, lookup_pairs.tracks);
+  resolveRelationsParticleIDs(lookup_pairs.particleIDs,
+                              update_pairs.recoParticles);
+  resolveRelationsVertices(update_pairs.vertices, lookup_pairs.recoParticles);
+  resolveRelationsSimCaloHit(update_pairs.simCaloHits,
+                             lookup_pairs.mcParticles);
+  resolveRelationsSimTrackerHits(update_pairs.simTrackerHits,
+                                 lookup_pairs.mcParticles);
+  resolveRelationsClusters(update_pairs.clusters, lookup_pairs.caloHits);
+}
 
 } // namespace EDM4hep2LCIOConv

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -18,19 +18,19 @@
 #include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/RecoParticleVertexAssociationCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-  using MutableTrackerHit3D = edm4hep::TrackerHit;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using MutableTrackerHit3D = edm4hep::TrackerHit;
 } // namespace edm4hep
 #endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
@@ -42,6 +42,8 @@ namespace edm4hep {
 #include <EVENT/Cluster.h>
 #include <EVENT/LCCollection.h>
 #include <EVENT/LCEvent.h>
+#include <EVENT/LCFloatVec.h>
+#include <EVENT/LCIntVec.h>
 #include <EVENT/LCRelation.h>
 #include <EVENT/MCParticle.h>
 #include <EVENT/ParticleID.h>
@@ -55,8 +57,6 @@ namespace edm4hep {
 #include <EVENT/TrackerHit.h>
 #include <EVENT/TrackerHitPlane.h>
 #include <EVENT/Vertex.h>
-#include <EVENT/LCIntVec.h>
-#include <EVENT/LCFloatVec.h>
 #include <UTIL/LCIterator.h>
 #include <lcio.h>
 
@@ -66,345 +66,333 @@ namespace edm4hep {
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 namespace LCIO2EDM4hepConv {
-  template<typename LcioT, typename EdmT>
-  using ObjectMapT = k4EDM4hep2LcioConv::MapT<LcioT, EdmT>;
+template <typename LcioT, typename EdmT>
+using ObjectMapT = k4EDM4hep2LcioConv::MapT<LcioT, EdmT>;
 
-  /**
-   * Maping holding all the original and converted objects in a 1:1 mapping in a
-   * way that makes the lookup from LCIO to EDM4hep easy.
-   */
-  struct LcioEdmTypeMapping {
-    ObjectMapT<lcio::Track*, edm4hep::MutableTrack> tracks {};
-    ObjectMapT<lcio::TrackerHit*, edm4hep::MutableTrackerHit3D> trackerHits {};
-    ObjectMapT<lcio::SimTrackerHit*, edm4hep::MutableSimTrackerHit> simTrackerHits {};
-    ObjectMapT<lcio::CalorimeterHit*, edm4hep::MutableCalorimeterHit> caloHits {};
-    ObjectMapT<lcio::RawCalorimeterHit*, edm4hep::MutableRawCalorimeterHit> rawCaloHits {};
-    ObjectMapT<lcio::SimCalorimeterHit*, edm4hep::MutableSimCalorimeterHit> simCaloHits {};
-    ObjectMapT<lcio::TPCHit*, edm4hep::MutableRawTimeSeries> tpcHits {};
-    ObjectMapT<lcio::Cluster*, edm4hep::MutableCluster> clusters {};
-    ObjectMapT<lcio::Vertex*, edm4hep::MutableVertex> vertices {};
-    ObjectMapT<lcio::ReconstructedParticle*, edm4hep::MutableReconstructedParticle> recoParticles {};
-    ObjectMapT<lcio::MCParticle*, edm4hep::MutableMCParticle> mcParticles {};
-    ObjectMapT<lcio::TrackerHitPlane*, edm4hep::MutableTrackerHitPlane> trackerHitPlanes {};
-  };
+/**
+ * Maping holding all the original and converted objects in a 1:1 mapping in a
+ * way that makes the lookup from LCIO to EDM4hep easy.
+ */
+struct LcioEdmTypeMapping {
+  ObjectMapT<lcio::Track*, edm4hep::MutableTrack> tracks{};
+  ObjectMapT<lcio::TrackerHit*, edm4hep::MutableTrackerHit3D> trackerHits{};
+  ObjectMapT<lcio::SimTrackerHit*, edm4hep::MutableSimTrackerHit> simTrackerHits{};
+  ObjectMapT<lcio::CalorimeterHit*, edm4hep::MutableCalorimeterHit> caloHits{};
+  ObjectMapT<lcio::RawCalorimeterHit*, edm4hep::MutableRawCalorimeterHit> rawCaloHits{};
+  ObjectMapT<lcio::SimCalorimeterHit*, edm4hep::MutableSimCalorimeterHit> simCaloHits{};
+  ObjectMapT<lcio::TPCHit*, edm4hep::MutableRawTimeSeries> tpcHits{};
+  ObjectMapT<lcio::Cluster*, edm4hep::MutableCluster> clusters{};
+  ObjectMapT<lcio::Vertex*, edm4hep::MutableVertex> vertices{};
+  ObjectMapT<lcio::ReconstructedParticle*, edm4hep::MutableReconstructedParticle> recoParticles{};
+  ObjectMapT<lcio::MCParticle*, edm4hep::MutableMCParticle> mcParticles{};
+  ObjectMapT<lcio::TrackerHitPlane*, edm4hep::MutableTrackerHitPlane> trackerHitPlanes{};
+};
 
-  using CollNamePair = std::tuple<std::string, std::unique_ptr<podio::CollectionBase>>;
+using CollNamePair = std::tuple<std::string, std::unique_ptr<podio::CollectionBase>>;
 
-  /*
-   * Convert a LCRunHeader to EDM4hep as a frame.
-   */
-  podio::Frame convertRunHeader(EVENT::LCRunHeader* rheader);
+/*
+ * Convert a LCRunHeader to EDM4hep as a frame.
+ */
+podio::Frame convertRunHeader(EVENT::LCRunHeader* rheader);
 
-  /**
-   * Convert a complete LCEvent from LCIO to EDM4hep.
-   *
-   * A second, optional argument can be passed to limit the collections to
-   * convert to the subset that is passed. NOTE: There is an implicit assumption
-   * here that collsToConvert only contains collection names that are present in
-   * the passed evt. There is no exception handling internally to guard against
-   * collections that are missing.
-   */
-  podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert = {});
+/**
+ * Convert a complete LCEvent from LCIO to EDM4hep.
+ *
+ * A second, optional argument can be passed to limit the collections to
+ * convert to the subset that is passed. NOTE: There is an implicit assumption
+ * here that collsToConvert only contains collection names that are present in
+ * the passed evt. There is no exception handling internally to guard against
+ * collections that are missing.
+ */
+podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert = {});
 
-  /**
-   * Convert an LCIOCollection by dispatching to the specific conversion
-   * function for the corresponding type (after querying the input collection).
-   * Populates the correct object mapping along the way.
-   *
-   * Returns a vector of names and collections (since some LCIO collections will
-   * result in more than one EDM4hep collection)
-   */
-  template<typename ObjectMappingT>
-  std::vector<CollNamePair>
-  convertCollection(const std::string& name, EVENT::LCCollection* LCCollection, ObjectMappingT& typeMapping);
+/**
+ * Convert an LCIOCollection by dispatching to the specific conversion
+ * function for the corresponding type (after querying the input collection).
+ * Populates the correct object mapping along the way.
+ *
+ * Returns a vector of names and collections (since some LCIO collections will
+ * result in more than one EDM4hep collection)
+ */
+template <typename ObjectMappingT>
+std::vector<CollNamePair> convertCollection(const std::string& name, EVENT::LCCollection* LCCollection,
+                                            ObjectMappingT& typeMapping);
 
-  /**
-   * Resolve all relations in all converted objects that are held in the map.
-   * Dispatch to the correpsonding implementation for all the types that have
-   * relations
-   */
-  template<typename ObjectMappingT>
-  void resolveRelations(ObjectMappingT& typeMapping);
+/**
+ * Resolve all relations in all converted objects that are held in the map.
+ * Dispatch to the correpsonding implementation for all the types that have
+ * relations
+ */
+template <typename ObjectMappingT>
+void resolveRelations(ObjectMappingT& typeMapping);
 
-  template<typename ObjectMappingT, typename ObjectMappingU>
-  void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
+template <typename ObjectMappingT, typename ObjectMappingU>
+void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
-  /**
-   * Convert LCRelation collections into the corresponding Association collections in EDM4hep
-   */
-  template<typename ObjectMappingT>
-  std::vector<CollNamePair> createAssociations(
-    const ObjectMappingT& typeMapping,
-    const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation);
+/**
+ * Convert LCRelation collections into the corresponding Association collections
+ * in EDM4hep
+ */
+template <typename ObjectMappingT>
+std::vector<CollNamePair>
+createAssociations(const ObjectMappingT& typeMapping,
+                   const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation);
 
-  /**
-   * Convert a subset collection, dispatching to the correct function for the
-   * type of the input collection
-   */
-  template<typename ObjectMappingT>
-  std::unique_ptr<podio::CollectionBase>
-  fillSubset(EVENT::LCCollection* LCCollection, const ObjectMappingT& typeMapping, const std::string& type);
+/**
+ * Convert a subset collection, dispatching to the correct function for the
+ * type of the input collection
+ */
+template <typename ObjectMappingT>
+std::unique_ptr<podio::CollectionBase> fillSubset(EVENT::LCCollection* LCCollection, const ObjectMappingT& typeMapping,
+                                                  const std::string& type);
 
-  /*
-   * Converts a LCIntVec or LCFloatVec Collection into a podio::UserDataCollection of the appropriate type.
-   *
-   * NOTE: LC[Int|Float]Vec are nested, but podio::UserDataCollection are flat. Hence, this will put all
-   * contents into one collection, and the [begin, end) indices in this collection into a second (flat)
-   * collection (with the suffix "_VecLengths" added to its name), such that the elements at position i,
-   * resp. (i + 1) form the [begin, end) indices for each of the original vector collections.
-   */
-  template<typename LCVecType>
-  std::vector<CollNamePair> convertLCVec(const std::string& name, EVENT::LCCollection* LCCollection);
+/*
+ * Converts a LCIntVec or LCFloatVec Collection into a podio::UserDataCollection
+ * of the appropriate type.
+ *
+ * NOTE: LC[Int|Float]Vec are nested, but podio::UserDataCollection are flat.
+ * Hence, this will put all contents into one collection, and the [begin, end)
+ * indices in this collection into a second (flat) collection (with the suffix
+ * "_VecLengths" added to its name), such that the elements at position i, resp.
+ * (i + 1) form the [begin, end) indices for each of the original vector
+ * collections.
+ */
+template <typename LCVecType>
+std::vector<CollNamePair> convertLCVec(const std::string& name, EVENT::LCCollection* LCCollection);
 
-  /**
-   * Converting all parameters of an LCIO Object and attaching them to the
-   * passed podio::Frame.
-   */
-  template<typename LCIOType>
-  void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event);
+/**
+ * Converting all parameters of an LCIO Object and attaching them to the
+ * passed podio::Frame.
+ */
+template <typename LCIOType>
+void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event);
 
-  inline edm4hep::Vector3f Vector3fFrom(const double* v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
+inline edm4hep::Vector3f Vector3fFrom(const double* v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
 
-  inline edm4hep::Vector3f Vector3fFrom(const EVENT::FloatVec& v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
+inline edm4hep::Vector3f Vector3fFrom(const EVENT::FloatVec& v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
 
-  /**
-   * Get the name of a ParticleID collection from the name of the reco
-   * collection (from which it is created) and the PID algorithm name.
-   */
-  inline std::string getPIDCollName(const std::string& recoCollName, const std::string& algoName)
-  {
-    return recoCollName + "_PID_" + algoName;
-  }
+/**
+ * Get the name of a ParticleID collection from the name of the reco
+ * collection (from which it is created) and the PID algorithm name.
+ */
+inline std::string getPIDCollName(const std::string& recoCollName, const std::string& algoName) {
+  return recoCollName + "_PID_" + algoName;
+}
 
-  /**
-   * Get the meta information for all particle id collections that are available
-   * from the PIDHandler
-   */
-  std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl);
+/**
+ * Get the meta information for all particle id collections that are available
+ * from the PIDHandler
+ */
+std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl);
 
-  /**
-   * Convert a TrackState
-   */
-  edm4hep::TrackState convertTrackState(const EVENT::TrackState* trackState);
+/**
+ * Convert a TrackState
+ */
+edm4hep::TrackState convertTrackState(const EVENT::TrackState* trackState);
 
-  /**
-   * Convert a ParticleID object.
-   *
-   * In LCIO ParticleIDs are persisted as part of the ReconstructedParticle they
-   * are attached to. There are no ParticleID collections in the event. Hence,
-   * this function converts single particle ID objects and the management of
-   * putting them into a collection and of creating the LCIO to EDM4hep mapping
-   * is done in the conversion of the ReconstructedParticles.
-   */
-  edm4hep::MutableParticleID convertParticleID(const EVENT::ParticleID* pid);
+/**
+ * Convert a ParticleID object.
+ *
+ * In LCIO ParticleIDs are persisted as part of the ReconstructedParticle they
+ * are attached to. There are no ParticleID collections in the event. Hence,
+ * this function converts single particle ID objects and the management of
+ * putting them into a collection and of creating the LCIO to EDM4hep mapping
+ * is done in the conversion of the ReconstructedParticles.
+ */
+edm4hep::MutableParticleID convertParticleID(const EVENT::ParticleID* pid);
 
-  /**
-   * Convert an MCParticle collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename MCParticleMapT>
-  std::unique_ptr<edm4hep::MCParticleCollection>
-  convertMCParticles(const std::string& name, EVENT::LCCollection* LCCollection, MCParticleMapT& mcparticlesMap);
+/**
+ * Convert an MCParticle collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename MCParticleMapT>
+std::unique_ptr<edm4hep::MCParticleCollection>
+convertMCParticles(const std::string& name, EVENT::LCCollection* LCCollection, MCParticleMapT& mcparticlesMap);
 
-  /**
-   * Convert a ReconstructedParticle collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   *
-   * NOTE: Also populates ParticleID collections, as those are persisted as
-   * part of the ReconstructedParticles in LCIO. The name of this collection is
-   * <name>_PID_<pid_algo_name> (see getPIDCollName)
-   */
-  template<typename RecoMapT>
-  std::vector<CollNamePair>
-  convertReconstructedParticles(const std::string& name, EVENT::LCCollection* LCCollection, RecoMapT& recoparticlesMap);
+/**
+ * Convert a ReconstructedParticle collection and return the resulting
+ * collection. Simultaneously populates the mapping from LCIO to EDM4hep
+ * objects.
+ *
+ * NOTE: Also populates ParticleID collections, as those are persisted as
+ * part of the ReconstructedParticles in LCIO. The name of this collection is
+ * <name>_PID_<pid_algo_name> (see getPIDCollName)
+ */
+template <typename RecoMapT>
+std::vector<CollNamePair> convertReconstructedParticles(const std::string& name, EVENT::LCCollection* LCCollection,
+                                                        RecoMapT& recoparticlesMap);
 
-  /**
-   * Convert a Vertex collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename VertexMapT>
-  std::unique_ptr<edm4hep::VertexCollection>
-  convertVertices(const std::string& name, EVENT::LCCollection* LCCollection, VertexMapT& vertexMap);
+/**
+ * Convert a Vertex collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename VertexMapT>
+std::unique_ptr<edm4hep::VertexCollection> convertVertices(const std::string& name, EVENT::LCCollection* LCCollection,
+                                                           VertexMapT& vertexMap);
 
-  /**
-   * Convert a SimTrackerHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename SimTrHitMapT>
-  std::unique_ptr<edm4hep::SimTrackerHitCollection>
-  convertSimTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, SimTrHitMapT& SimTrHitMap);
+/**
+ * Convert a SimTrackerHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename SimTrHitMapT>
+std::unique_ptr<edm4hep::SimTrackerHitCollection>
+convertSimTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, SimTrHitMapT& SimTrHitMap);
 
-  /**
-   * Convert a TPCHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::RawTimeSeriesCollection>
-  convertTPCHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TPCHitMap);
+/**
+ * Convert a TPCHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::RawTimeSeriesCollection> convertTPCHits(const std::string& name,
+                                                                 EVENT::LCCollection* LCCollection, HitMapT& TPCHitMap);
 
-  /**
-   * Convert a TrackerHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::TrackerHit3DCollection>
-  convertTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitMap);
+/**
+ * Convert a TrackerHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::TrackerHit3DCollection>
+convertTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitMap);
 
-  /**
-   * Convert a TrackerHitPlane collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::TrackerHitPlaneCollection>
-  convertTrackerHitPlanes(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitPlaneMap);
+/**
+ * Convert a TrackerHitPlane collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::TrackerHitPlaneCollection>
+convertTrackerHitPlanes(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitPlaneMap);
 
-  /**
-   * Convert a Track collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename TrackMapT>
-  std::unique_ptr<edm4hep::TrackCollection>
-  convertTracks(const std::string& name, EVENT::LCCollection* LCCollection, TrackMapT& TrackMap);
+/**
+ * Convert a Track collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename TrackMapT>
+std::unique_ptr<edm4hep::TrackCollection> convertTracks(const std::string& name, EVENT::LCCollection* LCCollection,
+                                                        TrackMapT& TrackMap);
 
-  /**
-   * Convert a SimCalorimeterHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::SimCalorimeterHitCollection>
-  convertSimCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& SimCaloHitMap);
+/**
+ * Convert a SimCalorimeterHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::SimCalorimeterHitCollection>
+convertSimCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& SimCaloHitMap);
 
-  /**
-   * Convert a RawCalorimeterHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::RawCalorimeterHitCollection>
-  convertRawCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& rawCaloHitMap);
+/**
+ * Convert a RawCalorimeterHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::RawCalorimeterHitCollection>
+convertRawCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& rawCaloHitMap);
 
-  /**
-   * Convert a CalorimeterHit collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::CalorimeterHitCollection>
-  convertCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& caloHitMap);
+/**
+ * Convert a CalorimeterHit collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename HitMapT>
+std::unique_ptr<edm4hep::CalorimeterHitCollection>
+convertCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& caloHitMap);
 
-  /**
-   * Convert a Cluster collection and return the resulting collection.
-   * Simultaneously populates the mapping from LCIO to EDM4hep objects.
-   */
-  template<typename ClusterMapT>
-  std::unique_ptr<edm4hep::ClusterCollection>
-  convertClusters(const std::string& name, EVENT::LCCollection* LCCollection, ClusterMapT& clusterMap);
+/**
+ * Convert a Cluster collection and return the resulting collection.
+ * Simultaneously populates the mapping from LCIO to EDM4hep objects.
+ */
+template <typename ClusterMapT>
+std::unique_ptr<edm4hep::ClusterCollection> convertClusters(const std::string& name, EVENT::LCCollection* LCCollection,
+                                                            ClusterMapT& clusterMap);
 
-  /**
-   * Create an EventHeaderCollection and fills it with the Metadata.
-   */
+/**
+ * Create an EventHeaderCollection and fills it with the Metadata.
+ */
 
-  std::unique_ptr<edm4hep::EventHeaderCollection> createEventHeader(const EVENT::LCEvent* evt);
+std::unique_ptr<edm4hep::EventHeaderCollection> createEventHeader(const EVENT::LCEvent* evt);
 
-  /**
-   * Helper function to create a subset collection from an existing (LCIO)
-   * subset collection. Needs the object mapping as input to resolve to the
-   * correct EDM4hep object for a given LCIO object.
-   *
-   * NOTE: Users responsibility to call this with the right inputs (i.e.
-   * matching types)
-   */
-  template<
-    typename CollT,
-    typename ObjectMapT,
-    typename LcioT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ObjectMapT>>,
-    typename Edm4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ObjectMapT>>
-  auto handleSubsetColl(EVENT::LCCollection* lcioColl, const ObjectMapT& elemMap);
+/**
+ * Helper function to create a subset collection from an existing (LCIO)
+ * subset collection. Needs the object mapping as input to resolve to the
+ * correct EDM4hep object for a given LCIO object.
+ *
+ * NOTE: Users responsibility to call this with the right inputs (i.e.
+ * matching types)
+ */
+template <typename CollT, typename ObjectMapT,
+          typename LcioT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ObjectMapT>>,
+          typename Edm4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ObjectMapT>>
+auto handleSubsetColl(EVENT::LCCollection* lcioColl, const ObjectMapT& elemMap);
 
-  /**
-   * Create an Association collection from an LCRelations collection. Templated
-   * on the From and To types as well as the direction of the relations in the
-   * input LCRelations collection with respect to the order in which they are
-   * mentioned in the Association collection of EDM4hep (since those are not
-   * directed).
-   *
-   * Necessary inputs apart from the LCRelations collection are the correct LCIO
-   * to EDM4hep object mappings to actually resolve the necessary relations.
-   */
-  template<
-    typename CollT,
-    bool Reverse,
-    typename FromMapT,
-    typename ToMapT,
-    typename FromLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<FromMapT>>,
-    typename ToLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ToMapT>>,
-    typename FromEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<FromMapT>,
-    typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
-  std::unique_ptr<CollT>
-  createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap, const ToMapT& toMap);
+/**
+ * Create an Association collection from an LCRelations collection. Templated
+ * on the From and To types as well as the direction of the relations in the
+ * input LCRelations collection with respect to the order in which they are
+ * mentioned in the Association collection of EDM4hep (since those are not
+ * directed).
+ *
+ * Necessary inputs apart from the LCRelations collection are the correct LCIO
+ * to EDM4hep object mappings to actually resolve the necessary relations.
+ */
+template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
+          typename FromLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<FromMapT>>,
+          typename ToLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ToMapT>>,
+          typename FromEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<FromMapT>,
+          typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
+std::unique_ptr<CollT> createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
+                                                   const ToMapT& toMap);
 
-  /**
-   * Creates the CaloHitContributions for all SimCaloHits.
-   * has to be done this way, since the converted McParticles are needeed.
-   * The contributions are also attached to their corresponding SimCalorimeterHits.
-   */
-  template<typename HitMapT, typename MCParticleMapT>
-  std::unique_ptr<edm4hep::CaloHitContributionCollection> createCaloHitContributions(
-    HitMapT& SimCaloHitMap,
-    const MCParticleMapT& mcparticlesMap);
+/**
+ * Creates the CaloHitContributions for all SimCaloHits.
+ * has to be done this way, since the converted McParticles are needeed.
+ * The contributions are also attached to their corresponding
+ * SimCalorimeterHits.
+ */
+template <typename HitMapT, typename MCParticleMapT>
+std::unique_ptr<edm4hep::CaloHitContributionCollection>
+createCaloHitContributions(HitMapT& SimCaloHitMap, const MCParticleMapT& mcparticlesMap);
 
-  /**
-   * Resolve the relations for the MCParticles.
-   */
-  template<typename MCParticleMapT, typename MCParticleLookupMapT>
-  void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap);
+/**
+ * Resolve the relations for the MCParticles.
+ */
+template <typename MCParticleMapT, typename MCParticleLookupMapT>
+void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap);
 
-  /**
-   * Resolve the relations for SimTrackerHits
-   */
-  template<typename HitMapT, typename MCParticleMapT>
-  void resolveRelationsSimTrackerHits(HitMapT& SimTrHitMap, const MCParticleMapT& mcparticlesMap);
+/**
+ * Resolve the relations for SimTrackerHits
+ */
+template <typename HitMapT, typename MCParticleMapT>
+void resolveRelationsSimTrackerHits(HitMapT& SimTrHitMap, const MCParticleMapT& mcparticlesMap);
 
-  /**
-   * Resolve the relations for ReconstructedParticles
-   */
-  template<
-    typename RecoParticleMapT,
-    typename RecoParticleLookupMapT,
-    typename VertexMapT,
-    typename ClusterMapT,
-    typename TrackMapT>
-  void resolveRelationsRecoParticles(
-    RecoParticleMapT& recoparticlesMap,
-    const RecoParticleLookupMapT& recoLookupMap,
-    const VertexMapT& vertexMap,
-    const ClusterMapT& clusterMap,
-    const TrackMapT& tracksMap);
+/**
+ * Resolve the relations for ReconstructedParticles
+ */
+template <typename RecoParticleMapT, typename RecoParticleLookupMapT, typename VertexMapT, typename ClusterMapT,
+          typename TrackMapT>
+void resolveRelationsRecoParticles(RecoParticleMapT& recoparticlesMap, const RecoParticleLookupMapT& recoLookupMap,
+                                   const VertexMapT& vertexMap, const ClusterMapT& clusterMap,
+                                   const TrackMapT& tracksMap);
 
-  /**
-   * Resolve the relations for Clusters
-   */
-  template<typename ClusterMapT, typename CaloHitMapT>
-  void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
+/**
+ * Resolve the relations for Clusters
+ */
+template <typename ClusterMapT, typename CaloHitMapT>
+void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap);
 
-  /**
-   * Resolve the relations for Tracks
-   */
-  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
-  void resolveRelationsTracks(
-    TrackMapT& tracksMap,
-    const TrackHitMapT& trackerHitMap,
-    const THPlaneHitMapT&,
-    const TPCHitMapT&);
+/**
+ * Resolve the relations for Tracks
+ */
+template <typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
+void resolveRelationsTracks(TrackMapT& tracksMap, const TrackHitMapT& trackerHitMap, const THPlaneHitMapT&,
+                            const TPCHitMapT&);
 
-  /**
-   * Resolve the relations for Vertices
-   */
-  template<typename VertexMapT, typename RecoParticleMapT>
-  void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoparticleMap);
+/**
+ * Resolve the relations for Vertices
+ */
+template <typename VertexMapT, typename RecoParticleMapT>
+void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoparticleMap);
 
 } // namespace LCIO2EDM4hepConv
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -4,1034 +4,1097 @@
 #include <edm4hep/ParticleIDCollection.h>
 
 namespace LCIO2EDM4hepConv {
-  template<typename LCIOType>
-  void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event)
-  {
-    const auto& params = lcioobj->getParameters();
-    // handle srting params
-    EVENT::StringVec keys;
-    const auto stringKeys = params.getStringKeys(keys);
-    for (auto i = 0u; i < stringKeys.size(); i++) {
-      EVENT::StringVec sValues;
-      const auto stringVals = params.getStringVals(stringKeys[i], sValues);
-      event.putParameter(stringKeys[i], stringVals);
+template <typename LCIOType>
+void convertObjectParameters(LCIOType *lcioobj, podio::Frame &event) {
+  const auto &params = lcioobj->getParameters();
+  // handle srting params
+  EVENT::StringVec keys;
+  const auto stringKeys = params.getStringKeys(keys);
+  for (auto i = 0u; i < stringKeys.size(); i++) {
+    EVENT::StringVec sValues;
+    const auto stringVals = params.getStringVals(stringKeys[i], sValues);
+    event.putParameter(stringKeys[i], stringVals);
+  }
+  // handle float params
+  EVENT::StringVec fkeys;
+  const auto floatKeys = params.getFloatKeys(fkeys);
+  for (auto i = 0u; i < floatKeys.size(); i++) {
+    EVENT::FloatVec fValues;
+    const auto floatVals = params.getFloatVals(floatKeys[i], fValues);
+    event.putParameter(floatKeys[i], floatVals);
+  }
+  // handle int params
+  EVENT::StringVec ikeys;
+  const auto intKeys = params.getIntKeys(ikeys);
+  for (auto i = 0u; i < intKeys.size(); i++) {
+    EVENT::IntVec iValues;
+    const auto intVals = params.getIntVals(intKeys[i], iValues);
+    event.putParameter(intKeys[i], intVals);
+  }
+  // handle double params
+  EVENT::StringVec dkeys;
+  const auto dKeys = params.getDoubleKeys(dkeys);
+  for (auto i = 0u; i < dKeys.size(); i++) {
+    EVENT::DoubleVec dValues;
+    const auto dVals = params.getDoubleVals(dKeys[i], dValues);
+    event.putParameter(dKeys[i], dVals);
+  }
+}
+
+template <typename LCVecType>
+std::vector<CollNamePair> convertLCVec(const std::string &name,
+                                       EVENT::LCCollection *LCCollection) {
+  auto dest = std::make_unique<
+      podio::UserDataCollection<typename LCVecType::value_type>>();
+  auto vecSizes = std::make_unique<podio::UserDataCollection<uint32_t>>();
+  if (LCCollection->getNumberOfElements() > 0) {
+    vecSizes->push_back(0);
+  }
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    const auto *rval = static_cast<LCVecType *>(LCCollection->getElementAt(i));
+    for (unsigned j = 0; j < rval->size(); j++) {
+      dest->push_back((*rval)[j]);
     }
-    // handle float params
-    EVENT::StringVec fkeys;
-    const auto floatKeys = params.getFloatKeys(fkeys);
-    for (auto i = 0u; i < floatKeys.size(); i++) {
-      EVENT::FloatVec fValues;
-      const auto floatVals = params.getFloatVals(floatKeys[i], fValues);
-      event.putParameter(floatKeys[i], floatVals);
-    }
-    // handle int params
-    EVENT::StringVec ikeys;
-    const auto intKeys = params.getIntKeys(ikeys);
-    for (auto i = 0u; i < intKeys.size(); i++) {
-      EVENT::IntVec iValues;
-      const auto intVals = params.getIntVals(intKeys[i], iValues);
-      event.putParameter(intKeys[i], intVals);
-    }
-    // handle double params
-    EVENT::StringVec dkeys;
-    const auto dKeys = params.getDoubleKeys(dkeys);
-    for (auto i = 0u; i < dKeys.size(); i++) {
-      EVENT::DoubleVec dValues;
-      const auto dVals = params.getDoubleVals(dKeys[i], dValues);
-      event.putParameter(dKeys[i], dVals);
+    vecSizes->push_back(dest->size());
+  }
+  std::vector<CollNamePair> results;
+  results.reserve(2);
+  results.emplace_back(name, std::move(dest));
+  results.emplace_back(name + "_VecLenghts", std::move(vecSizes));
+  return results;
+}
+
+template <typename CollT, typename ObjectMapT, typename LcioT,
+          typename Edm4hepT>
+auto handleSubsetColl(EVENT::LCCollection *lcioColl,
+                      const ObjectMapT &elemMap) {
+  auto edm4hepColl = std::make_unique<CollT>();
+  edm4hepColl->setSubsetCollection();
+
+  UTIL::LCIterator<LcioT> lcioIter(lcioColl);
+  while (const auto lcioElem = lcioIter.next()) {
+    if (auto edm4hepElem =
+            k4EDM4hep2LcioConv::detail::mapLookupTo(lcioElem, elemMap)) {
+      edm4hepColl->push_back(edm4hepElem.value());
+    } else {
+      std::cerr << "Cannot find corresponding EDM4hep object for an LCIO "
+                   "object in a subset collection of type "
+                << Edm4hepT::collection_type::valueTypeName << std::endl;
     }
   }
 
-  template<typename LCVecType>
-  std::vector<CollNamePair> convertLCVec(const std::string& name, EVENT::LCCollection* LCCollection)
-  {
-    auto dest = std::make_unique<podio::UserDataCollection<typename LCVecType::value_type>>();
-    auto vecSizes = std::make_unique<podio::UserDataCollection<uint32_t>>();
-    if (LCCollection->getNumberOfElements() > 0) {
-      vecSizes->push_back(0);
+  return edm4hepColl;
+}
+
+template <typename MCParticleMapT>
+std::unique_ptr<edm4hep::MCParticleCollection>
+convertMCParticles(const std::string &name, EVENT::LCCollection *LCCollection,
+                   MCParticleMapT &mcparticlesMap) {
+  auto dest = std::make_unique<edm4hep::MCParticleCollection>();
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::MCParticle *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    lval.setPDG(rval->getPDG());
+    lval.setGeneratorStatus(rval->getGeneratorStatus());
+    lval.setSimulatorStatus(rval->getSimulatorStatus());
+    lval.setCharge(rval->getCharge());
+    lval.setTime(rval->getTime());
+    lval.setMass(rval->getMass());
+    lval.setSpin(edm4hep::Vector3f(rval->getSpin()));
+    lval.setColorFlow(edm4hep::Vector2i(rval->getColorFlow()));
+    lval.setVertex(edm4hep::Vector3d(rval->getVertex()));
+    lval.setEndpoint(edm4hep::Vector3d(rval->getEndpoint()));
+    lval.setMomentum(rval->getMomentum());
+    lval.setMomentumAtEndpoint(rval->getMomentumAtEndpoint());
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, mcparticlesMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element" << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      const auto* rval = static_cast<LCVecType*>(LCCollection->getElementAt(i));
-      for (unsigned j = 0; j < rval->size(); j++) {
-        dest->push_back((*rval)[j]);
-      }
-      vecSizes->push_back(dest->size());
-    }
-    std::vector<CollNamePair> results;
-    results.reserve(2);
-    results.emplace_back(name, std::move(dest));
-    results.emplace_back(name + "_VecLenghts", std::move(vecSizes));
-    return results;
+  }
+  return dest;
+}
+
+template <typename RecoMapT>
+std::vector<CollNamePair>
+convertReconstructedParticles(const std::string &name,
+                              EVENT::LCCollection *LCCollection,
+                              RecoMapT &recoparticlesMap) {
+  auto dest = std::make_unique<edm4hep::ReconstructedParticleCollection>();
+
+  // Set up a PIDHandler to split off the ParticlID objects stored in the
+  // reconstructed particles into separate collections. Each algorithm id /
+  // name get's a separate collection
+  auto pidHandler = UTIL::PIDHandler(LCCollection);
+  // TODO: parameter names
+  std::map<int, std::unique_ptr<edm4hep::ParticleIDCollection>> particleIDs;
+  for (const auto id : pidHandler.getAlgorithmIDs()) {
+    particleIDs.emplace(id, std::make_unique<edm4hep::ParticleIDCollection>());
   }
 
-  template<typename CollT, typename ObjectMapT, typename LcioT, typename Edm4hepT>
-  auto handleSubsetColl(EVENT::LCCollection* lcioColl, const ObjectMapT& elemMap)
-  {
-    auto edm4hepColl = std::make_unique<CollT>();
-    edm4hepColl->setSubsetCollection();
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval = static_cast<EVENT::ReconstructedParticle *>(
+        LCCollection->getElementAt(i));
+    auto lval = dest->create();
 
-    UTIL::LCIterator<LcioT> lcioIter(lcioColl);
-    while (const auto lcioElem = lcioIter.next()) {
-      if (auto edm4hepElem = k4EDM4hep2LcioConv::detail::mapLookupTo(lcioElem, elemMap)) {
-        edm4hepColl->push_back(edm4hepElem.value());
-      }
-      else {
-        std::cerr << "Cannot find corresponding EDM4hep object for an LCIO object in a subset collection of type "
-                  << Edm4hepT::collection_type::valueTypeName << std::endl;
-      }
+    lval.setCharge(rval->getCharge());
+    auto &m = rval->getCovMatrix(); // 10 parameters
+    lval.setCovMatrix(
+        {m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9]});
+    lval.setEnergy(rval->getEnergy());
+    lval.setGoodnessOfPID(rval->getGoodnessOfPID());
+    lval.setMass(rval->getMass());
+    lval.setMomentum(Vector3fFrom(rval->getMomentum()));
+    lval.setReferencePoint(rval->getReferencePoint());
+    lval.setPDG(rval->getType());
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, recoparticlesMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
 
-    return edm4hepColl;
+    // Need to convert the particle IDs here, since they are part of the reco
+    // particle collection in LCIO.
+    for (const auto lcioPid : rval->getParticleIDs()) {
+      auto pid = convertParticleID(lcioPid);
+      pid.setParticle(lval);
+      if (auto pidIt = particleIDs.find(pid.getAlgorithmType());
+          pidIt != particleIDs.end()) {
+        pidIt->second->push_back(pid);
+      } else {
+        std::cerr << "ERROR: Found a PID object with an algorithm ID that is "
+                     "not known to the PIDHandler (id = "
+                  << pid.getAlgorithmType() << ")" << std::endl;
+      }
+    }
   }
 
-  template<typename MCParticleMapT>
-  std::unique_ptr<edm4hep::MCParticleCollection>
-  convertMCParticles(const std::string& name, EVENT::LCCollection* LCCollection, MCParticleMapT& mcparticlesMap)
-  {
-    auto dest = std::make_unique<edm4hep::MCParticleCollection>();
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::MCParticle*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+  std::vector<CollNamePair> results;
+  results.reserve(particleIDs.size() + 1);
+  results.emplace_back(name, std::move(dest));
+  for (auto &[id, coll] : particleIDs) {
+    results.emplace_back(getPIDCollName(name, pidHandler.getAlgorithmName(id)),
+                         std::move(coll));
+  }
+  return results;
+}
 
-      lval.setPDG(rval->getPDG());
-      lval.setGeneratorStatus(rval->getGeneratorStatus());
-      lval.setSimulatorStatus(rval->getSimulatorStatus());
-      lval.setCharge(rval->getCharge());
-      lval.setTime(rval->getTime());
-      lval.setMass(rval->getMass());
-      lval.setSpin(edm4hep::Vector3f(rval->getSpin()));
-      lval.setColorFlow(edm4hep::Vector2i(rval->getColorFlow()));
-      lval.setVertex(edm4hep::Vector3d(rval->getVertex()));
-      lval.setEndpoint(edm4hep::Vector3d(rval->getEndpoint()));
-      lval.setMomentum(rval->getMomentum());
-      lval.setMomentumAtEndpoint(rval->getMomentumAtEndpoint());
+template <typename VertexMapT>
+std::unique_ptr<edm4hep::VertexCollection>
+convertVertices(const std::string &name, EVENT::LCCollection *LCCollection,
+                VertexMapT &vertexMap) {
+  auto dest = std::make_unique<edm4hep::VertexCollection>();
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval = static_cast<EVENT::Vertex *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, mcparticlesMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element" << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+    lval.setPrimary(
+        rval->isPrimary() ? 1 : 0); // 1 for primary and 0 for not primary
+    lval.setChi2(rval->getChi2());
+    lval.setProbability(rval->getProbability());
+    lval.setPosition(rval->getPosition());
+    auto &m = rval->getCovMatrix(); // 6 parameters
+    lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
+    // FIXME: the algorithm type in LCIO is a string, but an integer is expected
+    // lval.setAlgorithmType(rval->getAlgorithmType());
+    // lval.setAssociatedParticle();  //set it when convert
+    // ReconstructedParticle
+    //
+    for (auto v : rval->getParameters()) {
+      lval.addToParameters(v);
     }
-    return dest;
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, vertexMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
+    }
+  }
+  return dest;
+}
+
+template <typename SimTrHitMapT>
+std::unique_ptr<edm4hep::SimTrackerHitCollection>
+convertSimTrackerHits(const std::string &name,
+                      EVENT::LCCollection *LCCollection,
+                      SimTrHitMapT &SimTrHitMap) {
+  auto dest = std::make_unique<edm4hep::SimTrackerHitCollection>();
+
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::SimTrackerHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setEDep(rval->getEDep());
+    lval.setTime(rval->getTime());
+    lval.setPathLength(rval->getPathLength());
+    lval.setQuality(rval->getQuality());
+    lval.setPosition(rval->getPosition());
+    lval.setMomentum(rval->getMomentum());
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, SimTrHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
+    }
+  }
+  return dest;
+}
+
+template <typename HitMapT>
+std::unique_ptr<edm4hep::RawTimeSeriesCollection>
+convertTPCHits(const std::string &name, EVENT::LCCollection *LCCollection,
+               HitMapT &TPCHitMap) {
+  auto dest = std::make_unique<edm4hep::RawTimeSeriesCollection>();
+
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval = static_cast<EVENT::TPCHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    lval.setCellID(rval->getCellID());
+    lval.setTime(rval->getTime());
+    lval.setCharge(rval->getCharge());
+    lval.setQuality(rval->getQuality());
+    for (unsigned j = 0, M = rval->getNRawDataWords(); j < M; j++) {
+      lval.addToAdcCounts(rval->getRawDataWord(j));
+    }
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TPCHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
+    }
   }
 
-  template<typename RecoMapT>
-  std::vector<CollNamePair>
-  convertReconstructedParticles(const std::string& name, EVENT::LCCollection* LCCollection, RecoMapT& recoparticlesMap)
-  {
-    auto dest = std::make_unique<edm4hep::ReconstructedParticleCollection>();
+  return dest;
+}
 
-    // Set up a PIDHandler to split off the ParticlID objects stored in the
-    // reconstructed particles into separate collections. Each algorithm id /
-    // name get's a separate collection
-    auto pidHandler = UTIL::PIDHandler(LCCollection);
-    // TODO: parameter names
-    std::map<int, std::unique_ptr<edm4hep::ParticleIDCollection>> particleIDs;
-    for (const auto id : pidHandler.getAlgorithmIDs()) {
-      particleIDs.emplace(id, std::make_unique<edm4hep::ParticleIDCollection>());
+template <typename HitMapT>
+std::unique_ptr<edm4hep::TrackerHit3DCollection>
+convertTrackerHits(const std::string &name, EVENT::LCCollection *LCCollection,
+                   HitMapT &TrackerHitMap) {
+  auto dest = std::make_unique<edm4hep::TrackerHit3DCollection>();
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::TrackerHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setType(rval->getType());
+    lval.setQuality(rval->getQuality());
+    lval.setTime(rval->getTime());
+    lval.setEDep(rval->getEDep());
+    lval.setEDepError(rval->getEDepError());
+    lval.setPosition(rval->getPosition());
+    auto &m = rval->getCovMatrix();
+    lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackerHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
+  }
+  return dest;
+}
 
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::ReconstructedParticle*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+template <typename HitMapT>
+std::unique_ptr<edm4hep::TrackerHitPlaneCollection>
+convertTrackerHitPlanes(const std::string &name,
+                        EVENT::LCCollection *LCCollection,
+                        HitMapT &TrackerHitPlaneMap) {
+  auto dest = std::make_unique<edm4hep::TrackerHitPlaneCollection>();
 
-      lval.setCharge(rval->getCharge());
-      auto& m = rval->getCovMatrix(); // 10 parameters
-      lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9]});
-      lval.setEnergy(rval->getEnergy());
-      lval.setGoodnessOfPID(rval->getGoodnessOfPID());
-      lval.setMass(rval->getMass());
-      lval.setMomentum(Vector3fFrom(rval->getMomentum()));
-      lval.setReferencePoint(rval->getReferencePoint());
-      lval.setPDG(rval->getType());
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::TrackerHitPlane *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, recoparticlesMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setType(rval->getType());
+    lval.setQuality(rval->getQuality());
+    lval.setTime(rval->getTime());
+    lval.setEDep(rval->getEDep());
+    lval.setEDepError(rval->getEDepError());
+    lval.setPosition(rval->getPosition());
+    lval.setU({rval->getU()[0], rval->getU()[1]});
+    lval.setV({rval->getV()[0], rval->getV()[1]});
+    lval.setDu(rval->getdU());
+    lval.setDv(rval->getdV());
+    auto &m = rval->getCovMatrix();
+    lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
 
-      // Need to convert the particle IDs here, since they are part of the reco
-      // particle collection in LCIO.
-      for (const auto lcioPid : rval->getParticleIDs()) {
-        auto pid = convertParticleID(lcioPid);
-        pid.setParticle(lval);
-        if (auto pidIt = particleIDs.find(pid.getAlgorithmType()); pidIt != particleIDs.end()) {
-          pidIt->second->push_back(pid);
-        }
-        else {
-          std::cerr << "ERROR: Found a PID object with an algorithm ID that is not known to the PIDHandler (id = "
-                    << pid.getAlgorithmType() << ")" << std::endl;
-        }
-      }
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackerHitPlaneMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-
-    std::vector<CollNamePair> results;
-    results.reserve(particleIDs.size() + 1);
-    results.emplace_back(name, std::move(dest));
-    for (auto& [id, coll] : particleIDs) {
-      results.emplace_back(getPIDCollName(name, pidHandler.getAlgorithmName(id)), std::move(coll));
-    }
-    return results;
   }
 
-  template<typename VertexMapT>
-  std::unique_ptr<edm4hep::VertexCollection>
-  convertVertices(const std::string& name, EVENT::LCCollection* LCCollection, VertexMapT& vertexMap)
-  {
-    auto dest = std::make_unique<edm4hep::VertexCollection>();
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::Vertex*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+  return dest;
+}
 
-      lval.setPrimary(rval->isPrimary() ? 1 : 0); // 1 for primary and 0 for not primary
-      lval.setChi2(rval->getChi2());
-      lval.setProbability(rval->getProbability());
-      lval.setPosition(rval->getPosition());
-      auto& m = rval->getCovMatrix(); // 6 parameters
-      lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
-      // FIXME: the algorithm type in LCIO is a string, but an integer is expected
-      // lval.setAlgorithmType(rval->getAlgorithmType());
-      // lval.setAssociatedParticle();  //set it when convert ReconstructedParticle
-      //
-      for (auto v : rval->getParameters()) {
-        lval.addToParameters(v);
-      }
+template <typename TrackMapT>
+std::unique_ptr<edm4hep::TrackCollection>
+convertTracks(const std::string &name, EVENT::LCCollection *LCCollection,
+              TrackMapT &TrackMap) {
+  auto dest = std::make_unique<edm4hep::TrackCollection>();
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, vertexMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval = static_cast<EVENT::Track *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    lval.setType(rval->getType());
+    lval.setChi2(rval->getChi2());
+    lval.setNdf(rval->getNdf());
+    lval.setDEdx(rval->getdEdx());
+    lval.setDEdxError(rval->getdEdxError());
+    lval.setRadiusOfInnermostHit(rval->getRadiusOfInnermostHit());
+
+    auto subdetectorHitNum = rval->getSubdetectorHitNumbers();
+    for (auto hitNum : subdetectorHitNum) {
+      lval.addToSubdetectorHitNumbers(hitNum);
     }
-    return dest;
+    auto &trackStates = rval->getTrackStates();
+    for (auto &trackState : trackStates) {
+      lval.addToTrackStates(convertTrackState(trackState));
+    }
+    auto quantities = edm4hep::Quantity{};
+    quantities.value = rval->getdEdx();
+    quantities.error = rval->getdEdxError();
+    lval.addToDxQuantities(quantities);
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
+    }
   }
 
-  template<typename SimTrHitMapT>
-  std::unique_ptr<edm4hep::SimTrackerHitCollection>
-  convertSimTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, SimTrHitMapT& SimTrHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::SimTrackerHitCollection>();
+  return dest;
+}
 
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::SimTrackerHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+template <typename HitMapT>
+std::unique_ptr<edm4hep::SimCalorimeterHitCollection>
+convertSimCalorimeterHits(const std::string &name,
+                          EVENT::LCCollection *LCCollection,
+                          HitMapT &SimCaloHitMap) {
+  auto dest = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::SimCalorimeterHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
 
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setEDep(rval->getEDep());
-      lval.setTime(rval->getTime());
-      lval.setPathLength(rval->getPathLength());
-      lval.setQuality(rval->getQuality());
-      lval.setPosition(rval->getPosition());
-      lval.setMomentum(rval->getMomentum());
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setEnergy(rval->getEnergy());
+    lval.setPosition(rval->getPosition());
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, SimTrHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, SimCaloHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-    return dest;
   }
 
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::RawTimeSeriesCollection>
-  convertTPCHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TPCHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::RawTimeSeriesCollection>();
+  return dest;
+}
 
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::TPCHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+template <typename HitMapT>
+std::unique_ptr<edm4hep::RawCalorimeterHitCollection>
+convertRawCalorimeterHits(const std::string &name,
+                          EVENT::LCCollection *LCCollection,
+                          HitMapT &rawCaloHitMap) {
+  auto dest = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
 
-      lval.setCellID(rval->getCellID());
-      lval.setTime(rval->getTime());
-      lval.setCharge(rval->getCharge());
-      lval.setQuality(rval->getQuality());
-      for (unsigned j = 0, M = rval->getNRawDataWords(); j < M; j++) {
-        lval.addToAdcCounts(rval->getRawDataWord(j));
-      }
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TPCHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::RawCalorimeterHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setAmplitude(rval->getAmplitude());
+    lval.setTimeStamp(rval->getTimeStamp());
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, rawCaloHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-
-    return dest;
   }
 
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::TrackerHit3DCollection>
-  convertTrackerHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::TrackerHit3DCollection>();
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::TrackerHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+  return dest;
+}
 
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setType(rval->getType());
-      lval.setQuality(rval->getQuality());
-      lval.setTime(rval->getTime());
-      lval.setEDep(rval->getEDep());
-      lval.setEDepError(rval->getEDepError());
-      lval.setPosition(rval->getPosition());
-      auto& m = rval->getCovMatrix();
-      lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
+template <typename HitMapT>
+std::unique_ptr<edm4hep::CalorimeterHitCollection>
+convertCalorimeterHits(const std::string &name,
+                       EVENT::LCCollection *LCCollection, HitMapT &caloHitMap) {
+  auto dest = std::make_unique<edm4hep::CalorimeterHitCollection>();
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackerHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval =
+        static_cast<EVENT::CalorimeterHit *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
+    uint64_t cellID = rval->getCellID1();
+    cellID = (cellID << 32) | rval->getCellID0();
+    lval.setCellID(cellID);
+    lval.setEnergy(rval->getEnergy());
+    lval.setEnergyError(rval->getEnergyError());
+    lval.setPosition(rval->getPosition());
+    lval.setTime(rval->getTime());
+    lval.setType(rval->getType());
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, caloHitMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
+      const auto existingId = existing.id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-    return dest;
   }
 
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::TrackerHitPlaneCollection>
-  convertTrackerHitPlanes(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& TrackerHitPlaneMap)
-  {
-    auto dest = std::make_unique<edm4hep::TrackerHitPlaneCollection>();
+  return dest;
+}
 
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::TrackerHitPlane*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+template <typename ClusterMapT>
+std::unique_ptr<edm4hep::ClusterCollection>
+convertClusters(const std::string &name, EVENT::LCCollection *LCCollection,
+                ClusterMapT &clusterMap) {
+  auto dest = std::make_unique<edm4hep::ClusterCollection>();
 
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setType(rval->getType());
-      lval.setQuality(rval->getQuality());
-      lval.setTime(rval->getTime());
-      lval.setEDep(rval->getEDep());
-      lval.setEDepError(rval->getEDepError());
-      lval.setPosition(rval->getPosition());
-      lval.setU({rval->getU()[0], rval->getU()[1]});
-      lval.setV({rval->getV()[0], rval->getV()[1]});
-      lval.setDu(rval->getdU());
-      lval.setDv(rval->getdV());
-      auto& m = rval->getCovMatrix();
-      lval.setCovMatrix({m[0], m[1], m[2], m[3], m[4], m[5]});
+  for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
+    auto *rval = static_cast<EVENT::Cluster *>(LCCollection->getElementAt(i));
+    auto lval = dest->create();
 
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackerHitPlaneMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
+    lval.setEnergy(rval->getEnergy());
+    lval.setEnergyError(rval->getEnergyError());
+    lval.setITheta(rval->getITheta());
+    lval.setPhi(rval->getIPhi());
+    lval.setPosition(rval->getPosition());
+    auto &m = rval->getPositionError();
+    lval.setPositionError({m[0], m[1], m[2], m[3], m[4], m[5]});
+    lval.setType(rval->getType());
+    lval.setDirectionError(Vector3fFrom(rval->getDirectionError()));
+
+    const auto [iterator, inserted] =
+        k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, clusterMap);
+    if (!inserted) {
+      auto existing = k4EDM4hep2LcioConv::detail::getKey(iterator);
+      const auto existingId = existing->id();
+      std::cerr << "EDM4hep element  " << existingId
+                << " did not get inserted. It belongs to the " << name
+                << " collection" << std::endl;
     }
-
-    return dest;
   }
+  return dest;
+}
 
-  template<typename TrackMapT>
-  std::unique_ptr<edm4hep::TrackCollection>
-  convertTracks(const std::string& name, EVENT::LCCollection* LCCollection, TrackMapT& TrackMap)
-  {
-    auto dest = std::make_unique<edm4hep::TrackCollection>();
-
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::Track*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
-
-      lval.setType(rval->getType());
-      lval.setChi2(rval->getChi2());
-      lval.setNdf(rval->getNdf());
-      lval.setDEdx(rval->getdEdx());
-      lval.setDEdxError(rval->getdEdxError());
-      lval.setRadiusOfInnermostHit(rval->getRadiusOfInnermostHit());
-
-      auto subdetectorHitNum = rval->getSubdetectorHitNumbers();
-      for (auto hitNum : subdetectorHitNum) {
-        lval.addToSubdetectorHitNumbers(hitNum);
-      }
-      auto& trackStates = rval->getTrackStates();
-      for (auto& trackState : trackStates) {
-        lval.addToTrackStates(convertTrackState(trackState));
-      }
-      auto quantities = edm4hep::Quantity {};
-      quantities.value = rval->getdEdx();
-      quantities.error = rval->getdEdxError();
-      lval.addToDxQuantities(quantities);
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, TrackMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
-    }
-
-    return dest;
+template <typename ObjectMappingT>
+std::vector<CollNamePair> convertCollection(const std::string &name,
+                                            EVENT::LCCollection *LCCollection,
+                                            ObjectMappingT &typeMapping) {
+  const auto &type = LCCollection->getTypeName();
+  std::vector<CollNamePair> retColls;
+  if (type == "MCParticle") {
+    retColls.emplace_back(
+        name, convertMCParticles(name, LCCollection, typeMapping.mcParticles));
+  } else if (type == "ReconstructedParticle") {
+    return convertReconstructedParticles(name, LCCollection,
+                                         typeMapping.recoParticles);
+  } else if (type == "Vertex") {
+    retColls.emplace_back(
+        name, convertVertices(name, LCCollection, typeMapping.vertices));
+  } else if (type == "Track") {
+    retColls.emplace_back(
+        name, convertTracks(name, LCCollection, typeMapping.tracks));
+  } else if (type == "Cluster") {
+    retColls.emplace_back(
+        name, convertClusters(name, LCCollection, typeMapping.clusters));
+  } else if (type == "SimCalorimeterHit") {
+    retColls.emplace_back(
+        name,
+        convertSimCalorimeterHits(name, LCCollection, typeMapping.simCaloHits));
+  } else if (type == "RawCalorimeterHit") {
+    retColls.emplace_back(
+        name,
+        convertRawCalorimeterHits(name, LCCollection, typeMapping.rawCaloHits));
+  } else if (type == "CalorimeterHit") {
+    retColls.emplace_back(
+        name, convertCalorimeterHits(name, LCCollection, typeMapping.caloHits));
+  } else if (type == "SimTrackerHit") {
+    retColls.emplace_back(
+        name,
+        convertSimTrackerHits(name, LCCollection, typeMapping.simTrackerHits));
+  } else if (type == "TPCHit") {
+    retColls.emplace_back(
+        name, convertTPCHits(name, LCCollection, typeMapping.tpcHits));
+  } else if (type == "TrackerHit") {
+    retColls.emplace_back(
+        name, convertTrackerHits(name, LCCollection, typeMapping.trackerHits));
+  } else if (type == "TrackerHitPlane") {
+    retColls.emplace_back(
+        name, convertTrackerHitPlanes(name, LCCollection,
+                                      typeMapping.trackerHitPlanes));
+  } else if (type == "LCIntVec") {
+    return convertLCVec<EVENT::LCIntVec>(name, LCCollection);
+  } else if (type == "LCFloatVec") {
+    return convertLCVec<EVENT::LCFloatVec>(name, LCCollection);
+  } else if (type != "LCRelation") {
+    std::cerr << type
+              << " is a collection type for which no known conversion exists."
+              << std::endl;
   }
+  return retColls;
+}
 
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::SimCalorimeterHitCollection>
-  convertSimCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& SimCaloHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::SimCalorimeterHitCollection>();
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::SimCalorimeterHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
+template <typename HitMapT, typename MCParticleMapT>
+std::unique_ptr<edm4hep::CaloHitContributionCollection>
+createCaloHitContributions(HitMapT &SimCaloHitMap,
+                           const MCParticleMapT &mcparticlesMap) {
+  auto contrCollection =
+      std::make_unique<edm4hep::CaloHitContributionCollection>();
+  for (auto &[lcioHit, edmHit] : SimCaloHitMap) {
+    auto NMCParticle = lcioHit->getNMCParticles();
+    for (int j = 0; j < NMCParticle; j++) {
+      auto edm_contr = contrCollection->create();
+      edmHit.addToContributions(edm_contr);
 
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setEnergy(rval->getEnergy());
-      lval.setPosition(rval->getPosition());
-
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, SimCaloHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
-    }
-
-    return dest;
-  }
-
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::RawCalorimeterHitCollection>
-  convertRawCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& rawCaloHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::RawCalorimeterHitCollection>();
-
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::RawCalorimeterHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
-
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setAmplitude(rval->getAmplitude());
-      lval.setTimeStamp(rval->getTimeStamp());
-
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, rawCaloHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
-    }
-
-    return dest;
-  }
-
-  template<typename HitMapT>
-  std::unique_ptr<edm4hep::CalorimeterHitCollection>
-  convertCalorimeterHits(const std::string& name, EVENT::LCCollection* LCCollection, HitMapT& caloHitMap)
-  {
-    auto dest = std::make_unique<edm4hep::CalorimeterHitCollection>();
-
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::CalorimeterHit*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
-      uint64_t cellID = rval->getCellID1();
-      cellID = (cellID << 32) | rval->getCellID0();
-      lval.setCellID(cellID);
-      lval.setEnergy(rval->getEnergy());
-      lval.setEnergyError(rval->getEnergyError());
-      lval.setPosition(rval->getPosition());
-      lval.setTime(rval->getTime());
-      lval.setType(rval->getType());
-
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, caloHitMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getMapped(iterator);
-        const auto existingId = existing.id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
-    }
-
-    return dest;
-  }
-
-  template<typename ClusterMapT>
-  std::unique_ptr<edm4hep::ClusterCollection>
-  convertClusters(const std::string& name, EVENT::LCCollection* LCCollection, ClusterMapT& clusterMap)
-  {
-    auto dest = std::make_unique<edm4hep::ClusterCollection>();
-
-    for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
-      auto* rval = static_cast<EVENT::Cluster*>(LCCollection->getElementAt(i));
-      auto lval = dest->create();
-
-      lval.setEnergy(rval->getEnergy());
-      lval.setEnergyError(rval->getEnergyError());
-      lval.setITheta(rval->getITheta());
-      lval.setPhi(rval->getIPhi());
-      lval.setPosition(rval->getPosition());
-      auto& m = rval->getPositionError();
-      lval.setPositionError({m[0], m[1], m[2], m[3], m[4], m[5]});
-      lval.setType(rval->getType());
-      lval.setDirectionError(Vector3fFrom(rval->getDirectionError()));
-
-      const auto [iterator, inserted] = k4EDM4hep2LcioConv::detail::mapInsert(rval, lval, clusterMap);
-      if (!inserted) {
-        auto existing = k4EDM4hep2LcioConv::detail::getKey(iterator);
-        const auto existingId = existing->id();
-        std::cerr << "EDM4hep element  " << existingId << " did not get inserted. It belongs to the " << name
-                  << " collection" << std::endl;
-      }
-    }
-    return dest;
-  }
-
-  template<typename ObjectMappingT>
-  std::vector<CollNamePair>
-  convertCollection(const std::string& name, EVENT::LCCollection* LCCollection, ObjectMappingT& typeMapping)
-  {
-    const auto& type = LCCollection->getTypeName();
-    std::vector<CollNamePair> retColls;
-    if (type == "MCParticle") {
-      retColls.emplace_back(name, convertMCParticles(name, LCCollection, typeMapping.mcParticles));
-    }
-    else if (type == "ReconstructedParticle") {
-      return convertReconstructedParticles(name, LCCollection, typeMapping.recoParticles);
-    }
-    else if (type == "Vertex") {
-      retColls.emplace_back(name, convertVertices(name, LCCollection, typeMapping.vertices));
-    }
-    else if (type == "Track") {
-      retColls.emplace_back(name, convertTracks(name, LCCollection, typeMapping.tracks));
-    }
-    else if (type == "Cluster") {
-      retColls.emplace_back(name, convertClusters(name, LCCollection, typeMapping.clusters));
-    }
-    else if (type == "SimCalorimeterHit") {
-      retColls.emplace_back(name, convertSimCalorimeterHits(name, LCCollection, typeMapping.simCaloHits));
-    }
-    else if (type == "RawCalorimeterHit") {
-      retColls.emplace_back(name, convertRawCalorimeterHits(name, LCCollection, typeMapping.rawCaloHits));
-    }
-    else if (type == "CalorimeterHit") {
-      retColls.emplace_back(name, convertCalorimeterHits(name, LCCollection, typeMapping.caloHits));
-    }
-    else if (type == "SimTrackerHit") {
-      retColls.emplace_back(name, convertSimTrackerHits(name, LCCollection, typeMapping.simTrackerHits));
-    }
-    else if (type == "TPCHit") {
-      retColls.emplace_back(name, convertTPCHits(name, LCCollection, typeMapping.tpcHits));
-    }
-    else if (type == "TrackerHit") {
-      retColls.emplace_back(name, convertTrackerHits(name, LCCollection, typeMapping.trackerHits));
-    }
-    else if (type == "TrackerHitPlane") {
-      retColls.emplace_back(name, convertTrackerHitPlanes(name, LCCollection, typeMapping.trackerHitPlanes));
-    }
-    else if (type == "LCIntVec") {
-      return convertLCVec<EVENT::LCIntVec>(name, LCCollection);
-    }
-    else if (type == "LCFloatVec") {
-      return convertLCVec<EVENT::LCFloatVec>(name, LCCollection);
-    }
-    else if (type != "LCRelation") {
-      std::cerr << type << " is a collection type for which no known conversion exists." << std::endl;
-    }
-    return retColls;
-  }
-
-  template<typename HitMapT, typename MCParticleMapT>
-  std::unique_ptr<edm4hep::CaloHitContributionCollection> createCaloHitContributions(
-    HitMapT& SimCaloHitMap,
-    const MCParticleMapT& mcparticlesMap)
-  {
-    auto contrCollection = std::make_unique<edm4hep::CaloHitContributionCollection>();
-    for (auto& [lcioHit, edmHit] : SimCaloHitMap) {
-      auto NMCParticle = lcioHit->getNMCParticles();
-      for (int j = 0; j < NMCParticle; j++) {
-        auto edm_contr = contrCollection->create();
-        edmHit.addToContributions(edm_contr);
-
-        edm_contr.setPDG(lcioHit->getPDGCont(j));
-        edm_contr.setTime(lcioHit->getTimeCont(j));
-        edm_contr.setEnergy(lcioHit->getEnergyCont(j));
-        edm_contr.setStepPosition(lcioHit->getStepPosition(j));
-        auto lcioParticle = (lcioHit->getParticleCont(j));
-        if (lcioParticle != nullptr) {
-          if (const auto edm4hepParticle = k4EDM4hep2LcioConv::detail::mapLookupTo(lcioParticle, mcparticlesMap)) {
-            edm_contr.setParticle(edm4hepParticle.value());
-          }
-          else {
-            std::cerr << "Cannot find corresponding EDM4hep MCParticle for a LCIO MCParticle, "
-                      << "while trying to build CaloHitContributions " << std::endl;
-          }
-        }
-      }
-    }
-    return contrCollection;
-  }
-
-  template<typename MCParticleMapT, typename MCParticleLookupMapT>
-  void resolveRelationsMCParticles(MCParticleMapT& mcparticlesMap, const MCParticleLookupMapT& lookupMap)
-  {
-    for (auto& [lcio, edm] : mcparticlesMap) {
-      auto daughters = lcio->getDaughters();
-      auto parents = lcio->getParents();
-
-      for (auto d : daughters) {
-        if (d == nullptr) {
-          continue;
-        }
-        if (const auto edmD = k4EDM4hep2LcioConv::detail::mapLookupTo(d, lookupMap)) {
-          edm.addToDaughters(edmD.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep MCParticle for an LCIO MCParticle, "
-                       "while trying to resolve the daughters of MCParticles"
+      edm_contr.setPDG(lcioHit->getPDGCont(j));
+      edm_contr.setTime(lcioHit->getTimeCont(j));
+      edm_contr.setEnergy(lcioHit->getEnergyCont(j));
+      edm_contr.setStepPosition(lcioHit->getStepPosition(j));
+      auto lcioParticle = (lcioHit->getParticleCont(j));
+      if (lcioParticle != nullptr) {
+        if (const auto edm4hepParticle =
+                k4EDM4hep2LcioConv::detail::mapLookupTo(lcioParticle,
+                                                        mcparticlesMap)) {
+          edm_contr.setParticle(edm4hepParticle.value());
+        } else {
+          std::cerr << "Cannot find corresponding EDM4hep MCParticle for a "
+                       "LCIO MCParticle, "
+                    << "while trying to build CaloHitContributions "
                     << std::endl;
         }
       }
-      for (auto p : parents) {
-        if (p == nullptr) {
-          continue;
-        }
-        if (const auto edmP = k4EDM4hep2LcioConv::detail::mapLookupTo(p, lookupMap)) {
-          edm.addToParents(edmP.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep MCParticle for the LCIO MCParticle, "
-                       "while trying to resolve the parents of MCParticles Collections"
-                    << std::endl;
-        }
-      }
     }
   }
+  return contrCollection;
+}
 
-  template<typename HitMapT, typename MCParticleMapT>
-  void resolveRelationsSimTrackerHits(HitMapT& SimTrHitMap, const MCParticleMapT& mcparticlesMap)
-  {
-    for (auto& [lcio, edm] : SimTrHitMap) {
-      auto mcps = lcio->getMCParticle();
-      if (mcps == nullptr) {
+template <typename MCParticleMapT, typename MCParticleLookupMapT>
+void resolveRelationsMCParticles(MCParticleMapT &mcparticlesMap,
+                                 const MCParticleLookupMapT &lookupMap) {
+  for (auto &[lcio, edm] : mcparticlesMap) {
+    auto daughters = lcio->getDaughters();
+    auto parents = lcio->getParents();
+
+    for (auto d : daughters) {
+      if (d == nullptr) {
         continue;
       }
-      if (const auto edmP = k4EDM4hep2LcioConv::detail::mapLookupTo(mcps, mcparticlesMap)) {
-        edm.setParticle(edmP.value());
+      if (const auto edmD =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(d, lookupMap)) {
+        edm.addToDaughters(edmD.value());
+      } else {
+        std::cerr << "Cannot find corresponding EDM4hep MCParticle for an LCIO "
+                     "MCParticle, "
+                     "while trying to resolve the daughters of MCParticles"
+                  << std::endl;
       }
-      else {
-        std::cerr << "Cannot find corresponding EDM4hep MCParticle for the LCIO MCParticle, "
-                     "while trying to resolve the SimTrackHit Relations"
+    }
+    for (auto p : parents) {
+      if (p == nullptr) {
+        continue;
+      }
+      if (const auto edmP =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(p, lookupMap)) {
+        edm.addToParents(edmP.value());
+      } else {
+        std::cerr
+            << "Cannot find corresponding EDM4hep MCParticle for the LCIO "
+               "MCParticle, "
+               "while trying to resolve the parents of MCParticles Collections"
+            << std::endl;
+      }
+    }
+  }
+}
+
+template <typename HitMapT, typename MCParticleMapT>
+void resolveRelationsSimTrackerHits(HitMapT &SimTrHitMap,
+                                    const MCParticleMapT &mcparticlesMap) {
+  for (auto &[lcio, edm] : SimTrHitMap) {
+    auto mcps = lcio->getMCParticle();
+    if (mcps == nullptr) {
+      continue;
+    }
+    if (const auto edmP =
+            k4EDM4hep2LcioConv::detail::mapLookupTo(mcps, mcparticlesMap)) {
+      edm.setParticle(edmP.value());
+    } else {
+      std::cerr << "Cannot find corresponding EDM4hep MCParticle for the LCIO "
+                   "MCParticle, "
+                   "while trying to resolve the SimTrackHit Relations"
+                << std::endl;
+    }
+  }
+}
+
+template <typename RecoParticleMapT, typename RecoParticleLookupMapT,
+          typename VertexMapT, typename ClusterMapT, typename TrackMapT>
+void resolveRelationsRecoParticles(RecoParticleMapT &recoparticlesMap,
+                                   const RecoParticleLookupMapT &recoLookupMap,
+                                   const VertexMapT &vertexMap,
+                                   const ClusterMapT &clusterMap,
+                                   const TrackMapT &tracksMap) {
+  for (auto &[lcio, edm] : recoparticlesMap) {
+
+    const auto &vertex = lcio->getStartVertex();
+    if (vertex != nullptr) {
+      if (const auto edmV =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(vertex, vertexMap)) {
+        edm.setStartVertex(edmV.value());
+      } else {
+        std::cerr
+            << "Cannot find corresponding EDM4hep Vertex for a LCIO Vertex, "
+               "while trying to resolve the ReconstructedParticle Relations "
+            << std::endl;
+      }
+    }
+
+    auto clusters = lcio->getClusters();
+    for (auto c : clusters) {
+      if (c == nullptr) {
+        continue;
+      }
+      if (const auto edmC =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(c, clusterMap)) {
+        edm.addToClusters(edmC.value());
+      } else {
+        std::cerr
+            << "Cannot find corresponding EDM4hep Cluster for a LCIO Cluster, "
+               "while trying to resolve the ReconstructedParticle Relations"
+            << std::endl;
+      }
+    }
+
+    auto tracks = lcio->getTracks();
+    for (auto t : tracks) {
+      if (t == nullptr) {
+        continue;
+      }
+      if (const auto edmT =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(t, tracksMap)) {
+        edm.addToTracks(edmT.value());
+      } else {
+        std::cerr
+            << "Cannot find corresponding EDM4hep Tracks for a LCIO Tracks, "
+               "while trying to resolve the ReconstructedParticle Relations"
+            << std::endl;
+      }
+    }
+
+    auto parents = lcio->getParticles();
+    for (auto p : parents) {
+      if (p == nullptr) {
+        continue;
+      }
+      if (const auto edmReco =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(p, recoLookupMap)) {
+        edm.addToParticles(edmReco.value());
+      } else {
+        std::cerr << "Cannot find corresponding EDM4hep RecoParticle for a "
+                     "LCIO RecoParticle, "
+                     "while trying to resolve the ReconstructedParticles "
+                     "parents Relations"
                   << std::endl;
       }
     }
   }
+}
 
-  template<
-    typename RecoParticleMapT,
-    typename RecoParticleLookupMapT,
-    typename VertexMapT,
-    typename ClusterMapT,
-    typename TrackMapT>
-  void resolveRelationsRecoParticles(
-    RecoParticleMapT& recoparticlesMap,
-    const RecoParticleLookupMapT& recoLookupMap,
-    const VertexMapT& vertexMap,
-    const ClusterMapT& clusterMap,
-    const TrackMapT& tracksMap)
-  {
-    for (auto& [lcio, edm] : recoparticlesMap) {
-
-      const auto& vertex = lcio->getStartVertex();
-      if (vertex != nullptr) {
-        if (const auto edmV = k4EDM4hep2LcioConv::detail::mapLookupTo(vertex, vertexMap)) {
-          edm.setStartVertex(edmV.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep Vertex for a LCIO Vertex, "
-                       "while trying to resolve the ReconstructedParticle Relations "
-                    << std::endl;
-        }
-      }
-
-      auto clusters = lcio->getClusters();
-      for (auto c : clusters) {
-        if (c == nullptr) {
-          continue;
-        }
-        if (const auto edmC = k4EDM4hep2LcioConv::detail::mapLookupTo(c, clusterMap)) {
-          edm.addToClusters(edmC.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep Cluster for a LCIO Cluster, "
-                       "while trying to resolve the ReconstructedParticle Relations"
-                    << std::endl;
-        }
-      }
-
-      auto tracks = lcio->getTracks();
-      for (auto t : tracks) {
-        if (t == nullptr) {
-          continue;
-        }
-        if (const auto edmT = k4EDM4hep2LcioConv::detail::mapLookupTo(t, tracksMap)) {
-          edm.addToTracks(edmT.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep Tracks for a LCIO Tracks, "
-                       "while trying to resolve the ReconstructedParticle Relations"
-                    << std::endl;
-        }
-      }
-
-      auto parents = lcio->getParticles();
-      for (auto p : parents) {
-        if (p == nullptr) {
-          continue;
-        }
-        if (const auto edmReco = k4EDM4hep2LcioConv::detail::mapLookupTo(p, recoLookupMap)) {
-          edm.addToParticles(edmReco.value());
-        }
-        else {
-          std::cerr << "Cannot find corresponding EDM4hep RecoParticle for a LCIO RecoParticle, "
-                       "while trying to resolve the ReconstructedParticles parents Relations"
-                    << std::endl;
-        }
-      }
-    }
-  }
-
-  template<typename ClusterMapT, typename CaloHitMapT>
-  void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloHitMap)
-  {
-    for (auto& [lcio, edm] : clustersMap) {
-      auto clusters = lcio->getClusters();
-      auto calohits = lcio->getCalorimeterHits();
-      auto shape = lcio->getShape();
-      auto subdetectorEnergies = lcio->getSubdetectorEnergies();
-      for (auto c : clusters) {
-        if (c == nullptr) {
-          continue;
-        }
-        if (const auto edmC = k4EDM4hep2LcioConv::detail::mapLookupTo(c, clustersMap)) {
-          edm.addToClusters(edmC.value());
-        }
-        else {
-          std::cerr << "Couldn't find cluster to add to Relations in edm" << std::endl;
-        }
-      }
-      for (auto cal : calohits) {
-        if (cal == nullptr) {
-          continue;
-        }
-        if (const auto edmCaloHit = k4EDM4hep2LcioConv::detail::mapLookupTo(cal, caloHitMap)) {
-          edm.addToHits(edmCaloHit.value());
-        }
-        else {
-          std::cerr << "Couldn't find CaloHit to add to Relations for Clusters in edm" << std::endl;
-        }
-      }
-      for (auto s : shape) {
-        edm.addToShapeParameters(s);
-      }
-      for (auto subE : subdetectorEnergies) {
-        edm.addToSubdetectorEnergies(subE);
-      }
-    }
-  }
-
-  template<typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT, typename TPCHitMapT>
-  void resolveRelationsTracks(
-    TrackMapT& tracksMap,
-    const TrackHitMapT& trackerHitMap,
-    const THPlaneHitMapT& trackerHitPlaneMap,
-    const TPCHitMapT&)
-  {
-    for (auto& [lcio, edm] : tracksMap) {
-      auto tracks = lcio->getTracks();
-      for (auto t : tracks) {
-        if (t == nullptr) {
-          continue;
-        }
-        if (const auto track = k4EDM4hep2LcioConv::detail::mapLookupTo(t, tracksMap)) {
-          edm.addToTracks(track.value());
-        }
-        else {
-          // std::cerr << "Couldn't find tracks to add to Tracks Relations in edm" << std::endl;
-        }
-      }
-      const auto trackerHits = lcio->getTrackerHits();
-      for (const auto th : trackerHits) {
-        bool found = false;
-        if (th == nullptr) {
-          continue;
-        }
-        if (const auto typedTH = dynamic_cast<EVENT::TrackerHitPlane*>(th)) {
-          if (const auto trHit = k4EDM4hep2LcioConv::detail::mapLookupTo(typedTH, trackerHitPlaneMap)) {
-            edm.addToTrackerHits(trHit.value());
-            found = true;
-          }
-        }
-        else if (auto typedTH = dynamic_cast<EVENT::TrackerHit*>(th)) {
-          if (const auto trHit = k4EDM4hep2LcioConv::detail::mapLookupTo(typedTH, trackerHitMap)) {
-            edm.addToTrackerHits(trHit.value());
-            found = true;
-          }
-        }
-
-        if (!found) {
-          std::cerr << "Couldn't find a edm4hep TrackerHit for an LCIO TrackerHit when resolving "
-                    << "relations for a Track" << std::endl;
-        }
-      }
-    }
-  }
-
-  template<typename VertexMapT, typename RecoParticleMapT>
-  void resolveRelationsVertices(VertexMapT& vertexMap, const RecoParticleMapT& recoparticleMap)
-  {
-    for (auto& [lcio, edm] : vertexMap) {
-      auto recoparticle = lcio->getAssociatedParticle();
-      if (recoparticle == nullptr) {
+template <typename ClusterMapT, typename CaloHitMapT>
+void resolveRelationsClusters(ClusterMapT &clustersMap,
+                              const CaloHitMapT &caloHitMap) {
+  for (auto &[lcio, edm] : clustersMap) {
+    auto clusters = lcio->getClusters();
+    auto calohits = lcio->getCalorimeterHits();
+    auto shape = lcio->getShape();
+    auto subdetectorEnergies = lcio->getSubdetectorEnergies();
+    for (auto c : clusters) {
+      if (c == nullptr) {
         continue;
       }
-      if (const auto recoP = k4EDM4hep2LcioConv::detail::mapLookupTo(recoparticle, recoparticleMap)) {
-        edm.setAssociatedParticle(recoP.value());
-      }
-      else {
-        std::cerr << "Couldn't find associated Particle to add to Vertex "
-                  << "Relations in edm" << std::endl;
-      }
-    }
-  }
-
-  template<typename ObjectMappingT>
-  void resolveRelations(ObjectMappingT& typeMapping)
-  {
-    resolveRelations(typeMapping, typeMapping);
-  }
-
-  template<typename ObjectMappingT, typename ObjectMappingU>
-  void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps)
-  {
-    resolveRelationsMCParticles(updateMaps.mcParticles, lookupMaps.mcParticles);
-    resolveRelationsRecoParticles(
-      updateMaps.recoParticles, lookupMaps.recoParticles, lookupMaps.vertices, lookupMaps.clusters, lookupMaps.tracks);
-    resolveRelationsSimTrackerHits(updateMaps.simTrackerHits, lookupMaps.mcParticles);
-    resolveRelationsClusters(updateMaps.clusters, lookupMaps.caloHits);
-    resolveRelationsTracks(updateMaps.tracks, lookupMaps.trackerHits, lookupMaps.trackerHitPlanes, lookupMaps.tpcHits);
-    resolveRelationsVertices(updateMaps.vertices, lookupMaps.recoParticles);
-  }
-
-  template<
-    typename CollT,
-    bool Reverse,
-    typename FromMapT,
-    typename ToMapT,
-    typename FromLCIOT,
-    typename ToLCIOT,
-    typename FromEDM4hepT,
-    typename ToEDM4hepT>
-  std::unique_ptr<CollT>
-  createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap, const ToMapT& toMap)
-  {
-    auto assocColl = std::make_unique<CollT>();
-    auto relIter = UTIL::LCIterator<EVENT::LCRelation>(relations);
-
-    while (const auto rel = relIter.next()) {
-      auto assoc = assocColl->create();
-      assoc.setWeight(rel->getWeight());
-      const auto lcioTo = static_cast<ToLCIOT*>(rel->getTo());
-      const auto lcioFrom = static_cast<FromLCIOT*>(rel->getFrom());
-      const auto edm4hepTo = k4EDM4hep2LcioConv::detail::mapLookupTo(lcioTo, toMap);
-      const auto edm4hepFrom = k4EDM4hep2LcioConv::detail::mapLookupTo(lcioFrom, fromMap);
-      if (edm4hepTo.has_value() && edm4hepFrom.has_value()) {
-        if constexpr (Reverse) {
-          if constexpr (std::is_same_v<k4EDM4hep2LcioConv::detail::mutable_t<ToEDM4hepT>, edm4hep::MutableVertex>) {
-            assoc.setVertex(*edm4hepTo);
-          }
-          else {
-            assoc.setSim(*edm4hepTo);
-          }
-          assoc.setRec(*edm4hepFrom);
-        }
-        else {
-          if constexpr (std::is_same_v<k4EDM4hep2LcioConv::detail::mutable_t<FromEDM4hepT>, edm4hep::MutableVertex>) {
-            assoc.setVertex(*edm4hepFrom);
-          }
-          else {
-            assoc.setSim(*edm4hepFrom);
-          }
-          assoc.setRec(*edm4hepTo);
-        }
+      if (const auto edmC =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(c, clustersMap)) {
+        edm.addToClusters(edmC.value());
+      } else {
+        std::cerr << "Couldn't find cluster to add to Relations in edm"
+                  << std::endl;
       }
     }
-
-    return assocColl;
-  }
-
-  template<typename ObjectMappingT>
-  std::vector<CollNamePair> createAssociations(
-    const ObjectMappingT& typeMapping,
-    const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation)
-  {
-    std::vector<CollNamePair> assoCollVec;
-    for (const auto& [name, relations] : LCRelation) {
-      const auto& params = relations->getParameters();
-
-      const auto& fromType = params.getStringVal("FromType");
-      const auto& toType = params.getStringVal("ToType");
-      if (fromType.empty() || toType.empty()) {
-        std::cerr << "LCRelation collection " << name << " has missing FromType or ToType parameters. "
-                  << "Cannot convert it without this information." << std::endl;
+    for (auto cal : calohits) {
+      if (cal == nullptr) {
         continue;
       }
+      if (const auto edmCaloHit =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(cal, caloHitMap)) {
+        edm.addToHits(edmCaloHit.value());
+      } else {
+        std::cerr
+            << "Couldn't find CaloHit to add to Relations for Clusters in edm"
+            << std::endl;
+      }
+    }
+    for (auto s : shape) {
+      edm.addToShapeParameters(s);
+    }
+    for (auto subE : subdetectorEnergies) {
+      edm.addToSubdetectorEnergies(subE);
+    }
+  }
+}
 
-      if (fromType == "MCParticle" && toType == "ReconstructedParticle") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoParticleAssociationCollection, false>(
+template <typename TrackMapT, typename TrackHitMapT, typename THPlaneHitMapT,
+          typename TPCHitMapT>
+void resolveRelationsTracks(TrackMapT &tracksMap,
+                            const TrackHitMapT &trackerHitMap,
+                            const THPlaneHitMapT &trackerHitPlaneMap,
+                            const TPCHitMapT &) {
+  for (auto &[lcio, edm] : tracksMap) {
+    auto tracks = lcio->getTracks();
+    for (auto t : tracks) {
+      if (t == nullptr) {
+        continue;
+      }
+      if (const auto track =
+              k4EDM4hep2LcioConv::detail::mapLookupTo(t, tracksMap)) {
+        edm.addToTracks(track.value());
+      } else {
+        // std::cerr << "Couldn't find tracks to add to Tracks Relations in edm"
+        // << std::endl;
+      }
+    }
+    const auto trackerHits = lcio->getTrackerHits();
+    for (const auto th : trackerHits) {
+      bool found = false;
+      if (th == nullptr) {
+        continue;
+      }
+      if (const auto typedTH = dynamic_cast<EVENT::TrackerHitPlane *>(th)) {
+        if (const auto trHit = k4EDM4hep2LcioConv::detail::mapLookupTo(
+                typedTH, trackerHitPlaneMap)) {
+          edm.addToTrackerHits(trHit.value());
+          found = true;
+        }
+      } else if (auto typedTH = dynamic_cast<EVENT::TrackerHit *>(th)) {
+        if (const auto trHit = k4EDM4hep2LcioConv::detail::mapLookupTo(
+                typedTH, trackerHitMap)) {
+          edm.addToTrackerHits(trHit.value());
+          found = true;
+        }
+      }
+
+      if (!found) {
+        std::cerr << "Couldn't find a edm4hep TrackerHit for an LCIO "
+                     "TrackerHit when resolving "
+                  << "relations for a Track" << std::endl;
+      }
+    }
+  }
+}
+
+template <typename VertexMapT, typename RecoParticleMapT>
+void resolveRelationsVertices(VertexMapT &vertexMap,
+                              const RecoParticleMapT &recoparticleMap) {
+  for (auto &[lcio, edm] : vertexMap) {
+    auto recoparticle = lcio->getAssociatedParticle();
+    if (recoparticle == nullptr) {
+      continue;
+    }
+    if (const auto recoP = k4EDM4hep2LcioConv::detail::mapLookupTo(
+            recoparticle, recoparticleMap)) {
+      edm.setAssociatedParticle(recoP.value());
+    } else {
+      std::cerr << "Couldn't find associated Particle to add to Vertex "
+                << "Relations in edm" << std::endl;
+    }
+  }
+}
+
+template <typename ObjectMappingT>
+void resolveRelations(ObjectMappingT &typeMapping) {
+  resolveRelations(typeMapping, typeMapping);
+}
+
+template <typename ObjectMappingT, typename ObjectMappingU>
+void resolveRelations(ObjectMappingT &updateMaps,
+                      const ObjectMappingU &lookupMaps) {
+  resolveRelationsMCParticles(updateMaps.mcParticles, lookupMaps.mcParticles);
+  resolveRelationsRecoParticles(updateMaps.recoParticles,
+                                lookupMaps.recoParticles, lookupMaps.vertices,
+                                lookupMaps.clusters, lookupMaps.tracks);
+  resolveRelationsSimTrackerHits(updateMaps.simTrackerHits,
+                                 lookupMaps.mcParticles);
+  resolveRelationsClusters(updateMaps.clusters, lookupMaps.caloHits);
+  resolveRelationsTracks(updateMaps.tracks, lookupMaps.trackerHits,
+                         lookupMaps.trackerHitPlanes, lookupMaps.tpcHits);
+  resolveRelationsVertices(updateMaps.vertices, lookupMaps.recoParticles);
+}
+
+template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
+          typename FromLCIOT, typename ToLCIOT, typename FromEDM4hepT,
+          typename ToEDM4hepT>
+std::unique_ptr<CollT>
+createAssociationCollection(EVENT::LCCollection *relations,
+                            const FromMapT &fromMap, const ToMapT &toMap) {
+  auto assocColl = std::make_unique<CollT>();
+  auto relIter = UTIL::LCIterator<EVENT::LCRelation>(relations);
+
+  while (const auto rel = relIter.next()) {
+    auto assoc = assocColl->create();
+    assoc.setWeight(rel->getWeight());
+    const auto lcioTo = static_cast<ToLCIOT *>(rel->getTo());
+    const auto lcioFrom = static_cast<FromLCIOT *>(rel->getFrom());
+    const auto edm4hepTo =
+        k4EDM4hep2LcioConv::detail::mapLookupTo(lcioTo, toMap);
+    const auto edm4hepFrom =
+        k4EDM4hep2LcioConv::detail::mapLookupTo(lcioFrom, fromMap);
+    if (edm4hepTo.has_value() && edm4hepFrom.has_value()) {
+      if constexpr (Reverse) {
+        if constexpr (std::is_same_v<
+                          k4EDM4hep2LcioConv::detail::mutable_t<ToEDM4hepT>,
+                          edm4hep::MutableVertex>) {
+          assoc.setVertex(*edm4hepTo);
+        } else {
+          assoc.setSim(*edm4hepTo);
+        }
+        assoc.setRec(*edm4hepFrom);
+      } else {
+        if constexpr (std::is_same_v<
+                          k4EDM4hep2LcioConv::detail::mutable_t<FromEDM4hepT>,
+                          edm4hep::MutableVertex>) {
+          assoc.setVertex(*edm4hepFrom);
+        } else {
+          assoc.setSim(*edm4hepFrom);
+        }
+        assoc.setRec(*edm4hepTo);
+      }
+    }
+  }
+
+  return assocColl;
+}
+
+template <typename ObjectMappingT>
+std::vector<CollNamePair> createAssociations(
+    const ObjectMappingT &typeMapping,
+    const std::vector<std::pair<std::string, EVENT::LCCollection *>>
+        &LCRelation) {
+  std::vector<CollNamePair> assoCollVec;
+  for (const auto &[name, relations] : LCRelation) {
+    const auto &params = relations->getParameters();
+
+    const auto &fromType = params.getStringVal("FromType");
+    const auto &toType = params.getStringVal("ToType");
+    if (fromType.empty() || toType.empty()) {
+      std::cerr << "LCRelation collection " << name
+                << " has missing FromType or ToType parameters. "
+                << "Cannot convert it without this information." << std::endl;
+      continue;
+    }
+
+    if (fromType == "MCParticle" && toType == "ReconstructedParticle") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoParticleAssociationCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.recoParticles);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "ReconstructedParticle" && toType == "MCParticle") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoParticleAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "ReconstructedParticle" && toType == "MCParticle") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoParticleAssociationCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.mcParticles);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "CalorimeterHit" && toType == "SimCalorimeterHit") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection, true>(
-          relations, typeMapping.caloHits, typeMapping.simCaloHits);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "SimCalorimeterHit" && toType == "CalorimeterHit") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection, false>(
-          relations, typeMapping.simCaloHits, typeMapping.caloHits);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "Cluster" && toType == "MCParticle") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoClusterParticleAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "CalorimeterHit" && toType == "SimCalorimeterHit") {
+      auto mc_a =
+          createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection,
+                                      true>(relations, typeMapping.caloHits,
+                                            typeMapping.simCaloHits);
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "SimCalorimeterHit" && toType == "CalorimeterHit") {
+      auto mc_a =
+          createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection,
+                                      false>(relations, typeMapping.simCaloHits,
+                                             typeMapping.caloHits);
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "Cluster" && toType == "MCParticle") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoClusterParticleAssociationCollection, true>(
           relations, typeMapping.clusters, typeMapping.mcParticles);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "MCParticle" && toType == "Cluster") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoClusterParticleAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "MCParticle" && toType == "Cluster") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoClusterParticleAssociationCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.clusters);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "MCParticle" && toType == "Track") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackParticleAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "MCParticle" && toType == "Track") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackParticleAssociationCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.tracks);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "Track" && toType == "MCParticle") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackParticleAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "Track" && toType == "MCParticle") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackParticleAssociationCollection, true>(
           relations, typeMapping.tracks, typeMapping.mcParticles);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "TrackerHit" && toType == "SimTrackerHit") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "TrackerHit" && toType == "SimTrackerHit") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackerAssociationCollection, true>(
           relations, typeMapping.trackerHits, typeMapping.simTrackerHits);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "SimTrackerHit" && toType == "TrackerHit") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "SimTrackerHit" && toType == "TrackerHit") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackerAssociationCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHits);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "SimTrackerHit" && toType == "TrackerHitPlane") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerHitPlaneAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "SimTrackerHit" && toType == "TrackerHitPlane") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackerHitPlaneAssociationCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHitPlanes);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "TrackerHitPlane" && toType == "SimTrackerHit") {
-        auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerHitPlaneAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "TrackerHitPlane" && toType == "SimTrackerHit") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::MCRecoTrackerHitPlaneAssociationCollection, true>(
           relations, typeMapping.trackerHitPlanes, typeMapping.simTrackerHits);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "ReconstructedParticle" && toType == "Vertex") {
-        auto mc_a = createAssociationCollection<edm4hep::RecoParticleVertexAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "ReconstructedParticle" && toType == "Vertex") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::RecoParticleVertexAssociationCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.vertices);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "Vertex" && toType == "ReconstructedParticle") {
-        auto mc_a = createAssociationCollection<edm4hep::RecoParticleVertexAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "Vertex" && toType == "ReconstructedParticle") {
+      auto mc_a = createAssociationCollection<
+          edm4hep::RecoParticleVertexAssociationCollection, false>(
           relations, typeMapping.vertices, typeMapping.recoParticles);
-        assoCollVec.emplace_back(name, std::move(mc_a));
-      }
-      else if (fromType == "CalorimeterHit" && toType == "MCParticle") {
-        auto assoc = createAssociationCollection<edm4hep::MCRecoCaloParticleAssociationCollection, true>(
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "CalorimeterHit" && toType == "MCParticle") {
+      auto assoc = createAssociationCollection<
+          edm4hep::MCRecoCaloParticleAssociationCollection, true>(
           relations, typeMapping.caloHits, typeMapping.mcParticles);
-        assoCollVec.emplace_back(name, std::move(assoc));
-      }
-      else if (fromType == "MCParticle" && toType == "CalorimeterHit") {
-        auto assoc = createAssociationCollection<edm4hep::MCRecoCaloParticleAssociationCollection, false>(
+      assoCollVec.emplace_back(name, std::move(assoc));
+    } else if (fromType == "MCParticle" && toType == "CalorimeterHit") {
+      auto assoc = createAssociationCollection<
+          edm4hep::MCRecoCaloParticleAssociationCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.caloHits);
-        assoCollVec.emplace_back(name, std::move(assoc));
-      }
-      else {
-        std::cout << "Relation from: " << fromType << " to: " << toType << " (" << name
-                  << ") is not beeing handled during creation of associations" << std::endl;
-      }
-    }
-
-    return assoCollVec;
-  }
-
-  template<typename ObjectMappingT>
-  std::unique_ptr<podio::CollectionBase>
-  fillSubset(EVENT::LCCollection* LCCollection, const ObjectMappingT& typeMapping, const std::string& type)
-  {
-    if (type == "MCParticle") {
-      return handleSubsetColl<edm4hep::MCParticleCollection>(LCCollection, typeMapping.mcParticles);
-    }
-    else if (type == "ReconstructedParticle") {
-      return handleSubsetColl<edm4hep::ReconstructedParticleCollection>(LCCollection, typeMapping.recoParticles);
-    }
-    else if (type == "Vertex") {
-      return handleSubsetColl<edm4hep::VertexCollection>(LCCollection, typeMapping.vertices);
-    }
-    else if (type == "Track") {
-      return handleSubsetColl<edm4hep::TrackCollection>(LCCollection, typeMapping.tracks);
-    }
-    else if (type == "Cluster") {
-      return handleSubsetColl<edm4hep::ClusterCollection>(LCCollection, typeMapping.clusters);
-    }
-    else if (type == "SimCalorimeterHit") {
-      return handleSubsetColl<edm4hep::SimCalorimeterHitCollection>(LCCollection, typeMapping.simCaloHits);
-    }
-    else if (type == "RawCalorimeterHit") {
-      return handleSubsetColl<edm4hep::RawCalorimeterHitCollection>(LCCollection, typeMapping.rawCaloHits);
-    }
-    else if (type == "CalorimeterHit") {
-      return handleSubsetColl<edm4hep::CalorimeterHitCollection>(LCCollection, typeMapping.caloHits);
-    }
-    else if (type == "SimTrackerHit") {
-      return handleSubsetColl<edm4hep::SimTrackerHitCollection>(LCCollection, typeMapping.simTrackerHits);
-    }
-    else if (type == "TPCHit") {
-      return handleSubsetColl<edm4hep::RawTimeSeriesCollection>(LCCollection, typeMapping.tpcHits);
-    }
-    else if (type == "TrackerHit") {
-      return handleSubsetColl<edm4hep::TrackerHit3DCollection>(LCCollection, typeMapping.trackerHits);
-    }
-    else if (type == "TrackerHitPlane") {
-      return handleSubsetColl<edm4hep::TrackerHitPlaneCollection>(LCCollection, typeMapping.trackerHitPlanes);
-    }
-    else {
-      return nullptr;
+      assoCollVec.emplace_back(name, std::move(assoc));
+    } else {
+      std::cout << "Relation from: " << fromType << " to: " << toType << " ("
+                << name
+                << ") is not beeing handled during creation of associations"
+                << std::endl;
     }
   }
+
+  return assoCollVec;
+}
+
+template <typename ObjectMappingT>
+std::unique_ptr<podio::CollectionBase>
+fillSubset(EVENT::LCCollection *LCCollection, const ObjectMappingT &typeMapping,
+           const std::string &type) {
+  if (type == "MCParticle") {
+    return handleSubsetColl<edm4hep::MCParticleCollection>(
+        LCCollection, typeMapping.mcParticles);
+  } else if (type == "ReconstructedParticle") {
+    return handleSubsetColl<edm4hep::ReconstructedParticleCollection>(
+        LCCollection, typeMapping.recoParticles);
+  } else if (type == "Vertex") {
+    return handleSubsetColl<edm4hep::VertexCollection>(LCCollection,
+                                                       typeMapping.vertices);
+  } else if (type == "Track") {
+    return handleSubsetColl<edm4hep::TrackCollection>(LCCollection,
+                                                      typeMapping.tracks);
+  } else if (type == "Cluster") {
+    return handleSubsetColl<edm4hep::ClusterCollection>(LCCollection,
+                                                        typeMapping.clusters);
+  } else if (type == "SimCalorimeterHit") {
+    return handleSubsetColl<edm4hep::SimCalorimeterHitCollection>(
+        LCCollection, typeMapping.simCaloHits);
+  } else if (type == "RawCalorimeterHit") {
+    return handleSubsetColl<edm4hep::RawCalorimeterHitCollection>(
+        LCCollection, typeMapping.rawCaloHits);
+  } else if (type == "CalorimeterHit") {
+    return handleSubsetColl<edm4hep::CalorimeterHitCollection>(
+        LCCollection, typeMapping.caloHits);
+  } else if (type == "SimTrackerHit") {
+    return handleSubsetColl<edm4hep::SimTrackerHitCollection>(
+        LCCollection, typeMapping.simTrackerHits);
+  } else if (type == "TPCHit") {
+    return handleSubsetColl<edm4hep::RawTimeSeriesCollection>(
+        LCCollection, typeMapping.tpcHits);
+  } else if (type == "TrackerHit") {
+    return handleSubsetColl<edm4hep::TrackerHit3DCollection>(
+        LCCollection, typeMapping.trackerHits);
+  } else if (type == "TrackerHitPlane") {
+    return handleSubsetColl<edm4hep::TrackerHitPlaneCollection>(
+        LCCollection, typeMapping.trackerHitPlanes);
+  } else {
+    return nullptr;
+  }
+}
 
 } // namespace LCIO2EDM4hepConv

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -6,168 +6,145 @@
 #include "UTIL/PIDHandler.h"
 #include <edm4hep/ParticleIDCollection.h>
 
-#include <limits>
 #include <algorithm>
+#include <limits>
 
 namespace EDM4hep2LCIOConv {
 
-  void convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event)
-  {
-    convertEventHeader(header_coll, lcio_event);
+void convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event) {
+  convertEventHeader(header_coll, lcio_event);
+}
+
+void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event) {
+  if (header_coll->size() != 1) {
+    return;
   }
 
-  void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event)
-  {
-    if (header_coll->size() != 1) {
-      return;
-    }
+  const auto& header = header_coll->at(0);
+  lcio_event->setEventNumber(header.getEventNumber());
+  lcio_event->setRunNumber(header.getRunNumber());
+  lcio_event->setTimeStamp(header.getTimeStamp());
+  lcio_event->setWeight(header.getWeight());
+}
 
-    const auto& header = header_coll->at(0);
-    lcio_event->setEventNumber(header.getEventNumber());
-    lcio_event->setRunNumber(header.getRunNumber());
-    lcio_event->setTimeStamp(header.getTimeStamp());
-    lcio_event->setWeight(header.getWeight());
+// Check if a collection is already in the event by its name
+bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event) {
+  const auto* coll = lcio_event->getCollectionNames();
+  return std::find(coll->begin(), coll->end(), collection_name) != coll->end();
+}
+
+void sortParticleIDs(std::vector<ParticleIDConvData>& pidCollections) {
+  std::sort(pidCollections.begin(), pidCollections.end(), [](const auto& pid1, const auto& pid2) {
+    static const auto defaultPidMeta = edm4hep::utils::ParticleIDMeta{"", std::numeric_limits<int>::max(), {}};
+    return pid1.metadata.value_or(defaultPidMeta).algoType < pid2.metadata.value_or(defaultPidMeta).algoType;
+  });
+}
+
+std::optional<int32_t> attachParticleIDMetaData(IMPL::LCEventImpl* lcEvent, const podio::Frame& edmEvent,
+                                                const ParticleIDConvData& pidCollMetaInfo) {
+  const auto& [name, coll, pidMetaInfo] = pidCollMetaInfo;
+  const auto recoName = edmEvent.getName((*coll)[0].getParticle().id().collectionID);
+  // If we can't get the reconstructed particle collection name there is not
+  // much we can do
+  if (!recoName.has_value()) {
+    return std::nullopt;
+  }
+  // If we can't get meta data information there is not much we can do either
+  if (!pidMetaInfo.has_value()) {
+    return std::nullopt;
+  }
+  if (pidMetaInfo.has_value() && !recoName.has_value()) {
+    return pidMetaInfo->algoType;
   }
 
-  // Check if a collection is already in the event by its name
-  bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event)
-  {
-    const auto* coll = lcio_event->getCollectionNames();
-    return std::find(coll->begin(), coll->end(), collection_name) != coll->end();
-  }
+  UTIL::PIDHandler pidHandler(lcEvent->getCollection(recoName.value()));
+  return pidHandler.addAlgorithm(pidMetaInfo->algoName, pidMetaInfo->paramNames);
+}
 
-  void sortParticleIDs(std::vector<ParticleIDConvData>& pidCollections)
-  {
-    std::sort(pidCollections.begin(), pidCollections.end(), [](const auto& pid1, const auto& pid2) {
-      static const auto defaultPidMeta = edm4hep::utils::ParticleIDMeta {"", std::numeric_limits<int>::max(), {}};
-      return pid1.metadata.value_or(defaultPidMeta).algoType < pid2.metadata.value_or(defaultPidMeta).algoType;
-    });
-  }
+std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, const podio::Frame& metadata) {
+  auto lcioEvent = std::make_unique<lcio::LCEventImpl>();
+  auto objectMappings = CollectionsPairVectors{};
 
-  std::optional<int32_t> attachParticleIDMetaData(
-    IMPL::LCEventImpl* lcEvent,
-    const podio::Frame& edmEvent,
-    const ParticleIDConvData& pidCollMetaInfo)
-  {
-    const auto& [name, coll, pidMetaInfo] = pidCollMetaInfo;
-    const auto recoName = edmEvent.getName((*coll)[0].getParticle().id().collectionID);
-    // If we can't get the reconstructed particle collection name there is not
-    // much we can do
-    if (!recoName.has_value()) {
-      return std::nullopt;
-    }
-    // If we can't get meta data information there is not much we can do either
-    if (!pidMetaInfo.has_value()) {
-      return std::nullopt;
-    }
-    if (pidMetaInfo.has_value() && !recoName.has_value()) {
-      return pidMetaInfo->algoType;
-    }
+  // We have to convert these after all other (specifically
+  // ReconstructedParticle) collections have been converted. Otherwise we will
+  // not be able to set all the metadata for the PIDHandler (LCIO) to work
+  // properly. Here we store the name, the collection as well as potentially
+  // available meta information that we obtain when we first come across a
+  // collection
+  std::vector<ParticleIDConvData> pidCollections{};
 
-    UTIL::PIDHandler pidHandler(lcEvent->getCollection(recoName.value()));
-    return pidHandler.addAlgorithm(pidMetaInfo->algoName, pidMetaInfo->paramNames);
-  }
+  const auto& collections = edmEvent.getAvailableCollections();
+  for (const auto& name : collections) {
+    const auto edmCollection = edmEvent.get(name);
 
-  std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, const podio::Frame& metadata)
-  {
-    auto lcioEvent = std::make_unique<lcio::LCEventImpl>();
-    auto objectMappings = CollectionsPairVectors {};
-
-    // We have to convert these after all other (specifically
-    // ReconstructedParticle) collections have been converted. Otherwise we will
-    // not be able to set all the metadata for the PIDHandler (LCIO) to work
-    // properly. Here we store the name, the collection as well as potentially
-    // available meta information that we obtain when we first come across a
-    // collection
-    std::vector<ParticleIDConvData> pidCollections {};
-
-    const auto& collections = edmEvent.getAvailableCollections();
-    for (const auto& name : collections) {
-      const auto edmCollection = edmEvent.get(name);
-
-      const auto& cellIDStr =
+    const auto& cellIDStr =
         metadata.getParameter<std::string>(podio::collMetadataParamName(name, edm4hep::CellIDEncoding));
 
-      if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
-        auto lcColl = convertTracks(coll, objectMappings.tracks);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::TrackerHit3DCollection*>(edmCollection)) {
-        auto lcColl = convertTrackerHits(coll, cellIDStr, objectMappings.trackerHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::TrackerHitPlaneCollection*>(edmCollection)) {
-        auto lcColl = convertTrackerHitPlanes(coll, cellIDStr, objectMappings.trackerHitPlanes);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::SimTrackerHitCollection*>(edmCollection)) {
-        auto lcColl = convertSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::CalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convertCalorimeterHits(coll, cellIDStr, objectMappings.caloHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::RawCalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convertRawCalorimeterHits(coll, objectMappings.rawCaloHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::SimCalorimeterHitCollection*>(edmCollection)) {
-        auto lcColl = convertSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::RawTimeSeriesCollection*>(edmCollection)) {
-        auto lcColl = convertTPCHits(coll, objectMappings.tpcHits);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::ClusterCollection*>(edmCollection)) {
-        auto lcColl = convertClusters(coll, objectMappings.clusters);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::VertexCollection*>(edmCollection)) {
-        auto lcColl = convertVertices(coll, objectMappings.vertices);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::MCParticleCollection*>(edmCollection)) {
-        auto lcColl = convertMCParticles(coll, objectMappings.mcParticles);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::ReconstructedParticleCollection*>(edmCollection)) {
-        auto lcColl = convertReconstructedParticles(coll, objectMappings.recoParticles);
-        lcioEvent->addCollection(lcColl.release(), name);
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
-        convertEventHeader(coll, lcioEvent.get());
-      }
-      else if (auto coll = dynamic_cast<const edm4hep::ParticleIDCollection*>(edmCollection)) {
-        pidCollections.emplace_back(name, coll, edm4hep::utils::PIDHandler::getAlgoInfo(metadata, name));
-      }
-      else if (dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
-        // "converted" during relation resolving later
-        continue;
-      }
-      else {
-        std::cerr << "Error trying to convert requested " << edmCollection->getValueTypeName() << " with name " << name
-                  << "\n"
-                  << "List of supported types: "
-                  << "Track, TrackerHit, TrackerHitPlane, SimTrackerHit, "
-                  << "Cluster, CalorimeterHit, RawCalorimeterHit, "
-                  << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
-                  << "MCParticle." << std::endl;
-      }
+    if (auto coll = dynamic_cast<const edm4hep::TrackCollection*>(edmCollection)) {
+      auto lcColl = convertTracks(coll, objectMappings.tracks);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::TrackerHit3DCollection*>(edmCollection)) {
+      auto lcColl = convertTrackerHits(coll, cellIDStr, objectMappings.trackerHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::TrackerHitPlaneCollection*>(edmCollection)) {
+      auto lcColl = convertTrackerHitPlanes(coll, cellIDStr, objectMappings.trackerHitPlanes);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::SimTrackerHitCollection*>(edmCollection)) {
+      auto lcColl = convertSimTrackerHits(coll, cellIDStr, objectMappings.simTrackerHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::CalorimeterHitCollection*>(edmCollection)) {
+      auto lcColl = convertCalorimeterHits(coll, cellIDStr, objectMappings.caloHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::RawCalorimeterHitCollection*>(edmCollection)) {
+      auto lcColl = convertRawCalorimeterHits(coll, objectMappings.rawCaloHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::SimCalorimeterHitCollection*>(edmCollection)) {
+      auto lcColl = convertSimCalorimeterHits(coll, cellIDStr, objectMappings.simCaloHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::RawTimeSeriesCollection*>(edmCollection)) {
+      auto lcColl = convertTPCHits(coll, objectMappings.tpcHits);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::ClusterCollection*>(edmCollection)) {
+      auto lcColl = convertClusters(coll, objectMappings.clusters);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::VertexCollection*>(edmCollection)) {
+      auto lcColl = convertVertices(coll, objectMappings.vertices);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::MCParticleCollection*>(edmCollection)) {
+      auto lcColl = convertMCParticles(coll, objectMappings.mcParticles);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::ReconstructedParticleCollection*>(edmCollection)) {
+      auto lcColl = convertReconstructedParticles(coll, objectMappings.recoParticles);
+      lcioEvent->addCollection(lcColl.release(), name);
+    } else if (auto coll = dynamic_cast<const edm4hep::EventHeaderCollection*>(edmCollection)) {
+      convertEventHeader(coll, lcioEvent.get());
+    } else if (auto coll = dynamic_cast<const edm4hep::ParticleIDCollection*>(edmCollection)) {
+      pidCollections.emplace_back(name, coll, edm4hep::utils::PIDHandler::getAlgoInfo(metadata, name));
+    } else if (dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
+      // "converted" during relation resolving later
+      continue;
+    } else {
+      std::cerr << "Error trying to convert requested " << edmCollection->getValueTypeName() << " with name " << name
+                << "\n"
+                << "List of supported types: "
+                << "Track, TrackerHit, TrackerHitPlane, SimTrackerHit, "
+                << "Cluster, CalorimeterHit, RawCalorimeterHit, "
+                << "SimCalorimeterHit, Vertex, ReconstructedParticle, "
+                << "MCParticle." << std::endl;
     }
-
-    sortParticleIDs(pidCollections);
-    for (const auto& pidCollMeta : pidCollections) {
-      // Use -1 as a somewhat easy to identify value of missing reco collections
-      // or pid metadata
-      const auto algoId = attachParticleIDMetaData(lcioEvent.get(), edmEvent, pidCollMeta).value_or(-1);
-      convertParticleIDs(pidCollMeta.coll, objectMappings.particleIDs, algoId);
-    }
-
-    resolveRelations(objectMappings);
-
-    return lcioEvent;
   }
+
+  sortParticleIDs(pidCollections);
+  for (const auto& pidCollMeta : pidCollections) {
+    // Use -1 as a somewhat easy to identify value of missing reco collections
+    // or pid metadata
+    const auto algoId = attachParticleIDMetaData(lcioEvent.get(), edmEvent, pidCollMeta).value_or(-1);
+    convertParticleIDs(pidCollMeta.coll, objectMappings.particleIDs, algoId);
+  }
+
+  resolveRelations(objectMappings);
+
+  return lcioEvent;
+}
 
 } // namespace EDM4hep2LCIOConv

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -6,149 +6,144 @@
 
 namespace LCIO2EDM4hepConv {
 
-  edm4hep::TrackState convertTrackState(const EVENT::TrackState* trackState)
-  {
-    auto edmtrackState = edm4hep::TrackState {};
-    edmtrackState.location = trackState->getLocation();
-    edmtrackState.D0 = trackState->getD0();
-    edmtrackState.phi = trackState->getPhi();
-    edmtrackState.omega = trackState->getOmega();
-    edmtrackState.Z0 = trackState->getZ0();
-    edmtrackState.tanLambda = trackState->getTanLambda();
-    // not available in lcio
-    edmtrackState.time = -1;
-    const auto refPoint = trackState->getReferencePoint();
-    edmtrackState.referencePoint = Vector3fFrom({refPoint[0], refPoint[1], refPoint[2]});
-    const auto& covMatrix = trackState->getCovMatrix();
-    edmtrackState.covMatrix = {
+edm4hep::TrackState convertTrackState(const EVENT::TrackState* trackState) {
+  auto edmtrackState = edm4hep::TrackState{};
+  edmtrackState.location = trackState->getLocation();
+  edmtrackState.D0 = trackState->getD0();
+  edmtrackState.phi = trackState->getPhi();
+  edmtrackState.omega = trackState->getOmega();
+  edmtrackState.Z0 = trackState->getZ0();
+  edmtrackState.tanLambda = trackState->getTanLambda();
+  // not available in lcio
+  edmtrackState.time = -1;
+  const auto refPoint = trackState->getReferencePoint();
+  edmtrackState.referencePoint = Vector3fFrom({refPoint[0], refPoint[1], refPoint[2]});
+  const auto& covMatrix = trackState->getCovMatrix();
+  edmtrackState.covMatrix = {
       covMatrix[0],  covMatrix[1], covMatrix[2], covMatrix[3],  covMatrix[4],  covMatrix[5],  covMatrix[6],
       covMatrix[7],  covMatrix[8], covMatrix[9], covMatrix[10], covMatrix[11], covMatrix[12], covMatrix[13],
       covMatrix[14], 0.f,          0.f,          0.f,           0.f,           0.f,           0.f};
 
-    return edmtrackState;
+  return edmtrackState;
+}
+
+edm4hep::MutableParticleID convertParticleID(const EVENT::ParticleID* pid) {
+  auto result = edm4hep::MutableParticleID{};
+  result.setType(pid->getType());
+  result.setPDG(pid->getPDG());
+  result.setAlgorithmType(pid->getAlgorithmType());
+  result.setLikelihood(pid->getLikelihood());
+
+  for (auto v : pid->getParameters()) {
+    result.addToParameters(v);
   }
 
-  edm4hep::MutableParticleID convertParticleID(const EVENT::ParticleID* pid)
-  {
-    auto result = edm4hep::MutableParticleID {};
-    result.setType(pid->getType());
-    result.setPDG(pid->getPDG());
-    result.setAlgorithmType(pid->getAlgorithmType());
-    result.setLikelihood(pid->getLikelihood());
+  return result;
+}
 
-    for (auto v : pid->getParameters()) {
-      result.addToParameters(v);
+std::unique_ptr<edm4hep::EventHeaderCollection> createEventHeader(const EVENT::LCEvent* evt) {
+  auto headerColl = std::make_unique<edm4hep::EventHeaderCollection>();
+  auto header = headerColl->create();
+
+  header.setEventNumber(evt->getEventNumber());
+  header.setRunNumber(evt->getRunNumber());
+  header.setTimeStamp(evt->getTimeStamp());
+  header.setWeight(evt->getWeight());
+  return headerColl;
+}
+
+std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl) {
+  std::vector<edm4hep::utils::ParticleIDMeta> pidInfos{};
+  auto pidHandler = UTIL::PIDHandler(recoColl);
+  for (const auto id : pidHandler.getAlgorithmIDs()) {
+    pidInfos.emplace_back(pidHandler.getAlgorithmName(id), id, pidHandler.getParameterNames(id));
+  }
+
+  return pidInfos;
+}
+
+podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert) {
+  auto typeMapping = LcioEdmTypeMapping{};
+  std::vector<CollNamePair> edmevent;
+  std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
+
+  const auto& lcioNames = [&collsToConvert, &evt]() {
+    if (collsToConvert.empty()) {
+      return *evt->getCollectionNames();
+    }
+    return collsToConvert;
+  }();
+
+  // In this loop the data gets converted.
+  for (const auto& lcioname : lcioNames) {
+    const auto& lcioColl = evt->getCollection(lcioname);
+    const auto& lciotype = lcioColl->getTypeName();
+    if (lciotype == "LCRelation") {
+      LCRelations.push_back(std::make_pair(lcioname, lcioColl));
+      // We handle Relations (aka Associations) once we have converted all the
+      // data parts.
+      continue;
     }
 
-    return result;
-  }
-
-  std::unique_ptr<edm4hep::EventHeaderCollection> createEventHeader(const EVENT::LCEvent* evt)
-  {
-    auto headerColl = std::make_unique<edm4hep::EventHeaderCollection>();
-    auto header = headerColl->create();
-
-    header.setEventNumber(evt->getEventNumber());
-    header.setRunNumber(evt->getRunNumber());
-    header.setTimeStamp(evt->getTimeStamp());
-    header.setWeight(evt->getWeight());
-    return headerColl;
-  }
-
-  std::vector<edm4hep::utils::ParticleIDMeta> getPIDMetaInfo(const EVENT::LCCollection* recoColl)
-  {
-    std::vector<edm4hep::utils::ParticleIDMeta> pidInfos {};
-    auto pidHandler = UTIL::PIDHandler(recoColl);
-    for (const auto id : pidHandler.getAlgorithmIDs()) {
-      pidInfos.emplace_back(pidHandler.getAlgorithmName(id), id, pidHandler.getParameterNames(id));
-    }
-
-    return pidInfos;
-  }
-
-  podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::string>& collsToConvert)
-  {
-    auto typeMapping = LcioEdmTypeMapping {};
-    std::vector<CollNamePair> edmevent;
-    std::vector<std::pair<std::string, EVENT::LCCollection*>> LCRelations;
-
-    const auto& lcioNames = [&collsToConvert, &evt]() {
-      if (collsToConvert.empty()) {
-        return *evt->getCollectionNames();
-      }
-      return collsToConvert;
-    }();
-
-    // In this loop the data gets converted.
-    for (const auto& lcioname : lcioNames) {
-      const auto& lcioColl = evt->getCollection(lcioname);
-      const auto& lciotype = lcioColl->getTypeName();
-      if (lciotype == "LCRelation") {
-        LCRelations.push_back(std::make_pair(lcioname, lcioColl));
-        // We handle Relations (aka Associations) once we have converted all the
-        // data parts.
-        continue;
-      }
-
-      if (!lcioColl->isSubset()) {
-        for (auto&& [name, edmColl] : convertCollection(lcioname, lcioColl, typeMapping)) {
-          if (edmColl != nullptr) {
-            edmevent.emplace_back(std::move(name), std::move(edmColl));
-          }
-        }
-      }
-    }
-    // Filling of the Subset Colections
-    for (const auto& lcioname : lcioNames) {
-
-      auto lcioColl = evt->getCollection(lcioname);
-      if (lcioColl->isSubset()) {
-        const auto& lciotype = lcioColl->getTypeName();
-        auto edmColl = fillSubset(lcioColl, typeMapping, lciotype);
+    if (!lcioColl->isSubset()) {
+      for (auto&& [name, edmColl] : convertCollection(lcioname, lcioColl, typeMapping)) {
         if (edmColl != nullptr) {
-          edmevent.emplace_back(lcioname, std::move(edmColl));
+          edmevent.emplace_back(std::move(name), std::move(edmColl));
         }
       }
     }
-    // Filling all the OneToMany and OneToOne Relations and creating the AssociationCollections.
-    resolveRelations(typeMapping);
-    auto assoCollVec = createAssociations(typeMapping, LCRelations);
-    auto headerColl = createEventHeader(evt);
-
-    // Now everything is done and we simply populate a Frame
-    podio::Frame event;
-    // convert put the event parameters into the frame
-    convertObjectParameters<EVENT::LCEvent>(evt, event);
-
-    // only create CaloHitContributions if necessary (i.e. if we have converted
-    // SimCalorimeterHits)
-    if (not typeMapping.simCaloHits.empty()) {
-      auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
-      event.put(std::move(calocontr), "AllCaloHitContributionsCombined");
-    }
-    event.put(std::move(headerColl), "EventHeader");
-    for (auto& [name, coll] : edmevent) {
-      event.put(std::move(coll), name);
-    }
-    for (auto& [name, coll] : assoCollVec) {
-      event.put(std::move(coll), name);
-    }
-    return event;
   }
+  // Filling of the Subset Colections
+  for (const auto& lcioname : lcioNames) {
 
-  podio::Frame convertRunHeader(EVENT::LCRunHeader* rheader)
-  {
-    podio::Frame runHeaderFrame;
-    runHeaderFrame.putParameter("runNumber", rheader->getRunNumber());
-    runHeaderFrame.putParameter("detectorName", rheader->getDetectorName());
-    runHeaderFrame.putParameter("description", rheader->getDescription());
-    auto subdetectors = rheader->getActiveSubdetectors();
-    runHeaderFrame.putParameter("activeSubdetectors", *subdetectors);
-
-    // convert everything set as a parameter
-    convertObjectParameters<EVENT::LCRunHeader>(rheader, runHeaderFrame);
-
-    return runHeaderFrame;
+    auto lcioColl = evt->getCollection(lcioname);
+    if (lcioColl->isSubset()) {
+      const auto& lciotype = lcioColl->getTypeName();
+      auto edmColl = fillSubset(lcioColl, typeMapping, lciotype);
+      if (edmColl != nullptr) {
+        edmevent.emplace_back(lcioname, std::move(edmColl));
+      }
+    }
   }
+  // Filling all the OneToMany and OneToOne Relations and creating the
+  // AssociationCollections.
+  resolveRelations(typeMapping);
+  auto assoCollVec = createAssociations(typeMapping, LCRelations);
+  auto headerColl = createEventHeader(evt);
+
+  // Now everything is done and we simply populate a Frame
+  podio::Frame event;
+  // convert put the event parameters into the frame
+  convertObjectParameters<EVENT::LCEvent>(evt, event);
+
+  // only create CaloHitContributions if necessary (i.e. if we have converted
+  // SimCalorimeterHits)
+  if (not typeMapping.simCaloHits.empty()) {
+    auto calocontr = createCaloHitContributions(typeMapping.simCaloHits, typeMapping.mcParticles);
+    event.put(std::move(calocontr), "AllCaloHitContributionsCombined");
+  }
+  event.put(std::move(headerColl), "EventHeader");
+  for (auto& [name, coll] : edmevent) {
+    event.put(std::move(coll), name);
+  }
+  for (auto& [name, coll] : assoCollVec) {
+    event.put(std::move(coll), name);
+  }
+  return event;
+}
+
+podio::Frame convertRunHeader(EVENT::LCRunHeader* rheader) {
+  podio::Frame runHeaderFrame;
+  runHeaderFrame.putParameter("runNumber", rheader->getRunNumber());
+  runHeaderFrame.putParameter("detectorName", rheader->getDetectorName());
+  runHeaderFrame.putParameter("description", rheader->getDescription());
+  auto subdetectors = rheader->getActiveSubdetectors();
+  runHeaderFrame.putParameter("activeSubdetectors", *subdetectors);
+
+  // convert everything set as a parameter
+  convertObjectParameters<EVENT::LCRunHeader>(rheader, runHeaderFrame);
+
+  return runHeaderFrame;
+}
 
 } // namespace LCIO2EDM4hepConv

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -12,20 +12,19 @@
 #else
 #include "podio/ROOTFrameWriter.h"
 namespace podio {
-  using ROOTWriter = podio::ROOTFrameWriter;
+using ROOTWriter = podio::ROOTFrameWriter;
 }
 #endif
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <iterator>
 #include <string>
-#include <vector>
 #include <utility>
-#include <cstdlib>
+#include <vector>
 
-std::vector<std::pair<std::string, std::string>> getNamesAndTypes(const std::string& collTypeFile)
-{
+std::vector<std::pair<std::string, std::string>> getNamesAndTypes(const std::string& collTypeFile) {
   std::ifstream input_file(collTypeFile);
   std::vector<std::pair<std::string, std::string>> names_types;
 
@@ -75,24 +74,21 @@ lcio2edm4hep infile.slcio outfile_edm4hep.root coltype.txt
 )";
 
 struct ParsedArgs {
-  std::string inputFile {};
-  std::string outputFile {};
-  std::string patchFile {};
-  int nEvents {-1};
+  std::string inputFile{};
+  std::string outputFile{};
+  std::string patchFile{};
+  int nEvents{-1};
 };
 
-void printUsageAndExit()
-{
+void printUsageAndExit() {
   std::cerr << usageMsg << std::endl;
   std::exit(1);
 }
 
-ParsedArgs parseArgs(std::vector<std::string> argv)
-{
+ParsedArgs parseArgs(std::vector<std::string> argv) {
   // find help
-  if (std::find_if(argv.begin(), argv.end(), [](const auto& elem) {
-        return elem == "-h" || elem == "--help";
-      }) != argv.end()) {
+  if (std::find_if(argv.begin(), argv.end(), [](const auto& elem) { return elem == "-h" || elem == "--help"; }) !=
+      argv.end()) {
     std::cerr << usageMsg << '\n' << helpMsg << std::endl;
     std::exit(0);
   }
@@ -132,12 +128,11 @@ ParsedArgs parseArgs(std::vector<std::string> argv)
   return args;
 }
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   const auto args = parseArgs({argv, argv + argc});
 
-  UTIL::CheckCollections colPatcher {};
-  std::vector<std::pair<std::string, std::string>> namesTypes {};
+  UTIL::CheckCollections colPatcher{};
+  std::vector<std::pair<std::string, std::string>> namesTypes{};
   const bool patching = !args.patchFile.empty();
   if (patching) {
     namesTypes = getNamesAndTypes(args.patchFile);
@@ -168,7 +163,7 @@ int main(int argc, char* argv[])
 
   podio::ROOTWriter writer(args.outputFile);
 
-  podio::Frame metadata {};
+  podio::Frame metadata{};
 
   for (int j = 0; j < lcreader->getNumberOfRuns(); ++j) {
     if (j % 1 == 0) {
@@ -199,8 +194,8 @@ int main(int argc, char* argv[])
         auto coll = evt->getCollection(name);
         if (coll->getTypeName() == "ReconstructedParticle") {
           for (const auto& pidInfo : LCIO2EDM4hepConv::getPIDMetaInfo(coll)) {
-            edm4hep::utils::PIDHandler::setAlgoInfo(
-              metadata, LCIO2EDM4hepConv::getPIDCollName(name, pidInfo.algoName), pidInfo);
+            edm4hep::utils::PIDHandler::setAlgoInfo(metadata, LCIO2EDM4hepConv::getPIDCollName(name, pidInfo.algoName),
+                                                    pidInfo);
           }
         }
       }

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -1,6 +1,6 @@
 #include "CompareEDM4hepLCIO.h"
-#include "ObjectMapping.h"
 #include "ComparisonUtils.h"
+#include "ObjectMapping.h"
 
 #include "podio/podioVersion.h"
 #if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
@@ -8,7 +8,7 @@
 #else
 #include "podio/ROOTFrameReader.h"
 namespace podio {
-  using ROOTReader = podio::ROOTFrameReader;
+using ROOTReader = podio::ROOTFrameReader;
 }
 #endif
 
@@ -21,8 +21,7 @@ namespace podio {
 
 constexpr auto usageMsg = R"(usage: compare-contents lciofile edm4hepfile)";
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   if (argc != 3) {
     std::cerr << usageMsg << std::endl;
     return 1;
@@ -68,7 +67,7 @@ int main(int argc, char* argv[])
         return 1;
       }
 
-      if (edmEvent.get(name)->size() != (unsigned) lcioColl->getNumberOfElements()) {
+      if (edmEvent.get(name)->size() != (unsigned)lcioColl->getNumberOfElements()) {
         std::cerr << "Collection " << name << " has different sizes. LCIO: " << lcioColl->getNumberOfElements()
                   << ", EDM4hep: " << coll->size() << std::endl;
         return 1;

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -8,14 +8,13 @@
 
 #include <iostream>
 
-#define ASSERT_SAME_OR_ABORT(type, name)                                     \
-  if (!compare(origEvent.get<type>(name), roundtripEvent.get<type>(name))) { \
-    std::cerr << "Comparison failure in " << name << std::endl;              \
-    return 1;                                                                \
+#define ASSERT_SAME_OR_ABORT(type, name)                                                                               \
+  if (!compare(origEvent.get<type>(name), roundtripEvent.get<type>(name))) {                                           \
+    std::cerr << "Comparison failure in " << name << std::endl;                                                        \
+    return 1;                                                                                                          \
   }
 
-int main()
-{
+int main() {
   const auto& [origEvent, metadata] = createExampleEvent();
   const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(origEvent, metadata);
   const auto roundtripEvent = LCIO2EDM4hepConv::convertEvent(lcioEvent.get());

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -1,7 +1,7 @@
-#include "EDM4hep2LCIOUtilities.h"
 #include "CompareEDM4hepLCIO.h"
-#include "ObjectMapping.h"
 #include "ComparisonUtils.h"
+#include "EDM4hep2LCIOUtilities.h"
+#include "ObjectMapping.h"
 
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h"
 
@@ -9,8 +9,7 @@
 
 #include "podio/Frame.h"
 
-int main()
-{
+int main() {
   const auto& [edmEvent, metadata] = createExampleEvent();
   const auto lcioEvent = EDM4hep2LCIOConv::convertEvent(edmEvent, metadata);
 
@@ -21,14 +20,13 @@ int main()
   for (const auto& name : edmEvent.getAvailableCollections()) {
     const auto edmColl = edmEvent.get(name);
     const auto typeName = edmColl->getValueTypeName();
-    if (
-      typeName == "edm4hep::CaloHitContribution" || typeName == "edm4hep::ParticleID" ||
-      typeName == "edm4hep::EventHeader") {
+    if (typeName == "edm4hep::CaloHitContribution" || typeName == "edm4hep::ParticleID" ||
+        typeName == "edm4hep::EventHeader") {
       continue;
     }
     try {
       const auto* lcColl = lcioEvent->getCollection(name);
-      if ((unsigned) lcColl->getNumberOfElements() != edmColl->size()) {
+      if ((unsigned)lcColl->getNumberOfElements() != edmColl->size()) {
         std::cerr << "Collection " << name << " has different sizes. EDM4hep: " << edmColl->size()
                   << ", LCIO: " << lcColl->getNumberOfElements() << std::endl;
         return 1;
@@ -43,9 +41,8 @@ int main()
 
   for (const auto& name : edmEvent.getAvailableCollections()) {
     const auto type = edmEvent.get(name)->getTypeName();
-    if (
-      type == "edm4hep::CaloHitContributionCollection" || type == "edm4hep::ParticleIDCollection" ||
-      type == "edm4hep::EventHeaderCollection") {
+    if (type == "edm4hep::CaloHitContributionCollection" || type == "edm4hep::ParticleIDCollection" ||
+        type == "edm4hep::EventHeaderCollection") {
       continue;
     }
     const auto* lcioColl = lcioEvent->getCollection(name);

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -2,29 +2,29 @@
 #include "ComparisonUtils.h"
 
 #include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
 #include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/ParticleIDCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/ClusterCollection.h"
-#include "edm4hep/ReconstructedParticleCollection.h"
-#include "edm4hep/ParticleIDCollection.h"
 
 #include <edm4hep/TrackState.h>
 #include <iostream>
 #include <podio/RelationRange.h>
 
-#define REQUIRE_SAME(expected, actual, msg)                                                                \
-  {                                                                                                        \
-    if (!((expected) == (actual))) {                                                                       \
-      std::cerr << msg << " are not the same (expected: " << (expected) << ", actual: " << (actual) << ")" \
-                << std::endl;                                                                              \
-      return false;                                                                                        \
-    }                                                                                                      \
+#define REQUIRE_SAME(expected, actual, msg)                                                                            \
+  {                                                                                                                    \
+    if (!((expected) == (actual))) {                                                                                   \
+      std::cerr << msg << " are not the same (expected: " << (expected) << ", actual: " << (actual) << ")"             \
+                << std::endl;                                                                                          \
+      return false;                                                                                                    \
+    }                                                                                                                  \
   }
 
-bool compare(const edm4hep::CalorimeterHitCollection& origColl, const edm4hep::CalorimeterHitCollection& roundtripColl)
-{
+bool compare(const edm4hep::CalorimeterHitCollection& origColl,
+             const edm4hep::CalorimeterHitCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     const auto origHit = origColl[i];
@@ -40,8 +40,7 @@ bool compare(const edm4hep::CalorimeterHitCollection& origColl, const edm4hep::C
   return true;
 }
 
-bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCParticleCollection& roundtripColl)
-{
+bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCParticleCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
 
   for (size_t i = 0; i < origColl.size(); ++i) {
@@ -54,8 +53,8 @@ bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCPar
     REQUIRE_SAME(origPart.getTime(), part.getTime(), "time in particle " << i);
     REQUIRE_SAME(origPart.getEndpoint(), part.getEndpoint(), "endpoint in particle " << i);
     REQUIRE_SAME(origPart.getMomentum(), part.getMomentum(), "momentum in particle " << i);
-    REQUIRE_SAME(
-      origPart.getMomentumAtEndpoint(), part.getMomentumAtEndpoint(), "momentumAtEndpoint in particle " << i);
+    REQUIRE_SAME(origPart.getMomentumAtEndpoint(), part.getMomentumAtEndpoint(),
+                 "momentumAtEndpoint in particle " << i);
     REQUIRE_SAME(origPart.getMass(), part.getMass(), "mass in particle " << i);
     REQUIRE_SAME(origPart.getCharge(), part.getCharge(), "charge in particle " << i);
     REQUIRE_SAME(origPart.getSpin(), part.getSpin(), "spin in particle " << i);
@@ -74,27 +73,21 @@ bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCPar
     // (assuming that the collection names are the same!)
     REQUIRE_SAME(origPart.getParents().size(), part.getParents().size(), "size of parents in particle " << i);
     for (size_t iP = 0; iP < origPart.getParents().size(); ++iP) {
-      REQUIRE_SAME(
-        origPart.getParents()[iP].getObjectID(),
-        part.getParents()[iP].getObjectID(),
-        " parent " << iP << " in particle " << i);
+      REQUIRE_SAME(origPart.getParents()[iP].getObjectID(), part.getParents()[iP].getObjectID(),
+                   " parent " << iP << " in particle " << i);
     }
     REQUIRE_SAME(origPart.getDaughters().size(), part.getDaughters().size(), "size of daughters in particle " << i);
     for (size_t iD = 0; iD < origPart.getDaughters().size(); ++iD) {
-      REQUIRE_SAME(
-        origPart.getDaughters()[iD].getObjectID(),
-        part.getDaughters()[iD].getObjectID(),
-        " daughter " << iD << " in particle " << i);
+      REQUIRE_SAME(origPart.getDaughters()[iD].getObjectID(), part.getDaughters()[iD].getObjectID(),
+                   " daughter " << iD << " in particle " << i);
     }
   }
 
   return true;
 }
 
-bool compare(
-  const edm4hep::SimCalorimeterHitCollection& origColl,
-  const edm4hep::SimCalorimeterHitCollection& roundtripColl)
-{
+bool compare(const edm4hep::SimCalorimeterHitCollection& origColl,
+             const edm4hep::SimCalorimeterHitCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     auto origHit = origColl[i];
@@ -114,23 +107,20 @@ bool compare(
       REQUIRE_SAME(origCont.getPDG(), cont.getPDG(), "pdg of contribution " << iC << " in hit " << i);
       REQUIRE_SAME(origCont.getEnergy(), cont.getEnergy(), "energy of contribution " << iC << " in hit " << i);
       REQUIRE_SAME(origCont.getTime(), cont.getTime(), "time of contribution " << iC << " in hit " << i);
-      REQUIRE_SAME(
-        origCont.getStepPosition(), cont.getStepPosition(), "stepPosition of contribution " << iC << " in hit " << i);
+      REQUIRE_SAME(origCont.getStepPosition(), cont.getStepPosition(),
+                   "stepPosition of contribution " << iC << " in hit " << i);
 
       // Check the MCParticles via ObjectID (asssuming collection names remain
       // unchanged)
-      REQUIRE_SAME(
-        origCont.getParticle().getObjectID(),
-        cont.getParticle().getObjectID(),
-        "particle of contribution " << iC << " in hit " << i);
+      REQUIRE_SAME(origCont.getParticle().getObjectID(), cont.getParticle().getObjectID(),
+                   "particle of contribution " << iC << " in hit " << i);
     }
   }
 
   return true;
 }
 
-bool compare(const edm4hep::TrackState& orig, const edm4hep::TrackState& roundtrip)
-{
+bool compare(const edm4hep::TrackState& orig, const edm4hep::TrackState& roundtrip) {
   REQUIRE_SAME(orig.location, roundtrip.location, "location in TrackState");
   REQUIRE_SAME(orig.D0, roundtrip.D0, "D0 in TrackState");
   REQUIRE_SAME(orig.Z0, roundtrip.Z0, "Z0 in TrackState");
@@ -147,8 +137,7 @@ bool compare(const edm4hep::TrackState& orig, const edm4hep::TrackState& roundtr
   return true;
 }
 
-bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackCollection& roundtripColl)
-{
+bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
 
   for (size_t i = 0; i < origColl.size(); ++i) {
@@ -166,8 +155,8 @@ bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackColle
     // have 50 hits. So here we just compare the ones that are available in the
     // original
     for (size_t iSN = 0; iSN < origSubDetHitNumbers.size(); ++iSN) {
-      REQUIRE_SAME(
-        origSubDetHitNumbers[iSN], subDetHitNumbers[iSN], "subdetector hit numbers " << iSN << " in track " << i);
+      REQUIRE_SAME(origSubDetHitNumbers[iSN], subDetHitNumbers[iSN],
+                   "subdetector hit numbers " << iSN << " in track " << i);
     }
     for (size_t iSN = origSubDetHitNumbers.size(); iSN < 50; ++iSN) {
       REQUIRE_SAME(0, subDetHitNumbers[iSN], "additional subdetector hit number in track " << i);
@@ -200,8 +189,7 @@ bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackColle
   return true;
 }
 
-bool compare(const edm4hep::TrackerHit3DCollection& origColl, const edm4hep::TrackerHit3DCollection& roundtripColl)
-{
+bool compare(const edm4hep::TrackerHit3DCollection& origColl, const edm4hep::TrackerHit3DCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     auto origHit = origColl[i];
@@ -220,10 +208,8 @@ bool compare(const edm4hep::TrackerHit3DCollection& origColl, const edm4hep::Tra
   return true;
 }
 
-bool compare(
-  const edm4hep::TrackerHitPlaneCollection& origColl,
-  const edm4hep::TrackerHitPlaneCollection& roundtripColl)
-{
+bool compare(const edm4hep::TrackerHitPlaneCollection& origColl,
+             const edm4hep::TrackerHitPlaneCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     auto origHit = origColl[i];
@@ -246,8 +232,7 @@ bool compare(
   return true;
 }
 
-bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterCollection& roundtripColl)
-{
+bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     auto origCluster = origColl[i];
@@ -257,10 +242,8 @@ bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterC
     const auto relClusters = cluster.getClusters();
     REQUIRE_SAME(origRelClusters.size(), relClusters.size(), "number of related clusters in cluster " << i);
     for (size_t iC = 0; iC < origRelClusters.size(); ++iC) {
-      REQUIRE_SAME(
-        origRelClusters[iC].getObjectID(),
-        relClusters[iC].getObjectID(),
-        "related cluster " << iC << " in cluster " << i);
+      REQUIRE_SAME(origRelClusters[iC].getObjectID(), relClusters[iC].getObjectID(),
+                   "related cluster " << iC << " in cluster " << i);
     }
 
     const auto origHits = origCluster.getHits();
@@ -281,10 +264,8 @@ bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterC
   return true;
 }
 
-bool compare(
-  const edm4hep::ReconstructedParticleCollection& origColl,
-  const edm4hep::ReconstructedParticleCollection& roundtripColl)
-{
+bool compare(const edm4hep::ReconstructedParticleCollection& origColl,
+             const edm4hep::ReconstructedParticleCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     auto origReco = origColl[i];
@@ -297,38 +278,31 @@ bool compare(
     const auto relClusters = reco.getClusters();
     REQUIRE_SAME(origRelClusters.size(), relClusters.size(), "number of related clusters in reco particle " << i);
     for (size_t iC = 0; iC < relClusters.size(); ++iC) {
-      REQUIRE_SAME(
-        origRelClusters[iC].getObjectID(),
-        relClusters[iC].getObjectID(),
-        "related cluster " << iC << " in reco particle " << i);
+      REQUIRE_SAME(origRelClusters[iC].getObjectID(), relClusters[iC].getObjectID(),
+                   "related cluster " << iC << " in reco particle " << i);
     }
 
     const auto origRelTracks = origReco.getTracks();
     const auto relTracks = reco.getTracks();
     REQUIRE_SAME(origRelTracks.size(), relTracks.size(), "number of related tracks in reco particle " << i);
     for (size_t iT = 0; iT < relTracks.size(); ++iT) {
-      REQUIRE_SAME(
-        origRelTracks[iT].getObjectID(),
-        relTracks[iT].getObjectID(),
-        "related track " << iT << " in reco particle " << i);
+      REQUIRE_SAME(origRelTracks[iT].getObjectID(), relTracks[iT].getObjectID(),
+                   "related track " << iT << " in reco particle " << i);
     }
 
     const auto origRelParticles = origReco.getParticles();
     const auto relParticles = reco.getParticles();
     REQUIRE_SAME(origRelParticles.size(), relParticles.size(), "number of related particles in reco particle " << i);
     for (size_t iP = 0; iP < relParticles.size(); ++iP) {
-      REQUIRE_SAME(
-        origRelParticles[iP].getObjectID(),
-        relParticles[iP].getObjectID(),
-        "related particle " << iP << " in reco particle " << i);
+      REQUIRE_SAME(origRelParticles[iP].getObjectID(), relParticles[iP].getObjectID(),
+                   "related particle " << iP << " in reco particle " << i);
     }
   }
 
   return true;
 }
 
-bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl)
-{
+bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     const auto origPid = origColl[i];
@@ -346,8 +320,8 @@ bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::Parti
       REQUIRE_SAME(origParams[iP], params[iP], "parameter " << iP << " in ParticleID " << i);
     }
 
-    REQUIRE_SAME(
-      origPid.getParticle().getObjectID(), pid.getParticle().getObjectID(), "related particle in ParticleID " << i);
+    REQUIRE_SAME(origPid.getParticle().getObjectID(), pid.getParticle().getObjectID(),
+                 "related particle in ParticleID " << i);
   }
   return true;
 }

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -7,23 +7,20 @@ bool compare(const edm4hep::CalorimeterHitCollection& origColl, const edm4hep::C
 
 bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCParticleCollection& roundtripColl);
 
-bool compare(
-  const edm4hep::SimCalorimeterHitCollection& origColl,
-  const edm4hep::SimCalorimeterHitCollection& roundtripColl);
+bool compare(const edm4hep::SimCalorimeterHitCollection& origColl,
+             const edm4hep::SimCalorimeterHitCollection& roundtripColl);
 
 bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackCollection& roundtripColl);
 
 bool compare(const edm4hep::TrackerHit3DCollection& origColl, const edm4hep::TrackerHit3DCollection& roundtripColl);
 
-bool compare(
-  const edm4hep::TrackerHitPlaneCollection& origColl,
-  const edm4hep::TrackerHitPlaneCollection& roundtripColl);
+bool compare(const edm4hep::TrackerHitPlaneCollection& origColl,
+             const edm4hep::TrackerHitPlaneCollection& roundtripColl);
 
 bool compare(const edm4hep::ClusterCollection& origColl, const edm4hep::ClusterCollection& roundtripColl);
 
-bool compare(
-  const edm4hep::ReconstructedParticleCollection& origColl,
-  const edm4hep::ReconstructedParticleCollection& roundtripColl);
+bool compare(const edm4hep::ReconstructedParticleCollection& origColl,
+             const edm4hep::ReconstructedParticleCollection& roundtripColl);
 
 bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl);
 

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -21,9 +21,8 @@
  */
 
 /// Convert the two 32 bit cellIDs into one 64 bit value
-template<typename LcioT>
-auto to64BitCellID(LcioT* obj)
-{
+template <typename LcioT>
+auto to64BitCellID(LcioT* obj) {
   const auto cellID0 = obj->getCellID0();
   const auto cellID1 = obj->getCellID1();
   uint64_t cellID = cellID1;
@@ -33,8 +32,7 @@ auto to64BitCellID(LcioT* obj)
 
 // ================= CalorimeterHit ================
 
-bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHit& edm4hepElem, const ObjectMappings&)
-{
+bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHit& edm4hepElem, const ObjectMappings&) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in CalorimeterHit");
 
@@ -46,18 +44,14 @@ bool compare(const EVENT::CalorimeterHit* lcioElem, const edm4hep::CalorimeterHi
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::CalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::CalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::CalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= Cluster ================
 
-bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem, const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem, const ObjectMappings& objectMaps) {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in Cluster");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergyError, "energyError in Cluster");
@@ -74,29 +68,23 @@ bool compare(const EVENT::Cluster* lcioElem, const edm4hep::Cluster& edm4hepElem
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getClusters, objectMaps.clusters, "related clusters in Cluster");
 
   // Different names of related calorimeter hits in interfaces
-  if (!compareRelation(
-        lcioElem->getCalorimeterHits(), edm4hepElem.getHits(), objectMaps.caloHits, "calorimeter hits in Cluster")) {
+  if (!compareRelation(lcioElem->getCalorimeterHits(), edm4hepElem.getHits(), objectMaps.caloHits,
+                       "calorimeter hits in Cluster")) {
     return false;
   }
 
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::ClusterCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::ClusterCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::Cluster>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= MCParticle ================
 
-bool compare(
-  const EVENT::MCParticle* lcioElem,
-  const edm4hep::MCParticle& edm4hepElem,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::MCParticle* lcioElem, const edm4hep::MCParticle& edm4hepElem,
+             const ObjectMappings& objectMaps) {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPDG, "PDG in MCParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getGeneratorStatus, "generatorStatus in MCParticle");
   // LCIO changes the SimulatorStatus during I/O, so here we have to check the
@@ -126,18 +114,14 @@ bool compare(
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::MCParticleCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticleCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::MCParticle>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= ParticleID ================
 
-bool compare(const EVENT::ParticleID* lcioElem, const edm4hep::ParticleID& edm4hepElem)
-{
+bool compare(const EVENT::ParticleID* lcioElem, const edm4hep::ParticleID& edm4hepElem) {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in ParticleID");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPDG, "PDG in ParticleID");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getAlgorithmType, "algorithmType in ParticleID");
@@ -147,11 +131,8 @@ bool compare(const EVENT::ParticleID* lcioElem, const edm4hep::ParticleID& edm4h
 
 // ================= RawCalorimeterHit ================
 
-bool compare(
-  const EVENT::RawCalorimeterHit* lcioElem,
-  const edm4hep::RawCalorimeterHit& edm4hepElem,
-  const ObjectMappings&)
-{
+bool compare(const EVENT::RawCalorimeterHit* lcioElem, const edm4hep::RawCalorimeterHit& edm4hepElem,
+             const ObjectMappings&) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in RawCalorimeterHit");
 
@@ -160,21 +141,15 @@ bool compare(
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::RawCalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= ReconstructedParticle ================
 
-bool compare(
-  const EVENT::ReconstructedParticle* lcioElem,
-  const edm4hep::ReconstructedParticle& edm4hepElem,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::ReconstructedParticle* lcioElem, const edm4hep::ReconstructedParticle& edm4hepElem,
+             const ObjectMappings& objectMaps) {
   ASSERT_COMPARE_VALS(lcioElem->getType(), edm4hepElem.getPDG(), "type/PDG in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEnergy, "energy in ReconstructedParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentum, "momentum in ReconstructedParticle");
@@ -186,10 +161,10 @@ bool compare(
 
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getClusters, objectMaps.clusters, "clusters in ReonstructedParticle");
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getTracks, objectMaps.tracks, "tracks in ReonstructedParticle");
-  ASSERT_COMPARE_RELATION(
-    lcioElem, edm4hepElem, getParticles, objectMaps.recoParticles, "particles in ReonstructedParticle");
-  ASSERT_COMPARE_RELATION(
-    lcioElem, edm4hepElem, getStartVertex, objectMaps.vertices, "startVertex in ReconstructedParticle");
+  ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getParticles, objectMaps.recoParticles,
+                          "particles in ReonstructedParticle");
+  ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getStartVertex, objectMaps.vertices,
+                          "startVertex in ReconstructedParticle");
 
   // ParticleIDs need special treatment because they live in different
   // collections in EDM4hep. Here we make sure that all ParticleIDs have been
@@ -204,8 +179,7 @@ bool compare(
                   << ", EDM4hep: " << edm4hepPid << ")" << std::endl;
         return false;
       }
-    }
-    else {
+    } else {
       std::cerr << "Cannot find a converted ParticleID object for particle ID " << i << std::endl;
       return false;
     }
@@ -214,21 +188,15 @@ bool compare(
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::ReconstructedParticleCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection,
+             const edm4hep::ReconstructedParticleCollection& edm4hepCollection, const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::ReconstructedParticle>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= SimCalorimeterHit ================
 
-bool compare(
-  const EVENT::SimCalorimeterHit* lcioElem,
-  const edm4hep::SimCalorimeterHit& edm4hepElem,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::SimCalorimeterHit* lcioElem, const edm4hep::SimCalorimeterHit& edm4hepElem,
+             const ObjectMappings& objectMaps) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in SimCalorimeterHit");
 
@@ -237,25 +205,20 @@ bool compare(
 
   // Contributions are not part of the "proper LCIO"
   const auto edmContributions = edm4hepElem.getContributions();
-  ASSERT_COMPARE_VALS(
-    (unsigned) lcioElem->getNMCContributions(), edmContributions.size(), "number of CaloHitContributions");
+  ASSERT_COMPARE_VALS((unsigned)lcioElem->getNMCContributions(), edmContributions.size(),
+                      "number of CaloHitContributions");
 
   for (int iCont = 0; iCont < lcioElem->getNMCContributions(); ++iCont) {
     const auto& edmContrib = edmContributions[iCont];
-    ASSERT_COMPARE_VALS(
-      lcioElem->getEnergyCont(iCont), edmContrib.getEnergy(), "energy in CaloHitContribution " + std::to_string(iCont));
-    ASSERT_COMPARE_VALS(
-      lcioElem->getStepPosition(iCont),
-      edmContrib.getStepPosition(),
-      "stepPosition in CaloHitContribution " + std::to_string(iCont));
-    ASSERT_COMPARE_VALS(
-      lcioElem->getTimeCont(iCont), edmContrib.getTime(), "time in CaloHitContribution " + std::to_string(iCont));
+    ASSERT_COMPARE_VALS(lcioElem->getEnergyCont(iCont), edmContrib.getEnergy(),
+                        "energy in CaloHitContribution " + std::to_string(iCont));
+    ASSERT_COMPARE_VALS(lcioElem->getStepPosition(iCont), edmContrib.getStepPosition(),
+                        "stepPosition in CaloHitContribution " + std::to_string(iCont));
+    ASSERT_COMPARE_VALS(lcioElem->getTimeCont(iCont), edmContrib.getTime(),
+                        "time in CaloHitContribution " + std::to_string(iCont));
 
-    if (!compareRelation(
-          lcioElem->getParticleCont(iCont),
-          edmContrib.getParticle(),
-          objectMaps.mcParticles,
-          " MCParticle in CaloHitContribution " + std::to_string(iCont))) {
+    if (!compareRelation(lcioElem->getParticleCont(iCont), edmContrib.getParticle(), objectMaps.mcParticles,
+                         " MCParticle in CaloHitContribution " + std::to_string(iCont))) {
       return false;
     }
   }
@@ -263,21 +226,15 @@ bool compare(
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::SimCalorimeterHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= SimTrackerHit ================
 
-bool compare(
-  const EVENT::SimTrackerHit* lcioElem,
-  const edm4hep::SimTrackerHit& edm4hepElem,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::SimTrackerHit* lcioElem, const edm4hep::SimTrackerHit& edm4hepElem,
+             const ObjectMappings& objectMaps) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getEDep, "EDep in SimTrackerHit");
@@ -287,26 +244,22 @@ bool compare(
   ASSERT_COMPARE(lcioElem, edm4hepElem, getPosition, "position in SimTrackerHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentum, "momentum in SimTrackerHit");
 
-  if (!compareRelation(
-        lcioElem->getMCParticle(), edm4hepElem.getParticle(), objectMaps.mcParticles, "MC particle in SimTrackerHit")) {
+  if (!compareRelation(lcioElem->getMCParticle(), edm4hepElem.getParticle(), objectMaps.mcParticles,
+                       "MC particle in SimTrackerHit")) {
     return false;
   }
 
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::SimTrackerHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimTrackerHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::SimTrackerHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TPCHit ================
 
-bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem, const ObjectMappings&)
-{
+bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4hepElem, const ObjectMappings&) {
   const uint64_t lcioCellID = lcioElem->getCellID();
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TPCHit");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getQuality, "quality in TPCHit");
@@ -315,18 +268,14 @@ bool compare(const EVENT::TPCHit* lcioElem, const edm4hep::RawTimeSeries& edm4he
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::TPCHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TrackState ================
 
-bool compare(const EVENT::TrackState* lcio, const edm4hep::TrackState& edm4hep)
-{
+bool compare(const EVENT::TrackState* lcio, const edm4hep::TrackState& edm4hep) {
   ASSERT_COMPARE_VALS(lcio->getLocation(), edm4hep.location, "location in TrackState");
   ASSERT_COMPARE_VALS(lcio->getD0(), edm4hep.D0, "D0 in TrackState");
   ASSERT_COMPARE_VALS(lcio->getZ0(), edm4hep.Z0, "Z0 in TrackState");
@@ -346,8 +295,7 @@ bool compare(const EVENT::TrackState* lcio, const edm4hep::TrackState& edm4hep)
 
 // ================= Track ================
 
-bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, const ObjectMappings& objectMaps) {
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getNdf, "ndf in Track");
@@ -384,15 +332,14 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   int iHit = 0;
   for (const auto* lcioHit : lcioElem->getTrackerHits()) {
     if (const auto typedHit = dynamic_cast<const EVENT::TrackerHitPlane*>(lcioHit)) {
-      if (!compareRelation(
-            typedHit, edmHits[iHit], objectMaps.trackerHitPlanes, "TrackerHit " + std::to_string(iHit) + " in Track")) {
+      if (!compareRelation(typedHit, edmHits[iHit], objectMaps.trackerHitPlanes,
+                           "TrackerHit " + std::to_string(iHit) + " in Track")) {
         return false;
       }
       iHit++;
-    }
-    else if (dynamic_cast<const IMPL::TrackerHitImpl*>(lcioHit)) {
-      if (!compareRelation(
-            lcioHit, edmHits[iHit], objectMaps.trackerHits, "TrackerHit " + std::to_string(iHit) + " in Track")) {
+    } else if (dynamic_cast<const IMPL::TrackerHitImpl*>(lcioHit)) {
+      if (!compareRelation(lcioHit, edmHits[iHit], objectMaps.trackerHits,
+                           "TrackerHit " + std::to_string(iHit) + " in Track")) {
         return false;
       }
       iHit++;
@@ -402,18 +349,14 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::Track>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TrackerHit ================
 
-bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit3D& edm4hepElem, const ObjectMappings&)
-{
+bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit3D& edm4hepElem, const ObjectMappings&) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHit");
 
@@ -427,18 +370,15 @@ bool compare(const EVENT::TrackerHit* lcioElem, const edm4hep::TrackerHit3D& edm
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackerHit3DCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHit3DCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::TrackerHit>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= TrackerHitPlane ================
 
-bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPlane& edm4hepElem, const ObjectMappings&)
-{
+bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPlane& edm4hepElem,
+             const ObjectMappings&) {
   const auto lcioCellID = to64BitCellID(lcioElem);
   ASSERT_COMPARE_VALS(lcioCellID, edm4hepElem.getCellID(), "cellID in TrackerHitPlane");
 
@@ -458,18 +398,14 @@ bool compare(const EVENT::TrackerHitPlane* lcioElem, const edm4hep::TrackerHitPl
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::TrackerHitPlane>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 // ================= Vertex ================
 
-bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem, const ObjectMappings& objectMaps)
-{
+bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem, const ObjectMappings& objectMaps) {
   // LCIO has isPrimary (bool), EDM4hep has getPrimary (int32_t)
   ASSERT_COMPARE_VALS(lcioElem->isPrimary(), edm4hepElem.getPrimary(), "primary in Vertex");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Vertex");
@@ -481,22 +417,18 @@ bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem, 
   // ASSERT_COMPARE(lcioElem, edm4hepElem, getAlgorithmType,
   //                "algorithmType in Vertex");
 
-  ASSERT_COMPARE_RELATION(
-    lcioElem, edm4hepElem, getAssociatedParticle, objectMaps.recoParticles, "associatedParticle in Vertex");
+  ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getAssociatedParticle, objectMaps.recoParticles,
+                          "associatedParticle in Vertex");
 
   return true;
 }
 
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::VertexCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps)
-{
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::Vertex>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
-bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent)
-{
+bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent) {
   const auto& edmEventHeader = edmEvent->get<edm4hep::EventHeaderCollection>("EventHeader")[0];
 
   ASSERT_COMPARE(lcevt, edmEventHeader, getEventNumber, "Event Number is not the same");

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -17,19 +17,19 @@
 #include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/RecoParticleVertexAssociationCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/RawTimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-  using TrackerHit3D = edm4hep::TrackerHit;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3D = edm4hep::TrackerHit;
 } // namespace edm4hep
 #endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
@@ -58,94 +58,60 @@ namespace edm4hep {
 #include <UTIL/PIDHandler.h>
 #include <lcio.h>
 
-bool compare(
-  const EVENT::CalorimeterHit* lcio,
-  const edm4hep::CalorimeterHit& edm4hep,
-  const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::CalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const EVENT::CalorimeterHit* lcio, const edm4hep::CalorimeterHit& edm4hep,
+             const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::CalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::Cluster* lcio, const edm4hep::Cluster& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::ClusterCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::ClusterCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::MCParticle* lcio, const edm4hep::MCParticle& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::MCParticleCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::MCParticleCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
-bool compare(
-  const EVENT::RawCalorimeterHit* lcio,
-  const edm4hep::RawCalorimeterHit& edm4hep,
-  const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const EVENT::RawCalorimeterHit* lcio, const edm4hep::RawCalorimeterHit& edm4hep,
+             const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawCalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
-bool compare(
-  const EVENT::ReconstructedParticle* lcio,
-  const edm4hep::ReconstructedParticle& edm4hep,
-  const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::ReconstructedParticleCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const EVENT::ReconstructedParticle* lcio, const edm4hep::ReconstructedParticle& edm4hep,
+             const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection,
+             const edm4hep::ReconstructedParticleCollection& edm4hepCollection, const ObjectMappings& objectMaps);
 
-bool compare(
-  const EVENT::SimCalorimeterHit* lcio,
-  const edm4hep::SimCalorimeterHit& edm4hep,
-  const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const EVENT::SimCalorimeterHit* lcio, const edm4hep::SimCalorimeterHit& edm4hep,
+             const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimCalorimeterHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::SimTrackerHit* lcio, const edm4hep::SimTrackerHit& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::SimTrackerHitCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::SimTrackerHitCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::TPCHit* lcio, const edm4hep::RawTimeSeries& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::RawTimeSeriesCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::TrackerHit* lcio, const edm4hep::TrackerHit3D& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackerHit3DCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHit3DCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
-bool compare(
-  const EVENT::TrackerHitPlane* lcio,
-  const edm4hep::TrackerHitPlane& edm4hep,
-  const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const EVENT::TrackerHitPlane* lcio, const edm4hep::TrackerHitPlane& edm4hep,
+             const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackerHitPlaneCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::TrackState* lcio, const edm4hep::TrackState& edm4hep);
 
 bool compare(const EVENT::Track* lcio, const edm4hep::Track& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::TrackCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::TrackCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::Vertex* lcio, const edm4hep::Vertex& edm4hep, const ObjectMappings& objectMaps);
-bool compare(
-  const lcio::LCCollection* lcioCollection,
-  const edm4hep::VertexCollection& edm4hepCollection,
-  const ObjectMappings& objectMaps);
+bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexCollection& edm4hepCollection,
+             const ObjectMappings& objectMaps);
 
 bool compare(const EVENT::ParticleID* lcio, const edm4hep::ParticleID& edm4hep);
 

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -9,25 +9,25 @@
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 } // namespace edm4hep
 #endif
-#include <edm4hep/TrackerHitPlaneCollection.h>
-#include <edm4hep/EventHeaderCollection.h>
-#include <edm4hep/RawTimeSeriesCollection.h>
-#include "edm4hep/TrackCollection.h"
-#include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
+#include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>
 
 #include "podio/Frame.h"
 
 #include <array>
-#include <cstdint>
 #include <cmath>
+#include <cstdint>
 
 constexpr std::uint64_t operator""_u64(unsigned long long num) { return static_cast<std::uint64_t>(num); }
 
@@ -37,10 +37,9 @@ constexpr static std::array CELLIDS = {0xcaffee_u64, 0xbeef_u64, 0xfe47_u64, 0x1
 constexpr static uint64_t createCellID(int i) { return CELLIDS[i % CELLIDS.size()]; }
 
 /// Create a covariance matrix for N dimensions in lower triangular form
-template<size_t N, typename T = float>
-constexpr auto createCov()
-{
-  std::array<T, N*(N + 1) / 2> result {};
+template <size_t N, typename T = float>
+constexpr auto createCov() {
+  std::array<T, N*(N + 1) / 2> result{};
 
   // Calculate the flat index from the 2D index
   const auto to_lower_tri = [](int i, int j) {
@@ -60,11 +59,9 @@ constexpr auto createCov()
   return result;
 }
 
-edm4hep::MCParticleCollection createMCParticles(
-  const int num_elements,
-  const std::vector<test_config::IdxPair>& mcp_parents_idx)
-{
-  auto coll = edm4hep::MCParticleCollection {};
+edm4hep::MCParticleCollection createMCParticles(const int num_elements,
+                                                const std::vector<test_config::IdxPair>& mcp_parents_idx) {
+  auto coll = edm4hep::MCParticleCollection{};
 
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
@@ -105,9 +102,8 @@ edm4hep::MCParticleCollection createMCParticles(
   return coll;
 }
 
-edm4hep::CalorimeterHitCollection createCalorimeterHits(const int num_elements)
-{
-  edm4hep::CalorimeterHitCollection coll {};
+edm4hep::CalorimeterHitCollection createCalorimeterHits(const int num_elements) {
+  edm4hep::CalorimeterHitCollection coll{};
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
     elem.setCellID(createCellID(i));
@@ -121,9 +117,8 @@ edm4hep::CalorimeterHitCollection createCalorimeterHits(const int num_elements)
   return coll;
 }
 
-edm4hep::RawCalorimeterHitCollection createRawCalorimeterHits(const int num_elements)
-{
-  edm4hep::RawCalorimeterHitCollection coll {};
+edm4hep::RawCalorimeterHitCollection createRawCalorimeterHits(const int num_elements) {
+  edm4hep::RawCalorimeterHitCollection coll{};
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
     elem.setCellID(createCellID(i));
@@ -134,9 +129,8 @@ edm4hep::RawCalorimeterHitCollection createRawCalorimeterHits(const int num_elem
   return coll;
 }
 
-edm4hep::RawTimeSeriesCollection createTPCHits(const int num_elements, const int num_rawwords)
-{
-  edm4hep::RawTimeSeriesCollection coll {};
+edm4hep::RawTimeSeriesCollection createTPCHits(const int num_elements, const int num_rawwords) {
+  edm4hep::RawTimeSeriesCollection coll{};
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
 
@@ -152,9 +146,8 @@ edm4hep::RawTimeSeriesCollection createTPCHits(const int num_elements, const int
   return coll;
 }
 
-edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements)
-{
-  edm4hep::TrackerHit3DCollection coll {};
+edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements) {
+  edm4hep::TrackerHit3DCollection coll{};
 
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
@@ -171,9 +164,8 @@ edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements)
   return coll;
 }
 
-edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements)
-{
-  edm4hep::TrackerHitPlaneCollection coll {};
+edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements) {
+  edm4hep::TrackerHitPlaneCollection coll{};
   for (int i = 0; i < num_elements; ++i) {
     auto elem = coll.create();
     elem.setCellID(createCellID(i));
@@ -193,15 +185,11 @@ edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements
   return coll;
 }
 
-edm4hep::TrackCollection createTracks(
-  const int num_elements,
-  const int subdetectorhitnumbers,
-  const int num_track_states,
-  const edm4hep::TrackerHit3DCollection& trackerHits,
-  const edm4hep::TrackerHitPlaneCollection& trackerHitPlanes,
-  const std::vector<std::size_t>& link_trackerhit_idcs,
-  const std::vector<test_config::IdxPair>& track_link_tracks_idcs)
-{
+edm4hep::TrackCollection createTracks(const int num_elements, const int subdetectorhitnumbers,
+                                      const int num_track_states, const edm4hep::TrackerHit3DCollection& trackerHits,
+                                      const edm4hep::TrackerHitPlaneCollection& trackerHitPlanes,
+                                      const std::vector<std::size_t>& link_trackerhit_idcs,
+                                      const std::vector<test_config::IdxPair>& track_link_tracks_idcs) {
   // edm4hep::Track
   auto track_coll = edm4hep::TrackCollection();
 
@@ -251,14 +239,12 @@ edm4hep::TrackCollection createTracks(
   return track_coll;
 }
 
-std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection> createSimCalorimeterHits(
-  const int num_elements,
-  const int num_contributions,
-  const edm4hep::MCParticleCollection& mcParticles,
-  const std::vector<test_config::CaloContIdx>& link_mcparticles_idcs)
-{
+std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection>
+createSimCalorimeterHits(const int num_elements, const int num_contributions,
+                         const edm4hep::MCParticleCollection& mcParticles,
+                         const std::vector<test_config::CaloContIdx>& link_mcparticles_idcs) {
   auto simcalohit_coll = edm4hep::SimCalorimeterHitCollection();
-  auto contrib_coll = edm4hep::CaloHitContributionCollection {};
+  auto contrib_coll = edm4hep::CaloHitContributionCollection{};
 
   for (int i = 0; i < num_elements; ++i) {
     // auto* elem = new edm4hep::SimCalorimeterHit();
@@ -289,9 +275,8 @@ std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionColl
   return {std::move(simcalohit_coll), std::move(contrib_coll)};
 }
 
-edm4hep::EventHeaderCollection createEventHeader()
-{
-  auto evtHeaderColl = edm4hep::EventHeaderCollection {};
+edm4hep::EventHeaderCollection createEventHeader() {
+  auto evtHeaderColl = edm4hep::EventHeaderCollection{};
   auto evtHeader = evtHeaderColl.create();
 
   evtHeader.setWeight(3.14f);
@@ -302,14 +287,11 @@ edm4hep::EventHeaderCollection createEventHeader()
   return evtHeaderColl;
 }
 
-edm4hep::ClusterCollection createClusters(
-  const int num_elements,
-  const edm4hep::CalorimeterHitCollection& caloHits,
-  const int num_subdet_energies,
-  const std::vector<test_config::IdxPair>& clusterHitIdcs,
-  const std::vector<test_config::IdxPair>& clusterClusterIdcs)
-{
-  auto clusterColl = edm4hep::ClusterCollection {};
+edm4hep::ClusterCollection createClusters(const int num_elements, const edm4hep::CalorimeterHitCollection& caloHits,
+                                          const int num_subdet_energies,
+                                          const std::vector<test_config::IdxPair>& clusterHitIdcs,
+                                          const std::vector<test_config::IdxPair>& clusterClusterIdcs) {
+  auto clusterColl = edm4hep::ClusterCollection{};
   for (int i = 0; i < num_elements; ++i) {
     auto cluster = clusterColl.create();
 
@@ -329,15 +311,12 @@ edm4hep::ClusterCollection createClusters(
   return clusterColl;
 }
 
-edm4hep::ReconstructedParticleCollection createRecoParticles(
-  const int nRecos,
-  const edm4hep::TrackCollection& tracks,
-  const std::vector<test_config::IdxPair>& trackIdcs,
-  const edm4hep::ClusterCollection& clusters,
-  const std::vector<test_config::IdxPair>& clusterIdcs,
-  const std::vector<test_config::IdxPair>& recIdcs)
-{
-  auto recoColl = edm4hep::ReconstructedParticleCollection {};
+edm4hep::ReconstructedParticleCollection createRecoParticles(const int nRecos, const edm4hep::TrackCollection& tracks,
+                                                             const std::vector<test_config::IdxPair>& trackIdcs,
+                                                             const edm4hep::ClusterCollection& clusters,
+                                                             const std::vector<test_config::IdxPair>& clusterIdcs,
+                                                             const std::vector<test_config::IdxPair>& recIdcs) {
+  auto recoColl = edm4hep::ReconstructedParticleCollection{};
   for (int i = 0; i < nRecos; ++i) {
     auto reco = recoColl.create();
     reco.setCharge(1.23f);
@@ -357,10 +336,9 @@ edm4hep::ReconstructedParticleCollection createRecoParticles(
   return recoColl;
 }
 
-std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
-  const std::vector<std::vector<int>>& recoIdcs,
-  const edm4hep::ReconstructedParticleCollection& recoParticles)
-{
+std::vector<edm4hep::ParticleIDCollection>
+createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
+                  const edm4hep::ReconstructedParticleCollection& recoParticles) {
   std::vector<edm4hep::ParticleIDCollection> collections;
   collections.reserve(recoIdcs.size());
 
@@ -378,54 +356,37 @@ std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
   return collections;
 }
 
-std::tuple<podio::Frame, podio::Frame> createExampleEvent()
-{
-  auto retTuple = std::make_tuple(podio::Frame {}, podio::Frame {});
+std::tuple<podio::Frame, podio::Frame> createExampleEvent() {
+  auto retTuple = std::make_tuple(podio::Frame{}, podio::Frame{});
 
   auto& [event, metadata] = retTuple;
 
   event.put(createEventHeader(), "EventHeader");
   const auto& mcParticles =
-    event.put(createMCParticles(test_config::nMCParticles, test_config::mcpParentIdcs), "mcParticles");
+      event.put(createMCParticles(test_config::nMCParticles, test_config::mcpParentIdcs), "mcParticles");
   const auto& caloHits = event.put(createCalorimeterHits(test_config::nCaloHits), "caloHits");
   event.put(createRawCalorimeterHits(test_config::nRawCaloHits), "rawCaloHits");
   event.put(createTPCHits(test_config::nTPCHits, test_config::nTPCRawWords), "tpcHits");
   const auto& trackerHits = event.put(createTrackerHits(test_config::nTrackerHits), "trackerHits");
   const auto& trackerHitPlanes = event.put(createTrackerHitPlanes(test_config::nTrackerHits), "trackerHitPlanes");
-  const auto& tracks = event.put(
-    createTracks(
-      test_config::nTracks,
-      test_config::nSubdetectorHitNumbers,
-      test_config::nTrackStates,
-      trackerHits,
-      trackerHitPlanes,
-      test_config::trackTrackerHitIdcs,
-      test_config::trackTrackIdcs),
-    "tracks");
+  const auto& tracks = event.put(createTracks(test_config::nTracks, test_config::nSubdetectorHitNumbers,
+                                              test_config::nTrackStates, trackerHits, trackerHitPlanes,
+                                              test_config::trackTrackerHitIdcs, test_config::trackTrackIdcs),
+                                 "tracks");
 
-  const auto& clusters = event.put(
-    createClusters(
-      test_config::nClusters,
-      caloHits,
-      test_config::nSubdetectorEnergies,
-      test_config::clusterHitIdcs,
-      test_config::clusterClusterIdcs),
-    "clusters");
+  const auto& clusters = event.put(createClusters(test_config::nClusters, caloHits, test_config::nSubdetectorEnergies,
+                                                  test_config::clusterHitIdcs, test_config::clusterClusterIdcs),
+                                   "clusters");
 
   auto [tmpSimCaloHits, tmpCaloHitConts] = createSimCalorimeterHits(
-    test_config::nSimCaloHits, test_config::nCaloHitContributions, mcParticles, test_config::simCaloHitMCIdcs);
+      test_config::nSimCaloHits, test_config::nCaloHitContributions, mcParticles, test_config::simCaloHitMCIdcs);
   event.put(std::move(tmpSimCaloHits), "simCaloHits");
   event.put(std::move(tmpCaloHitConts), "caloHitContributions");
 
-  const auto& recoColl = event.put(
-    createRecoParticles(
-      test_config::nRecoParticles,
-      tracks,
-      test_config::recoTrackIdcs,
-      clusters,
-      test_config::recoClusterIdcs,
-      test_config::recoRecoIdcs),
-    "recos");
+  const auto& recoColl =
+      event.put(createRecoParticles(test_config::nRecoParticles, tracks, test_config::recoTrackIdcs, clusters,
+                                    test_config::recoClusterIdcs, test_config::recoRecoIdcs),
+                "recos");
 
   // Start at 0 here because that is also where the PIDHandler in LCIO starts
   int algoId = 0;
@@ -433,8 +394,8 @@ std::tuple<podio::Frame, podio::Frame> createExampleEvent()
     // Make sure to use the same name as is generated for the LCIO to EDM4hep
     // conversion
     const auto pidCollName = "recos_PID_pidAlgo_" + std::to_string(algoId);
-    edm4hep::utils::PIDHandler::setAlgoInfo(
-      metadata, pidColl, pidCollName, {"pidAlgo_" + std::to_string(algoId), algoId, {"param"}});
+    edm4hep::utils::PIDHandler::setAlgoInfo(metadata, pidColl, pidCollName,
+                                            {"pidAlgo_" + std::to_string(algoId), algoId, {"param"}});
 
     event.put(std::move(pidColl), pidCollName);
 

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -2,114 +2,104 @@
 #define K4EDM4HEP2LCIOCONV_TEST_EDM4HEP2LCIOUTILITIES_H
 
 #include <cstddef>
+#include <tuple>
 #include <utility>
 #include <vector>
-#include <tuple>
 
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 } // namespace edm4hep
 #endif
 
 namespace edm4hep {
-  class CalorimeterHitCollection;
-  class MCParticleCollection;
-  class RawCalorimeterHitCollection;
-  class RawTimeSeriesCollection;
-  class TrackerHitPlaneCollection;
-  class TrackCollection;
-  class SimCalorimeterHitCollection;
-  class CaloHitContributionCollection;
-  class EventHeaderCollection;
-  class ClusterCollection;
-  class ReconstructedParticleCollection;
-  class ParticleIDCollection;
+class CalorimeterHitCollection;
+class MCParticleCollection;
+class RawCalorimeterHitCollection;
+class RawTimeSeriesCollection;
+class TrackerHitPlaneCollection;
+class TrackCollection;
+class SimCalorimeterHitCollection;
+class CaloHitContributionCollection;
+class EventHeaderCollection;
+class ClusterCollection;
+class ReconstructedParticleCollection;
+class ParticleIDCollection;
 } // namespace edm4hep
 
 namespace podio {
-  class Frame;
+class Frame;
 }
 
 namespace test_config {
-  constexpr static int nMCParticles = 5; ///< The number of MCParticles to generate
+constexpr static int nMCParticles = 5; ///< The number of MCParticles to generate
 
-  using IdxPair = std::pair<int, int>;
-  /// How to create the MC particle hierarchy, e.g. {4, 0} means that mc[4] will
-  /// have mc[0] as a parent, and mc[0] will get mc[4] as a daughter
-  const static std::vector<IdxPair> mcpParentIdcs = {{4, 0}, {4, 1}, {3, 2}, {3, 0}, {3, 1}, {2, 1}};
+using IdxPair = std::pair<int, int>;
+/// How to create the MC particle hierarchy, e.g. {4, 0} means that mc[4] will
+/// have mc[0] as a parent, and mc[0] will get mc[4] as a daughter
+const static std::vector<IdxPair> mcpParentIdcs = {{4, 0}, {4, 1}, {3, 2}, {3, 0}, {3, 1}, {2, 1}};
 
-  constexpr static int nCaloHits = 2;    ///< The number of CalorimeterHits to generate
-  constexpr static int nRawCaloHits = 2; ///< The number of RawCalorimeterHits to generate
+constexpr static int nCaloHits = 2;    ///< The number of CalorimeterHits to generate
+constexpr static int nRawCaloHits = 2; ///< The number of RawCalorimeterHits to generate
 
-  constexpr static int nTPCHits = 4;     ///< The number of TPCHits (RawTimeSeries) to generate
-  constexpr static int nTPCRawWords = 6; ///< The number of raw words to put into each TPCHit
+constexpr static int nTPCHits = 4;     ///< The number of TPCHits (RawTimeSeries) to generate
+constexpr static int nTPCRawWords = 6; ///< The number of raw words to put into each TPCHit
 
-  constexpr static int nTrackerHits = 5; ///< The number of TrackerHits to generate
+constexpr static int nTrackerHits = 5; ///< The number of TrackerHits to generate
 
-  constexpr static int nTracks = 4;                ///< The number of tracks to generate
-  constexpr static int nSubdetectorHitNumbers = 4; ///< The number of subdetector hits for each track
-  /// The tracker hits that should be added to each track
-  const static std::vector<std::size_t> trackTrackerHitIdcs = {0, 2, 4};
-  constexpr static int nTrackStates = 5; ///< The number of track states for each track
-  /// The tracks that should be linked, first index is the track to which the
-  /// second index will be added
-  const static std::vector<IdxPair> trackTrackIdcs = {{0, 2}, {1, 3}, {2, 3}, {3, 2}, {3, 0}};
+constexpr static int nTracks = 4;                ///< The number of tracks to generate
+constexpr static int nSubdetectorHitNumbers = 4; ///< The number of subdetector hits for each track
+/// The tracker hits that should be added to each track
+const static std::vector<std::size_t> trackTrackerHitIdcs = {0, 2, 4};
+constexpr static int nTrackStates = 5; ///< The number of track states for each track
+/// The tracks that should be linked, first index is the track to which the
+/// second index will be added
+const static std::vector<IdxPair> trackTrackIdcs = {{0, 2}, {1, 3}, {2, 3}, {3, 2}, {3, 0}};
 
-  constexpr static int nSimCaloHits = 3;          ///< The number of SimCalorimeterHits
-  constexpr static int nCaloHitContributions = 4; ///< The number of CalorimeterHit Contributions
-  /// idcs to setup relations between SimCalorimeterHits, CaloHitContributions
-  /// and MCParticles (in this order)
-  using CaloContIdx = std::tuple<int, int, int>;
-  /// The index values to use for setting up the relations
-  const static std::vector<CaloContIdx> simCaloHitMCIdcs = {
-    {0, 0, 0},
-    {0, 1, 2},
-    {0, 2, 1},
-    {0, 3, 4},
-    {1, 0, 1},
-    {1, 1, 3},
-    {1, 2, 4},
-    {1, 3, 4},
-    {2, 0, 0},
-    {2, 1, 3},
-    {2, 2, 2},
-    {2, 3, 0}};
+constexpr static int nSimCaloHits = 3;          ///< The number of SimCalorimeterHits
+constexpr static int nCaloHitContributions = 4; ///< The number of CalorimeterHit Contributions
+/// idcs to setup relations between SimCalorimeterHits, CaloHitContributions
+/// and MCParticles (in this order)
+using CaloContIdx = std::tuple<int, int, int>;
+/// The index values to use for setting up the relations
+const static std::vector<CaloContIdx> simCaloHitMCIdcs = {{0, 0, 0}, {0, 1, 2}, {0, 2, 1}, {0, 3, 4},
+                                                          {1, 0, 1}, {1, 1, 3}, {1, 2, 4}, {1, 3, 4},
+                                                          {2, 0, 0}, {2, 1, 3}, {2, 2, 2}, {2, 3, 0}};
 
-  /// The number of clusters to create
-  constexpr static int nClusters = 5;
-  /// The number of subdetector energy entries to create
-  constexpr static int nSubdetectorEnergies = 6;
-  /// The calorimeter hits that should be associated with each cluster. First
-  /// index is the cluster, second is the calorimeter hit
-  const static std::vector<IdxPair> clusterHitIdcs = {{0, 0}, {0, 1}, {1, 0}, {2, 1}, {2, 0}, {3, 0}, {3, 0}};
-  /// The clustes (from inside the same collection) that should be added to each
-  /// cluster. First index is the cluster to which the second index cluster will
-  /// be added
-  const static std::vector<IdxPair> clusterClusterIdcs = {{0, 4}, {0, 3}, {0, 1}, {4, 3}, {4, 2}, {2, 3}, {1, 1}};
+/// The number of clusters to create
+constexpr static int nClusters = 5;
+/// The number of subdetector energy entries to create
+constexpr static int nSubdetectorEnergies = 6;
+/// The calorimeter hits that should be associated with each cluster. First
+/// index is the cluster, second is the calorimeter hit
+const static std::vector<IdxPair> clusterHitIdcs = {{0, 0}, {0, 1}, {1, 0}, {2, 1}, {2, 0}, {3, 0}, {3, 0}};
+/// The clustes (from inside the same collection) that should be added to each
+/// cluster. First index is the cluster to which the second index cluster will
+/// be added
+const static std::vector<IdxPair> clusterClusterIdcs = {{0, 4}, {0, 3}, {0, 1}, {4, 3}, {4, 2}, {2, 3}, {1, 1}};
 
-  /// The number of reco particles to create
-  constexpr static int nRecoParticles = 6;
-  /// The related clusters that should be associated to the reco particles.
-  /// First index is the reco particle, second is the index of the cluster in
-  /// its collection
-  const static std::vector<IdxPair> recoClusterIdcs = {{0, 4}, {0, 3}, {2, 2}, {5, 1}, {5, 0}};
+/// The number of reco particles to create
+constexpr static int nRecoParticles = 6;
+/// The related clusters that should be associated to the reco particles.
+/// First index is the reco particle, second is the index of the cluster in
+/// its collection
+const static std::vector<IdxPair> recoClusterIdcs = {{0, 4}, {0, 3}, {2, 2}, {5, 1}, {5, 0}};
 
-  /// The related tracks that should be associated to the reco particles. First
-  /// index is the reco particle, second is the index of the track in its
-  /// collection
-  const static std::vector<IdxPair> recoTrackIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}};
+/// The related tracks that should be associated to the reco particles. First
+/// index is the reco particle, second is the index of the track in its
+/// collection
+const static std::vector<IdxPair> recoTrackIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}};
 
-  /// The related reco partiles that should be associated to the reco particles.
-  /// First index is the reco particle, second is the index of the related reco
-  /// particle
-  const static std::vector<IdxPair> recoRecoIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}, {1, 2}, {2, 4}};
+/// The related reco partiles that should be associated to the reco particles.
+/// First index is the reco particle, second is the index of the related reco
+/// particle
+const static std::vector<IdxPair> recoRecoIdcs = {{0, 3}, {2, 2}, {5, 1}, {5, 0}, {1, 2}, {2, 4}};
 
-  /// The number of entries for the generated ParticleID collections
-  const static std::vector<std::vector<int>> pidRecoIdcs = {{1, 3, 4}, {2, 3}, {0, 1, 2, 3, 4, 5}};
+/// The number of entries for the generated ParticleID collections
+const static std::vector<std::vector<int>> pidRecoIdcs = {{1, 3, 4}, {2, 3}, {0, 1, 2, 3, 4, 5}};
 } // namespace test_config
 
 /**
@@ -118,9 +108,8 @@ namespace test_config {
  * used to determine the daughter element, while the .second index will be used
  * to determine the parent.
  */
-edm4hep::MCParticleCollection createMCParticles(
-  const int num_elements,
-  const std::vector<test_config::IdxPair>& mcp_parents_idx);
+edm4hep::MCParticleCollection createMCParticles(const int num_elements,
+                                                const std::vector<test_config::IdxPair>& mcp_parents_idx);
 
 /**
  * Create a CalorimeterHit collection
@@ -146,44 +135,36 @@ edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements);
  * Create a track collection with tracks that have links to other tracks (in the
  * same collection) and tracker hits
  */
-edm4hep::TrackCollection createTracks(
-  const int num_elements,
-  const int subdetectorhitnumbers,
-  const int num_track_states,
-  const edm4hep::TrackerHit3DCollection& trackerHits,
-  const std::vector<std::size_t>& link_trackerhit_idcs,
-  const std::vector<test_config::IdxPair>& track_link_tracks_idcs);
+edm4hep::TrackCollection createTracks(const int num_elements, const int subdetectorhitnumbers,
+                                      const int num_track_states, const edm4hep::TrackerHit3DCollection& trackerHits,
+                                      const std::vector<std::size_t>& link_trackerhit_idcs,
+                                      const std::vector<test_config::IdxPair>& track_link_tracks_idcs);
 
 /**
  * Create a SimCalorimeterHit (and an accompanying CaloHitContribution)
  * collection with links to MCParticles
  */
-std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection> createSimCalorimeterHits(
-  const int num_elements,
-  const int num_contributions,
-  const edm4hep::MCParticleCollection& mcParticles,
-  const std::vector<test_config::CaloContIdx>& link_mcparticles_idcs);
+std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection>
+createSimCalorimeterHits(const int num_elements, const int num_contributions,
+                         const edm4hep::MCParticleCollection& mcParticles,
+                         const std::vector<test_config::CaloContIdx>& link_mcparticles_idcs);
 
 edm4hep::EventHeaderCollection createEventHeader();
 
-edm4hep::ClusterCollection createClusters(
-  const int num_elements,
-  const edm4hep::CalorimeterHitCollection& caloHits,
-  const int num_subdet_energies,
-  const std::vector<test_config::IdxPair>& clusterHitIdcs,
-  const std::vector<test_config::IdxPair>& clusterClusterIdcs);
+edm4hep::ClusterCollection createClusters(const int num_elements, const edm4hep::CalorimeterHitCollection& caloHits,
+                                          const int num_subdet_energies,
+                                          const std::vector<test_config::IdxPair>& clusterHitIdcs,
+                                          const std::vector<test_config::IdxPair>& clusterClusterIdcs);
 
-edm4hep::ReconstructedParticleCollection createRecoParticles(
-  const int nRecos,
-  const edm4hep::TrackCollection& tracks,
-  const std::vector<test_config::IdxPair>& trackIdcs,
-  const edm4hep::ClusterCollection& clusters,
-  const std::vector<test_config::IdxPair>& clusterIdcs,
-  const std::vector<test_config::IdxPair>& recIdcs);
+edm4hep::ReconstructedParticleCollection createRecoParticles(const int nRecos, const edm4hep::TrackCollection& tracks,
+                                                             const std::vector<test_config::IdxPair>& trackIdcs,
+                                                             const edm4hep::ClusterCollection& clusters,
+                                                             const std::vector<test_config::IdxPair>& clusterIdcs,
+                                                             const std::vector<test_config::IdxPair>& recIdcs);
 
-std::vector<edm4hep::ParticleIDCollection> createParticleIDs(
-  const std::vector<std::vector<int>>& recoIdcs,
-  const edm4hep::ReconstructedParticleCollection& recoParticles);
+std::vector<edm4hep::ParticleIDCollection>
+createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
+                  const edm4hep::ReconstructedParticleCollection& recoParticles);
 
 /**
  * Create an example event that can be used to test the converter. Also populate

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -1,21 +1,20 @@
 #include "ObjectMapping.h"
 
+#include "EVENT/CalorimeterHit.h"
+#include "EVENT/Cluster.h"
+#include "EVENT/LCCollection.h"
 #include "EVENT/LCEvent.h"
+#include "EVENT/MCParticle.h"
+#include "EVENT/ParticleID.h"
+#include "EVENT/RawCalorimeterHit.h"
+#include "EVENT/ReconstructedParticle.h"
+#include "EVENT/SimCalorimeterHit.h"
+#include "EVENT/SimTrackerHit.h"
+#include "EVENT/TPCHit.h"
 #include "EVENT/Track.h"
 #include "EVENT/TrackerHit.h"
 #include "EVENT/TrackerHitPlane.h"
-#include "EVENT/SimTrackerHit.h"
-#include "EVENT/CalorimeterHit.h"
-#include "EVENT/RawCalorimeterHit.h"
-#include "EVENT/SimCalorimeterHit.h"
-#include "EVENT/TPCHit.h"
-#include "EVENT/Cluster.h"
 #include "EVENT/Vertex.h"
-#include "EVENT/ReconstructedParticle.h"
-#include "EVENT/MCParticle.h"
-#include "EVENT/LCEvent.h"
-#include "EVENT/LCCollection.h"
-#include "EVENT/ParticleID.h"
 #include "UTIL/LCIterator.h"
 #include "UTIL/PIDHandler.h"
 
@@ -25,32 +24,31 @@
 #else
 #include "edm4hep/TrackerHitCollection.h"
 namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 } // namespace edm4hep
 #endif
-#include "edm4hep/TrackerHitPlaneCollection.h"
-#include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/ClusterCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/RawCalorimeterHitCollection.h"
-#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/ReconstructedParticleCollection.h"
-#include "edm4hep/RawTimeSeriesCollection.h"
-#include "edm4hep/VertexCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
+#include "edm4hep/RawCalorimeterHitCollection.h"
+#include "edm4hep/RawTimeSeriesCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/VertexCollection.h"
 
 #include "podio/Frame.h"
 
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
-#include <vector>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
-template<typename LcioT, typename EDM4hepT, typename MapT>
-void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl)
-{
+template <typename LcioT, typename EDM4hepT, typename MapT>
+void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl) {
   // Simply assume that the collections have the same size here
   UTIL::LCIterator<LcioT> lcioIt(lcioColl);
 
@@ -60,27 +58,23 @@ void fillMap(MapT& map, EVENT::LCCollection* lcioColl, const EDM4hepT& edmColl)
   }
 }
 
-#define FILL_MAP(Type, mapName)                                  \
-  if (type == #Type) {                                           \
-    using namespace edm4hep;                                     \
-    auto& edm4hepColl = edmEvt.get<Type::collection_type>(name); \
-    fillMap<EVENT::Type>(mapName, lcioColl, edm4hepColl);        \
+#define FILL_MAP(Type, mapName)                                                                                        \
+  if (type == #Type) {                                                                                                 \
+    using namespace edm4hep;                                                                                           \
+    auto& edm4hepColl = edmEvt.get<Type::collection_type>(name);                                                       \
+    fillMap<EVENT::Type>(mapName, lcioColl, edm4hepColl);                                                              \
   }
 
-void fillRecoPIDMaps(
-  ObjectMappings::Map<const EVENT::ReconstructedParticle*>& recoMap,
-  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID>& pidMap,
-  const std::string& recoName,
-  EVENT::LCEvent* lcEvt,
-  const podio::Frame& edmEvt)
-{
+void fillRecoPIDMaps(ObjectMappings::Map<const EVENT::ReconstructedParticle*>& recoMap,
+                     std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID>& pidMap,
+                     const std::string& recoName, EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt) {
   UTIL::LCIterator<EVENT::ReconstructedParticle> lcioIt(lcEvt, recoName);
   UTIL::PIDHandler pidHandler(lcioIt());
   const auto& edmColl = edmEvt.get<edm4hep::ReconstructedParticleCollection>(recoName);
 
   // Simply need to assume here that per algorithm the pid "collections" run in
   // parallel.
-  std::unordered_map<std::string, unsigned> algoIdcs {};
+  std::unordered_map<std::string, unsigned> algoIdcs{};
   for (const auto edmElem : edmColl) {
     const auto* lcioElem = lcioIt.next();
     recoMap.emplace(lcioElem, edmElem.getObjectID());
@@ -95,8 +89,7 @@ void fillRecoPIDMaps(
   }
 }
 
-std::string getRecoName(const std::string& pidName)
-{
+std::string getRecoName(const std::string& pidName) {
   const auto pos = pidName.find("_PID_");
   if (pos != std::string::npos) {
     return pidName.substr(0, pos);
@@ -104,9 +97,8 @@ std::string getRecoName(const std::string& pidName)
   return "";
 }
 
-ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt)
-{
-  ObjectMappings mapping {};
+ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt) {
+  ObjectMappings mapping{};
   for (const auto& name : *(lcEvt->getCollectionNames())) {
     // We only use non subset collections here, because we want the "real"
     // objects

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -8,44 +8,44 @@
 #include <unordered_map>
 
 namespace EVENT {
-  class Track;
-  class TrackerHit;
-  class TrackerHitPlane;
-  class SimTrackerHit;
-  class CalorimeterHit;
-  class RawCalorimeterHit;
-  class SimCalorimeterHit;
-  class TPCHit;
-  class Cluster;
-  class Vertex;
-  class ReconstructedParticle;
-  class MCParticle;
-  class LCEvent;
-  class ParticleID;
+class Track;
+class TrackerHit;
+class TrackerHitPlane;
+class SimTrackerHit;
+class CalorimeterHit;
+class RawCalorimeterHit;
+class SimCalorimeterHit;
+class TPCHit;
+class Cluster;
+class Vertex;
+class ReconstructedParticle;
+class MCParticle;
+class LCEvent;
+class ParticleID;
 } // namespace EVENT
 
 namespace podio {
-  class Frame;
+class Frame;
 } // namespace podio
 
 struct ObjectMappings {
-  template<typename K>
+  template <typename K>
   using Map = std::unordered_map<K, podio::ObjectID>;
 
-  Map<const EVENT::Track*> tracks {};
-  Map<const EVENT::TrackerHit*> trackerHits {};
-  Map<const EVENT::TrackerHitPlane*> trackerHitPlanes {};
-  Map<const EVENT::SimTrackerHit*> simTrackerHits {};
-  Map<const EVENT::Cluster*> clusters {};
-  Map<const EVENT::CalorimeterHit*> caloHits {};
-  Map<const EVENT::RawCalorimeterHit*> rawCaloHits {};
-  Map<const EVENT::SimCalorimeterHit*> simCaloHits {};
-  Map<const EVENT::MCParticle*> mcParticles {};
-  Map<const EVENT::ReconstructedParticle*> recoParticles {};
-  Map<const EVENT::TPCHit*> tpcHits {};
-  Map<const EVENT::Vertex*> vertices {};
+  Map<const EVENT::Track*> tracks{};
+  Map<const EVENT::TrackerHit*> trackerHits{};
+  Map<const EVENT::TrackerHitPlane*> trackerHitPlanes{};
+  Map<const EVENT::SimTrackerHit*> simTrackerHits{};
+  Map<const EVENT::Cluster*> clusters{};
+  Map<const EVENT::CalorimeterHit*> caloHits{};
+  Map<const EVENT::RawCalorimeterHit*> rawCaloHits{};
+  Map<const EVENT::SimCalorimeterHit*> simCaloHits{};
+  Map<const EVENT::MCParticle*> mcParticles{};
+  Map<const EVENT::ReconstructedParticle*> recoParticles{};
+  Map<const EVENT::TPCHit*> tpcHits{};
+  Map<const EVENT::Vertex*> vertices{};
 
-  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs {};
+  std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs{};
 
   static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
 };


### PR DESCRIPTION
BEGINRELEASENOTES
- Synchronize `.clang-format` configuration with the one from `key4hep-dev-utils/defaults` to have the same configuration as in other Key4hep repositories.
- Make necessary format changes.
- Switch the pre-commit CI workflow to use the key4hep nightlies as environment.

ENDRELEASENOTES

@jmcarcell I am not sure why this was not done by the sync script. Was this disabled for this repo for clang-format?