### PR TITLE
Don't use radiusOfInnermostHit for EDM4hep tracks

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -431,10 +431,10 @@ convEvent(const podio::Frame& edmEvent, const podio::Frame& metadata = podio::Fr
 }
 
 /**
- * Get the 3D radius of the TrackState at the IP from the given track. This is
+ * Get the radius of the TrackState at the first from the given track. This is
  * used to set the radiusOfInnermostHit in the LCIO track during the conversion
  */
-std::optional<double> getRadiusOfStateAtIP(const edm4hep::Track& track);
+std::optional<double> getRadiusOfStateAtFirstHit(const edm4hep::Track& track, bool use3D = false);
 
 } // namespace EDM4hep2LCIOConv
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -134,6 +134,10 @@ std::optional<int32_t> attachParticleIDMetaData(IMPL::LCEventImpl* lcEvent, cons
 /**
  * Convert EDM4hep Tracks to LCIO. Simultaneously populate the mapping from
  * EDM4hep to LCIO objects for relation resolving in a second step.
+ *
+ * NOTE: Since the edm4hep::Track does not have a radiusOfInnermostHit field,
+ * this quantity is calculated on the fly from the attached TrackState using the
+ * getRadiusOfStateAtFirstHit function with the default 2D version.
  */
 template <typename TrackMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollection* const edmCollection,

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -430,6 +430,12 @@ convEvent(const podio::Frame& edmEvent, const podio::Frame& metadata = podio::Fr
   return convertEvent(edmEvent, metadata);
 }
 
+/**
+ * Get the 3D radius of the TrackState at the IP from the given track. This is
+ * used to set the radiusOfInnermostHit in the LCIO track during the conversion
+ */
+std::optional<double> getRadiusOfStateAtIP(const edm4hep::Track& track);
+
 } // namespace EDM4hep2LCIOConv
 
 #include "k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp"

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -1,6 +1,8 @@
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
 #include <cassert>
+#include <cmath>
+#include <limits>
 
 #include "TMath.h"
 
@@ -25,7 +27,15 @@ std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollect
       lcio_tr->setNdf(edm_tr.getNdf());
       lcio_tr->setdEdx(edm_tr.getDEdx());
       lcio_tr->setdEdxError(edm_tr.getDEdxError());
-      lcio_tr->setRadiusOfInnermostHit(edm_tr.getRadiusOfInnermostHit());
+      double radius = std::numeric_limits<double>::max();
+      for (const auto& hit : edm_tr.getTrackerHits()) {
+        radius = std::min(radius, std::sqrt(hit.getPosition()[0] * hit.getPosition()[0] +
+                                            hit.getPosition()[1] * hit.getPosition()[1]));
+      }
+      if (radius == std::numeric_limits<double>::max()) {
+        radius = 0;
+      }
+      lcio_tr->setRadiusOfInnermostHit(radius);
 
       // Loop over the hit Numbers in the track
       lcio_tr->subdetectorHitNumbers().resize(edm_tr.subdetectorHitNumbers_size());

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -27,7 +27,7 @@ std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollect
       lcio_tr->setNdf(edm_tr.getNdf());
       lcio_tr->setdEdx(edm_tr.getDEdx());
       lcio_tr->setdEdxError(edm_tr.getDEdxError());
-      lcio_tr->setRadiusOfInnermostHit(getRadiusOfStateAtIP(edm_tr).value_or(-1.0));
+      lcio_tr->setRadiusOfInnermostHit(getRadiusOfStateAtFirstHit(edm_tr).value_or(-1.0));
 
       // Loop over the hit Numbers in the track
       lcio_tr->subdetectorHitNumbers().resize(edm_tr.subdetectorHitNumbers_size());

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <limits>
 
 #include "TMath.h"
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -27,15 +27,7 @@ std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollect
       lcio_tr->setNdf(edm_tr.getNdf());
       lcio_tr->setdEdx(edm_tr.getDEdx());
       lcio_tr->setdEdxError(edm_tr.getDEdxError());
-      double radius = std::numeric_limits<double>::max();
-      for (const auto& hit : edm_tr.getTrackerHits()) {
-        radius = std::min(radius, std::sqrt(hit.getPosition()[0] * hit.getPosition()[0] +
-                                            hit.getPosition()[1] * hit.getPosition()[1]));
-      }
-      if (radius == std::numeric_limits<double>::max()) {
-        radius = 0;
-      }
-      lcio_tr->setRadiusOfInnermostHit(radius);
+      lcio_tr->setRadiusOfInnermostHit(getRadiusOfStateAtIP(edm_tr).value_or(-1.0));
 
       // Loop over the hit Numbers in the track
       lcio_tr->subdetectorHitNumbers().resize(edm_tr.subdetectorHitNumbers_size());

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -348,7 +348,6 @@ std::unique_ptr<edm4hep::TrackCollection> convertTracks(const std::string& name,
     lval.setNdf(rval->getNdf());
     lval.setDEdx(rval->getdEdx());
     lval.setDEdxError(rval->getdEdxError());
-    lval.setRadiusOfInnermostHit(rval->getRadiusOfInnermostHit());
 
     auto subdetectorHitNum = rval->getSubdetectorHitNumbers();
     for (auto hitNum : subdetectorHitNum) {

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -147,11 +147,11 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
   return lcioEvent;
 }
 
-std::optional<double> getRadiusOfStateAtIP(const edm4hep::Track& track) {
+std::optional<double> getRadiusOfStateAtFirstHit(const edm4hep::Track& track, bool use3D) {
   for (const auto& state : track.getTrackStates()) {
-    if (state.location == edm4hep::TrackState::AtIP) {
+    if (state.location == edm4hep::TrackState::AtFirstHit) {
       const auto refP = state.referencePoint;
-      return std::sqrt(refP.x * refP.x + refP.y * refP.y + refP.z * refP.z);
+      return std::sqrt(refP.x * refP.x + refP.y * refP.y + use3D * refP.z * refP.z);
     }
   }
   return std::nullopt;

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -147,4 +147,14 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
   return lcioEvent;
 }
 
+std::optional<double> getRadiusOfStateAtIP(const edm4hep::Track& track) {
+  for (const auto& state : track.getTrackStates()) {
+    if (state.location == edm4hep::TrackState::AtIP) {
+      const auto refP = state.referencePoint;
+      return std::sqrt(refP.x * refP.x + refP.y * refP.y + refP.z * refP.z);
+    }
+  }
+  return std::nullopt;
+}
+
 } // namespace EDM4hep2LCIOConv

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(TestUtils PUBLIC EDM4HEP::edm4hep LCIO::lcio)
 target_include_directories(TestUtils PUBLIC ${LCIO_INCLUDE_DIRS})
 
 add_executable(compare-contents compare_contents.cpp)
-target_link_libraries(compare-contents PRIVATE edmCompare podio::podioRootIO)
+target_link_libraries(compare-contents PRIVATE edmCompare podio::podioRootIO k4EDM4hep2LcioConv)
 target_include_directories(compare-contents PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>)
 

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -3,6 +3,7 @@
 
 #include "IMPL/TrackerHitImpl.h"
 
+#include <cmath>
 #include <cstdint>
 
 #include "TMath.h"
@@ -314,7 +315,17 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   ASSERT_COMPARE_VALS(lcioElem->getdEdx(), dxQuantities[0].value, "dEdx in DxQuantities in Track");
   ASSERT_COMPARE_VALS(lcioElem->getdEdxError(), dxQuantities[0].error, "dEdxError in DxQuantities in Track");
 
-  ASSERT_COMPARE(lcioElem, edm4hepElem, getRadiusOfInnermostHit, "radiusOfInnermostHit in Track");
+  double radius = std::numeric_limits<double>::max();
+  for (const auto& hit : edm4hepElem.getTrackerHits()) {
+    radius = std::min(
+        radius, std::sqrt(hit.getPosition()[0] * hit.getPosition()[0] + hit.getPosition()[1] * hit.getPosition()[1]));
+  }
+  if (radius == std::numeric_limits<double>::max()) {
+    radius = 0;
+  }
+    ASSERT_COMPARE_VALS_FLOAT(lcioElem->getRadiusOfInnermostHit(), radius, lcioElem->getRadiusOfInnermostHit() / 1e6,
+                              "radiusOfInnermostHit in Track");
+  }
 
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getTracks, objectMaps.tracks, "Tracks in Track");
 

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -323,6 +323,17 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   if (radius == std::numeric_limits<double>::max()) {
     radius = 0;
   }
+  std::cout << lcioElem->getRadiusOfInnermostHit() << " " << lcioElem->getTrackerHits().size() << std::endl;
+  std::cout << radius << " " << edm4hepElem.getTrackerHits().size() << std::endl;
+  if (lcioElem->getTrackerHits().size()) {
+    for (const auto* hit : lcioElem->getTrackerHits()) {
+      std::cout << std::sqrt(hit->getPosition()[0] * hit->getPosition()[0] +
+                             hit->getPosition()[1] * hit->getPosition()[1])
+                << std::sqrt(hit->getPosition()[0] * hit->getPosition()[0] +
+                             hit->getPosition()[1] * hit->getPosition()[1] +
+                             hit->getPosition()[2] * hit->getPosition()[2])
+                << hit->getQuality() << " " << hit->getType() << std::endl;
+    }
     ASSERT_COMPARE_VALS_FLOAT(lcioElem->getRadiusOfInnermostHit(), radius, lcioElem->getRadiusOfInnermostHit() / 1e6,
                               "radiusOfInnermostHit in Track");
   }

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -199,7 +199,6 @@ edm4hep::TrackCollection createTracks(const int num_elements, const int subdetec
     elem.setType(2); // TODO specific type
     elem.setChi2(i * 10.f);
     elem.setNdf(i * 12);
-    elem.setRadiusOfInnermostHit(i * 5.f);
 
     elem.setDEdx(i);
     elem.setDEdxError(i / std::sqrt(i + 1));


### PR DESCRIPTION
and compute it from hits when going from EDM4hep to LCIO. See
https://github.com/key4hep/EDM4hep/pull/326. Uses the utility to compare floats introduced in https://github.com/key4hep/k4EDM4hep2LcioConv/pull/71.

Currently there is an issue in the comparisons because in some LCIO collections the radius of the inner most hit doesn't match what you get from the list of hist associated with the track, which isn't enforced anywhere that it should be. One option is to loosen the comparison criteria.

BEGINRELEASENOTES
- Don't use radiusOfInnermostHit for EDM4hep tracks, compute it from track state at first hit when going from LCIO to EDM4hep.

ENDRELEASENOTES