### PR TITLE
Standalone printout only for every 10% of processed events

### DIFF
--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -209,8 +209,9 @@ int main(int argc, char* argv[]) {
 
   const int nEvt = args.nEvents > 0 ? args.nEvents : lcreader->getNumberOfEvents();
   for (int i = 0; i < nEvt; ++i) {
-    if (i % 10 == 0) {
-      std::cout << "processing Event: " << i << std::endl;
+    int percEvt = i * 100 / (nEvt - 1);
+    if (percEvt % 10 == 0) {
+      std::cout << "processed amount of events: " << percEvt << "% (event: " << i << ")" << std::endl;
     }
     auto evt = lcreader->readNextEvent();
     // Patching the Event to make sure all events contain the same Collections.

--- a/tests/compare_contents.cpp
+++ b/tests/compare_contents.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
 
   // loop going over every name of the lcio collection and checking if a
   // collection with the same name exists in the edm file.
-  std::cout << "number of Events" << edmreader.getEntries("events") << std::endl;
+  std::cout << "number of Events " << edmreader.getEntries("events") << std::endl;
   for (size_t n = 0; n < edmreader.getEntries("events"); ++n) {
     if (n % 10 == 0) {
       std::cout << "Event number: " << n << std::endl;


### PR DESCRIPTION
BEGINRELEASENOTES
- Standalone printout only for every 10% of processed events instead of every 10 events

ENDRELEASENOTES

fixes #65 