### PR TITLE
Convert existing association types to LCRelation collections

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -410,6 +410,9 @@ void resolveRelations(ObjectMappingT& typeMapping);
 template <typename ObjectMappingT, typename ObjectMappingU>
 void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
+/**
+ * Convert the passed associatoin collections to LCRelation collections
+ */
 template <typename ObjectMappingT>
 std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> createLCRelationCollections(
     const std::vector<std::tuple<std::string, const podio::CollectionBase*>>& associationCollections,

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -411,9 +411,9 @@ template <typename ObjectMappingT, typename ObjectMappingU>
 void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
 template <typename ObjectMappingT>
-std::vector<std::unique_ptr<lcio::LCCollection>>
-createLCRelationCollections(const std::vector<const podio::CollectionBase*>& associationCollections,
-                            const ObjectMappingT& objectMaps);
+std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> createLCRelationCollections(
+    const std::vector<std::tuple<std::string, const podio::CollectionBase*>>& associationCollections,
+    const ObjectMappingT& objectMaps);
 
 /**
  * Create an LCRelation collection from the passed Association Collection

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -411,6 +411,18 @@ template <typename ObjectMappingT, typename ObjectMappingU>
 void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
 template <typename ObjectMappingT>
+std::vector<std::unique_ptr<lcio::LCCollection>>
+createLCRelationCollections(const std::vector<const podio::CollectionBase*>& associationCollections,
+                            const ObjectMappingT& objectMaps);
+
+/**
+ * Create an LCRelation collection from the passed Association Collection
+ */
+template <typename AssocCollT, typename FromMapT, typename ToMapT>
+std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const AssocCollT& associations, const FromMapT& fromMap,
+                                                               const ToMapT& toMap);
+
+template <typename ObjectMappingT>
 [[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs) {
   resolveRelations(update_pairs);
 }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -8,9 +8,9 @@
 #include <edm4hep/MCRecoTrackerAssociationCollection.h>
 #include <edm4hep/RecoParticleVertexAssociationCollection.h>
 
-#include "TMath.h"
-
 #include <UTIL/LCRelationNavigator.h>
+
+#include "TMath.h"
 
 namespace EDM4hep2LCIOConv {
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -761,21 +761,21 @@ std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> create
   for (const auto& [name, coll] : associationCollections) {
     if (const auto assocs = dynamic_cast<const edm4hep::MCRecoParticleAssociationCollection*>(coll)) {
       relationColls.emplace_back(name,
-                                 createLCRelationCollection(*assocs, objectMaps.mcParticles, objectMaps.recoParticles));
+                                 createLCRelationCollection(*assocs, objectMaps.recoParticles, objectMaps.mcParticles));
     } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoCaloAssociationCollection*>(coll)) {
       relationColls.emplace_back(name,
-                                 createLCRelationCollection(*assocs, objectMaps.simCaloHits, objectMaps.caloHits));
+                                 createLCRelationCollection(*assocs, objectMaps.caloHits, objectMaps.simCaloHits));
     } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoTrackerAssociationCollection*>(coll)) {
       relationColls.emplace_back(
-          name, createLCRelationCollection(*assocs, objectMaps.simTrackerHits, objectMaps.trackerHits));
+          name, createLCRelationCollection(*assocs, objectMaps.trackerHits, objectMaps.simTrackerHits));
     } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoCaloParticleAssociationCollection*>(coll)) {
       relationColls.emplace_back(name,
-                                 createLCRelationCollection(*assocs, objectMaps.mcParticles, objectMaps.caloHits));
+                                 createLCRelationCollection(*assocs, objectMaps.caloHits, objectMaps.mcParticles));
     } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoClusterParticleAssociationCollection*>(coll)) {
       relationColls.emplace_back(name,
-                                 createLCRelationCollection(*assocs, objectMaps.mcParticles, objectMaps.clusters));
+                                 createLCRelationCollection(*assocs, objectMaps.clusters, objectMaps.mcParticles));
     } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoTrackParticleAssociationCollection*>(coll)) {
-      relationColls.emplace_back(name, createLCRelationCollection(*assocs, objectMaps.mcParticles, objectMaps.tracks));
+      relationColls.emplace_back(name, createLCRelationCollection(*assocs, objectMaps.tracks, objectMaps.mcParticles));
     } else if (const auto assocs = dynamic_cast<const edm4hep::RecoParticleVertexAssociationCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.recoParticles, objectMaps.vertices));
@@ -832,8 +832,8 @@ std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const AssocCollT&
                   << " and " << detail::getTypeName<ToLCIOT>() << std::endl;
       }
     } else {
-      const auto edm4hepTo = assoc.getRec();
-      const auto edm4hepFrom = assoc.getSim();
+      const auto edm4hepTo = assoc.getSim();
+      const auto edm4hepFrom = assoc.getRec();
       const auto lcioTo = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepTo, toMap);
       const auto lcioFrom = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepFrom, fromMap);
       if (lcioTo && lcioFrom) {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -780,7 +780,7 @@ std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> create
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.recoParticles, objectMaps.vertices));
     } else {
-      std::cerr << "Trying to create an association collection of type " << coll->getTypeName()
+      std::cerr << "Trying to create an LCRelation collection from a " << coll->getTypeName()
                 << " which is not supported" << std::endl;
     }
   }

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -2,12 +2,11 @@
 
 #include "edm4hep/Constants.h"
 #include "edm4hep/utils/ParticleIDUtils.h"
-
-#include "UTIL/PIDHandler.h"
 #include <edm4hep/ParticleIDCollection.h>
 
+#include "UTIL/PIDHandler.h"
+
 #include <algorithm>
-#include <edm4hep/RecoParticleVertexAssociationCollection.h>
 #include <limits>
 
 namespace EDM4hep2LCIOConv {

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -30,6 +30,8 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_1");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_2");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_3");
+  ASSERT_SAME_OR_ABORT(edm4hep::MCRecoParticleAssociationCollection, "mcRecoAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::MCRecoCaloAssociationCollection, "mcCaloHitsAssocs");
 
   return 0;
 }

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -59,6 +59,8 @@ int main() {
     ASSERT_COMPARE_OR_EXIT(edm4hep::RawTimeSeriesCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::ClusterCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::VertexCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::MCRecoParticleAssociationCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::MCRecoCaloAssociationCollection)
   }
 
   return 0;

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -1,27 +1,4 @@
 #include "CompareEDM4hepEDM4hep.h"
-#include "ComparisonUtils.h"
-
-#include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/ClusterCollection.h"
-#include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/ParticleIDCollection.h"
-#include "edm4hep/ReconstructedParticleCollection.h"
-#include "edm4hep/SimCalorimeterHitCollection.h"
-#include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitPlaneCollection.h"
-
-#include <edm4hep/TrackState.h>
-#include <iostream>
-#include <podio/RelationRange.h>
-
-#define REQUIRE_SAME(expected, actual, msg)                                                                            \
-  {                                                                                                                    \
-    if (!((expected) == (actual))) {                                                                                   \
-      std::cerr << msg << " are not the same (expected: " << (expected) << ", actual: " << (actual) << ")"             \
-                << std::endl;                                                                                          \
-      return false;                                                                                                    \
-    }                                                                                                                  \
-  }
 
 bool compare(const edm4hep::CalorimeterHitCollection& origColl,
              const edm4hep::CalorimeterHitCollection& roundtripColl) {
@@ -322,6 +299,20 @@ bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::Parti
 
     REQUIRE_SAME(origPid.getParticle().getObjectID(), pid.getParticle().getObjectID(),
                  "related particle in ParticleID " << i);
+  }
+  return true;
+}
+
+bool compare(const edm4hep::RecoParticleVertexAssociationCollection& origColl,
+             const edm4hep::RecoParticleVertexAssociationCollection& roundtripColl) {
+  REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    const auto origAssoc = origColl[i];
+    const auto assoc = roundtripColl[i];
+
+    REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
+    REQUIRE_SAME(origAssoc.getVertex().id(), assoc.getVertex().id(), "vertex in association " << i);
+    REQUIRE_SAME(origAssoc.getRec().id(), assoc.getRec().id(), "reco particle in association " << i);
   }
   return true;
 }

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -1,7 +1,19 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H
 #define K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H
 
+#include "ComparisonUtils.h"
 #include "EDM4hep2LCIOUtilities.h"
+
+#include <iostream>
+
+#define REQUIRE_SAME(expected, actual, msg)                                                                            \
+  {                                                                                                                    \
+    if (!((expected) == (actual))) {                                                                                   \
+      std::cerr << msg << " are not the same (expected: " << (expected) << ", actual: " << (actual) << ")"             \
+                << std::endl;                                                                                          \
+      return false;                                                                                                    \
+    }                                                                                                                  \
+  }
 
 bool compare(const edm4hep::CalorimeterHitCollection& origColl, const edm4hep::CalorimeterHitCollection& roundtripColl);
 
@@ -23,5 +35,22 @@ bool compare(const edm4hep::ReconstructedParticleCollection& origColl,
              const edm4hep::ReconstructedParticleCollection& roundtripColl);
 
 bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::ParticleIDCollection& roundtripColl);
+
+bool compare(const edm4hep::RecoParticleVertexAssociationCollection& origColl,
+             const edm4hep::RecoParticleVertexAssociationCollection& roundtripColl);
+
+template <typename AssociationCollT>
+bool compare(const AssociationCollT& origColl, const AssociationCollT& roundtripColl) {
+  REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    const auto origAssoc = origColl[i];
+    const auto assoc = roundtripColl[i];
+
+    REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
+    REQUIRE_SAME(origAssoc.getSim().id(), assoc.getSim().id(), "MC part(icle) in association " << i);
+    REQUIRE_SAME(origAssoc.getRec().id(), assoc.getRec().id(), "reco part(icle) in association " << i);
+  }
+  return true;
+}
 
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPEDM4HEP_H

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -1,6 +1,7 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H
 #define K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H
 
+#include "ComparisonUtils.h"
 #include "ObjectMapping.h"
 
 #include "edm4hep/CaloHitContributionCollection.h"
@@ -115,4 +116,121 @@ bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexColl
 bool compare(const EVENT::ParticleID* lcio, const edm4hep::ParticleID& edm4hep);
 
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent);
+
+template <typename AssocCollT>
+bool compare(const lcio::LCCollection* lcioCollection, const AssocCollT& edm4hepCollection,
+             const ObjectMappings& objectMaps) {
+  return compareCollection<EVENT::LCRelation>(lcioCollection, edm4hepCollection, objectMaps);
+}
+
+namespace detail {
+template <typename AssocT>
+struct LcioFromToTypeHelper;
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoParticleAssociation> {
+  using from_type = EVENT::ReconstructedParticle;
+  using to_type = EVENT::MCParticle;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoCaloAssociation> {
+  using from_type = EVENT::CalorimeterHit;
+  using to_type = EVENT::SimCalorimeterHit;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoTrackerAssociation> {
+  using from_type = EVENT::TrackerHit;
+  using to_type = EVENT::SimTrackerHit;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoCaloParticleAssociation> {
+  using from_type = EVENT::CalorimeterHit;
+  using to_type = EVENT::MCParticle;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoClusterParticleAssociation> {
+  using from_type = EVENT::Cluster;
+  using to_type = EVENT::MCParticle;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::MCRecoTrackParticleAssociation> {
+  using from_type = EVENT::Track;
+  using to_type = EVENT::MCParticle;
+};
+
+template <>
+struct LcioFromToTypeHelper<edm4hep::RecoParticleVertexAssociation> {
+  using from_type = EVENT::ReconstructedParticle;
+  using to_type = EVENT::Vertex;
+};
+
+template <typename AssocT>
+using getLcioFromType = typename LcioFromToTypeHelper<AssocT>::from_type;
+
+template <typename AssocT>
+using getLcioToType = typename LcioFromToTypeHelper<AssocT>::to_type;
+
+template <typename T>
+const auto& getObjectMap(const ObjectMappings& maps) {
+  if constexpr (std::is_same_v<T, EVENT::MCParticle>) {
+    return maps.mcParticles;
+  } else if constexpr (std::is_same_v<T, EVENT::ReconstructedParticle>) {
+    return maps.recoParticles;
+  } else if constexpr (std::is_same_v<T, EVENT::SimCalorimeterHit>) {
+    return maps.simCaloHits;
+  } else if constexpr (std::is_same_v<T, EVENT::SimTrackerHit>) {
+    return maps.simTrackerHits;
+  } else if constexpr (std::is_same_v<T, EVENT::TrackerHit>) {
+    return maps.trackerHits;
+  } else if constexpr (std::is_same_v<T, EVENT::Cluster>) {
+    return maps.clusters;
+  } else if constexpr (std::is_same_v<T, EVENT::CalorimeterHit>) {
+    return maps.caloHits;
+  } else if constexpr (std::is_same_v<T, EVENT::Track>) {
+    return maps.tracks;
+  } else {
+    return maps.vertices;
+  }
+}
+
+} // namespace detail
+
+template <typename AssocT>
+bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectMappings& objectMaps) {
+
+  ASSERT_COMPARE(lcio, edm4hep, getWeight, "weight in relation / association");
+
+  using LcioFromT = detail::getLcioFromType<AssocT>;
+  using LcioToT = detail::getLcioToType<AssocT>;
+
+  const auto lcioFrom = static_cast<LcioFromT*>(lcio->getFrom());
+  const auto edm4hepFrom = edm4hep.getRec();
+  if (!compareRelation(lcioFrom, edm4hepFrom, detail::getObjectMap<LcioFromT>(objectMaps),
+                       "from / rec object in relation / association")) {
+    return false;
+  }
+
+  const auto lcioTo = static_cast<LcioToT*>(lcio->getTo());
+  if constexpr (std::is_same_v<AssocT, edm4hep::RecoParticleVertexAssociation>) {
+    const auto edm4hepTo = edm4hep.getVertex();
+    if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
+                         "vertex object in relation / association")) {
+      return false;
+    }
+  } else {
+    const auto edm4hepTo = edm4hep.getSim();
+    if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
+                         "to / mc object in relation / association")) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -1,7 +1,5 @@
 #include "EDM4hep2LCIOUtilities.h"
 
-#include <edm4hep/MCRecoCaloAssociationCollection.h>
-#include <edm4hep/MCRecoParticleAssociationCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>
 
 #include "podio/Frame.h"

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -1,11 +1,25 @@
 #ifndef K4EDM4HEP2LCIOCONV_TEST_EDM4HEP2LCIOUTILITIES_H
 #define K4EDM4HEP2LCIOCONV_TEST_EDM4HEP2LCIOUTILITIES_H
 
-#include <cstddef>
-#include <tuple>
-#include <utility>
-#include <vector>
-
+#include "edm4hep/CaloHitContributionCollection.h"
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/RawCalorimeterHitCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#include <edm4hep/EventHeaderCollection.h>
+#include <edm4hep/MCRecoCaloAssociationCollection.h>
+#include <edm4hep/MCRecoCaloParticleAssociationCollection.h>
+#include <edm4hep/MCRecoClusterParticleAssociationCollection.h>
+#include <edm4hep/MCRecoParticleAssociationCollection.h>
+#include <edm4hep/MCRecoTrackParticleAssociationCollection.h>
+#include <edm4hep/MCRecoTrackerAssociationCollection.h>
+#include <edm4hep/ParticleIDCollection.h>
+#include <edm4hep/RawTimeSeriesCollection.h>
+#include <edm4hep/RecoParticleVertexAssociationCollection.h>
+#include <edm4hep/TrackerHitPlaneCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
@@ -15,20 +29,10 @@ using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 } // namespace edm4hep
 #endif
 
-namespace edm4hep {
-class CalorimeterHitCollection;
-class MCParticleCollection;
-class RawCalorimeterHitCollection;
-class RawTimeSeriesCollection;
-class TrackerHitPlaneCollection;
-class TrackCollection;
-class SimCalorimeterHitCollection;
-class CaloHitContributionCollection;
-class EventHeaderCollection;
-class ClusterCollection;
-class ReconstructedParticleCollection;
-class ParticleIDCollection;
-} // namespace edm4hep
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace podio {
 class Frame;
@@ -165,6 +169,13 @@ edm4hep::ReconstructedParticleCollection createRecoParticles(const int nRecos, c
 std::vector<edm4hep::ParticleIDCollection>
 createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
                   const edm4hep::ReconstructedParticleCollection& recoParticles);
+
+edm4hep::MCRecoParticleAssociationCollection
+createMCRecoParticleAssocs(const edm4hep::MCParticleCollection& mcParticles,
+                           const edm4hep::ReconstructedParticleCollection& recoParticles);
+
+edm4hep::MCRecoCaloAssociationCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
+                                                            const edm4hep::CalorimeterHitCollection& caloHits);
 
 /**
  * Create an example event that can be used to test the converter. Also populate


### PR DESCRIPTION
BEGINRELEASENOTES
- Add conversion of EDM4hep `Association` collections to `LCRelation` collections in LCIO.
  - The order of the relation in LCIO follows the following pattern: `From` will be the reconstruction part and `To` will be the simulation / mc part.

ENDRELEASENOTES

Fixes #67, Patially addresses https://github.com/key4hep/k4MarlinWrapper/issues/186 (needs minimal work in k4MarlinWrapper)
