### PR TITLE
Remove association that will be removed in EDM4hep

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -15,7 +15,6 @@
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
-#include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -874,14 +874,6 @@ createAssociations(const ObjectMappingT& typeMapping,
       auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
-    } else if (fromType == "SimTrackerHit" && toType == "TrackerHitPlane") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerHitPlaneAssociationCollection, false>(
-          relations, typeMapping.simTrackerHits, typeMapping.trackerHitPlanes);
-      assoCollVec.emplace_back(name, std::move(mc_a));
-    } else if (fromType == "TrackerHitPlane" && toType == "SimTrackerHit") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerHitPlaneAssociationCollection, true>(
-          relations, typeMapping.trackerHitPlanes, typeMapping.simTrackerHits);
-      assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "ReconstructedParticle" && toType == "Vertex") {
       auto mc_a = createAssociationCollection<edm4hep::RecoParticleVertexAssociationCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.vertices);

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -14,7 +14,6 @@
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackParticleAssociationCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
-#include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `MCRecoTrackerHitPlaneAssociation` since it has been / will be removed from EDM4hep in [EDM4hep#331](https://github.com/key4hep/EDM4hep/pull/331)

ENDRELEASENOTES

These changes do **not** require the EDM4hep PR to be merged first!