### PR TITLE
Find MathCore from ROOT since it is being linked to later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ k4edm4hep2lcioconv_set_compiler_flags()
 find_package(LCIO 2.20.1 REQUIRED)
 find_package(podio REQUIRED)
 find_package(EDM4HEP 0.10.1 REQUIRED)
+find_package(ROOT REQUIRED COMPONENTS MathCore)
 
 add_subdirectory(k4EDM4hep2LcioConv)
 add_subdirectory(standalone)

--- a/k4EDM4hep2LcioConv/CMakeLists.txt
+++ b/k4EDM4hep2LcioConv/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(ROOT REQUIRED COMPONENTS MathCore)
-
 add_library(k4EDM4hep2LcioConv SHARED
   src/k4EDM4hep2LcioConv.cpp
   src/k4Lcio2EDM4hepConv.cpp


### PR DESCRIPTION
Locally CMake complains that `ROOT::MathCore` isn't found for `edmCompare`, I add it to the top-level `CMakeLists.txt` since it's already being used for the converter. See #71 and #75. 

BEGINRELEASENOTES
- Find `MathCore` from ROOT since it is being linked to later

ENDRELEASENOTES