### PR TITLE
Convert dQ/dx information in both directions for Tracks

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -17,6 +17,7 @@
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/RecDqdxCollection.h>
 #include <edm4hep/RecoParticleVertexAssociationCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
@@ -104,6 +105,11 @@ struct ParticleIDConvData {
   std::string name;
   const edm4hep::ParticleIDCollection* coll;
   std::optional<edm4hep::utils::ParticleIDMeta> metadata;
+};
+
+struct TrackDqdxConvData {
+  std::string name;
+  const edm4hep::RecDqdxCollection* coll;
 };
 
 /// Sort the ParticleIDs according to their algorithmType.
@@ -398,6 +404,20 @@ void resolveRelationsClusters(ClusterMapT& clustersMap, const CaloHitMapT& caloH
 
 template <typename PidMapT, typename RecoParticleMapT>
 void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMap);
+
+/// Attach the dE/dx information that is stored in the RecDqdxCollections to the
+/// corresponding tracks
+///
+/// @note: This assumes that all tracks have been converted already
+template <typename TrackMapT>
+void attachDedxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections);
+
+/// Attach the dE/dx information that is stored in the RecDqdxCollection to the
+/// corresponding tracks
+///
+/// @note: This assumes that all tracks have been converted already
+template <typename TrackMapT>
+void attachDedxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection);
 
 /**
  * Resolve all relations in all converted objects that are held in the map.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -410,14 +410,14 @@ void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMa
 ///
 /// @note: This assumes that all tracks have been converted already
 template <typename TrackMapT>
-void attachDedxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections);
+void attachDqdxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections);
 
 /// Attach the dE/dx information that is stored in the RecDqdxCollection to the
 /// corresponding tracks
 ///
 /// @note: This assumes that all tracks have been converted already
 template <typename TrackMapT>
-void attachDedxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection);
+void attachDqdxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection);
 
 /**
  * Resolve all relations in all converted objects that are held in the map.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -31,8 +31,6 @@ std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollect
       }
       lcio_tr->setChi2(edm_tr.getChi2());
       lcio_tr->setNdf(edm_tr.getNdf());
-      lcio_tr->setdEdx(edm_tr.getDEdx());
-      lcio_tr->setdEdxError(edm_tr.getDEdxError());
       lcio_tr->setRadiusOfInnermostHit(getRadiusOfStateAtFirstHit(edm_tr).value_or(-1.0));
 
       // Loop over the hit Numbers in the track
@@ -725,6 +723,29 @@ void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMa
       lcioReco.value()->addParticleID(lcioPid);
     } else {
       std::cerr << "Cannot find a reconstructed particle to attach a ParticleID to" << std::endl;
+    }
+  }
+}
+
+template <typename TrackMapT>
+void attachDedxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections) {
+  for (const auto& coll : dQdxCollections) {
+    attachDedxInfo(trackMap, coll);
+  }
+}
+
+template <typename TrackMapT>
+void attachDedxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection) {
+  const auto& [name, coll] = dQdxCollection;
+
+  for (const auto& elem : *coll) {
+    const auto dQdxTrack = elem.getTrack();
+    const auto lcioTrack = k4EDM4hep2LcioConv::detail::mapLookupFrom(dQdxTrack, trackMap);
+    if (lcioTrack) {
+      lcioTrack.value()->setdEdx(elem.getDQdx().value);
+      lcioTrack.value()->setdEdxError(elem.getDQdx().error);
+    } else {
+      std::cerr << "Cannot find a track to attach dQ/dx information to for collection: " << name << std::endl;
     }
   }
 }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -728,14 +728,14 @@ void resolveRelationsParticleIDs(PidMapT& pidMap, const RecoParticleMapT& recoMa
 }
 
 template <typename TrackMapT>
-void attachDedxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections) {
+void attachDqdxInfo(TrackMapT& trackMap, const std::vector<TrackDqdxConvData>& dQdxCollections) {
   for (const auto& coll : dQdxCollections) {
-    attachDedxInfo(trackMap, coll);
+    attachDqdxInfo(trackMap, coll);
   }
 }
 
 template <typename TrackMapT>
-void attachDedxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection) {
+void attachDqdxInfo(TrackMapT& trackMap, const TrackDqdxConvData& dQdxCollection) {
   const auto& [name, coll] = dQdxCollection;
 
   for (const auto& elem : *coll) {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -275,8 +275,8 @@ convertTrackerHitPlanes(const std::string& name, EVENT::LCCollection* LCCollecti
  * Simultaneously populates the mapping from LCIO to EDM4hep objects.
  */
 template <typename TrackMapT>
-std::unique_ptr<edm4hep::TrackCollection> convertTracks(const std::string& name, EVENT::LCCollection* LCCollection,
-                                                        TrackMapT& TrackMap);
+std::vector<CollNamePair> convertTracks(const std::string& name, EVENT::LCCollection* LCCollection,
+                                        TrackMapT& TrackMap);
 
 /**
  * Convert a SimCalorimeterHit collection and return the resulting collection.

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
     convertParticleIDs(pidCollMeta.coll, objectMappings.particleIDs, algoId);
   }
 
-  attachDedxInfo(objectMappings.tracks, dQdxCollections);
+  attachDqdxInfo(objectMappings.tracks, dQdxCollections);
 
   resolveRelations(objectMappings);
 

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -32,6 +32,7 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_3");
   ASSERT_SAME_OR_ABORT(edm4hep::MCRecoParticleAssociationCollection, "mcRecoAssocs");
   ASSERT_SAME_OR_ABORT(edm4hep::MCRecoCaloAssociationCollection, "mcCaloHitsAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::RecDqdxCollection, "tracks_dQdx")
 
   return 0;
 }

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -21,7 +21,7 @@ int main() {
     const auto edmColl = edmEvent.get(name);
     const auto typeName = edmColl->getValueTypeName();
     if (typeName == "edm4hep::CaloHitContribution" || typeName == "edm4hep::ParticleID" ||
-        typeName == "edm4hep::EventHeader") {
+        typeName == "edm4hep::EventHeader" || typeName == "edm4hep::RecDqdx") {
       continue;
     }
     try {
@@ -42,7 +42,7 @@ int main() {
   for (const auto& name : edmEvent.getAvailableCollections()) {
     const auto type = edmEvent.get(name)->getTypeName();
     if (type == "edm4hep::CaloHitContributionCollection" || type == "edm4hep::ParticleIDCollection" ||
-        type == "edm4hep::EventHeaderCollection") {
+        type == "edm4hep::EventHeaderCollection" || type == "edm4hep::RecDqdxCollection") {
       continue;
     }
     const auto* lcioColl = lcioEvent->getCollection(name);

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -53,4 +53,6 @@ bool compare(const AssociationCollT& origColl, const AssociationCollT& roundtrip
   return true;
 }
 
+bool compare(const edm4hep::RecDqdxCollection& origColl, const edm4hep::RecDqdxCollection& roundtripColl);
+
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -303,18 +303,16 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getNdf, "ndf in Track");
-  // LCIO has getdEdx instead of getDEdx
-  ASSERT_COMPARE_VALS(lcioElem->getdEdx(), edm4hepElem.getDEdx(), "dEdx in Track");
-  ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), edm4hepElem.getDEdxError(), "dEdxError in Track");
-  // Also check whether these have been corretly put into the dQQuantities
-  const auto dxQuantities = edm4hepElem.getDxQuantities();
-  if (dxQuantities.size() != 1) {
-    std::cerr << "DxQuantities have not been filled correctly, expected exactly 1, got " << dxQuantities.size()
-              << " in Track" << std::endl;
+
+  // EDM4hep does not have the dEdx information inside the track, but rather
+  // inside a RecDqdx object
+  const auto& dQdxInfos = objectMaps.trackPidHandler.getDqdxValues(edm4hepElem);
+  if (dQdxInfos.size() != 1) {
+    std::cerr << "Could not find a unique RecDqdx object for track" << std::endl;
     return false;
   }
-  ASSERT_COMPARE_VALS(lcioElem->getdEdx(), dxQuantities[0].value, "dEdx in DxQuantities in Track");
-  ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), dxQuantities[0].error, "dEdxError in DxQuantities in Track");
+  ASSERT_COMPARE_VALS(lcioElem->getdEdx(), dQdxInfos[0].getDQdx().value, "dEdx in Track");
+  ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), dQdxInfos[0].getDQdx().error, "dEdxError in Track");
 
   double radius = EDM4hep2LCIOConv::getRadiusOfStateAtFirstHit(edm4hepElem).value_or(-1.0);
   double radius3D = EDM4hep2LCIOConv::getRadiusOfStateAtFirstHit(edm4hepElem, true).value_or(-1.0);

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -18,6 +18,7 @@
 #include <edm4hep/MCRecoTrackerAssociationCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/RecDqdxCollection.h>
 #include <edm4hep/RecoParticleVertexAssociationCollection.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -89,14 +89,6 @@ void fillRecoPIDMaps(ObjectMappings::Map<const EVENT::ReconstructedParticle*>& r
   }
 }
 
-std::string getRecoName(const std::string& pidName) {
-  const auto pos = pidName.find("_PID_");
-  if (pos != std::string::npos) {
-    return pidName.substr(0, pos);
-  }
-  return "";
-}
-
 ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt) {
   ObjectMappings mapping{};
   for (const auto& name : *(lcEvt->getCollectionNames())) {

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -19,6 +19,7 @@
 #include "UTIL/PIDHandler.h"
 
 #include "edm4hep/TrackCollection.h"
+#include <edm4hep/RecDqdxCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
@@ -124,6 +125,9 @@ ObjectMappings ObjectMappings::fromEvent(EVENT::LCEvent* lcEvt, const podio::Fra
     // conceptual differences
     if (type == "ReconstructedParticle") {
       fillRecoPIDMaps(mapping.recoParticles, mapping.particleIDs, name, lcEvt, edmEvt);
+    }
+    if (type == "Track") {
+      mapping.trackPidHandler.addColl(edmEvt.get<edm4hep::RecDqdxCollection>(name + "_dQdx"));
     }
   }
 

--- a/tests/src/ObjectMapping.h
+++ b/tests/src/ObjectMapping.h
@@ -2,6 +2,7 @@
 #define K4EDM4HEP2LCIOCONV_TEST_OBJECTMAPPINGS_H
 
 #include <edm4hep/ParticleID.h>
+#include <edm4hep/utils/TrackUtils.h>
 
 #include "podio/ObjectID.h"
 
@@ -46,6 +47,8 @@ struct ObjectMappings {
   Map<const EVENT::Vertex*> vertices{};
 
   std::unordered_map<const EVENT::ParticleID*, edm4hep::ParticleID> particleIDs{};
+
+  edm4hep::utils::TrackPIDHandler trackPidHandler{};
 
   static ObjectMappings fromEvent(EVENT::LCEvent* lcEvt, const podio::Frame& edmEvt);
 };


### PR DESCRIPTION
needed after https://github.com/key4hep/EDM4hep/pull/311. I think in this case all the comparisons are simply dropped since we are not saving that dE/dx information in another place.

BEGINRELEASENOTES
- Make the conversion handle the fact that EDM4hep tracks do no longer have any dQ/dx information but rather store this in a separate `RecDqdx` collection.
  - From LCIO to EDM4hep: Create a `RecDqdx` collection for every converted track collection with the suffix `_dQdx`
  - From EDM4hep to LCIO: Offer functionality to attach the information stored in `RecDqdx` collections to converted tracks via the `attachDqdxInfo` function(s).

ENDRELEASENOTES