### PR TITLE
Make sure to still convert TrackerHitPlane associations

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -866,11 +866,11 @@ createAssociations(const ObjectMappingT& typeMapping,
       auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackParticleAssociationCollection, true>(
           relations, typeMapping.tracks, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
-    } else if (fromType == "TrackerHit" && toType == "SimTrackerHit") {
+    } else if ((fromType == "TrackerHit" || fromType == "TrackerHitPlane") && toType == "SimTrackerHit") {
       auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, true>(
           relations, typeMapping.trackerHits, typeMapping.simTrackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
-    } else if (fromType == "SimTrackerHit" && toType == "TrackerHit") {
+    } else if (fromType == "SimTrackerHit" && (toType == "TrackerHit" || fromType == "TrackerHitPlane")) {
       auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to still convert assocations between `TrackerHitPlane` and `SimTrackerHit`

ENDRELEASENOTES

Small bug introduced in #73 

@Zehvogel, this should get rid of the messages you see, I think.
