### PR TITLE
Make sure to always put a CaloHitContribution collection into the event

### DIFF
--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -218,7 +218,10 @@ int main(int argc, char* argv[]) {
     if (patching == true) {
       colPatcher.patchCollections(evt);
     }
-    const auto edmEvent = LCIO2EDM4hepConv::convertEvent(evt, collsToConvert);
+    auto edmEvent = LCIO2EDM4hepConv::convertEvent(evt, collsToConvert);
+    if (edmEvent.get("AllCaloHitContributionsCombined") == nullptr) {
+      edmEvent.put(edm4hep::CaloHitContributionCollection(), "AllCaloHitContributionsCombined");
+    }
 
     // For the first event we also convert some meta information for the
     // ParticleID handling

--- a/standalone/lcio2edm4hep.cpp
+++ b/standalone/lcio2edm4hep.cpp
@@ -161,7 +161,6 @@ int main(int argc, char* argv[]) {
   UTIL::CheckCollections colPatcher{};
   std::vector<NamesType> namesTypes{};
   const bool patching = !args.patchFile.empty();
-  // Keep track of whether we have any SimCalorimeterHits
   if (patching) {
     namesTypes = getNamesAndTypes(args.patchFile);
     if (namesTypes.empty()) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Always put a `CaloHitContribution` collection into the event, even if no `SimCalorimeterHit`s have been converted in `lcio2edm4hep`. Fixes [#78](https://github.com/key4hep/k4EDM4hep2LcioConv/issues/78)

ENDRELEASENOTES
