### PR TITLE
Fix issue with undefined methods in EDM4hep to LCIO conversion

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -817,11 +817,11 @@ std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> create
 
 namespace detail {
   template <typename T>
-  constexpr const char* getTypeName();
+  consteval const char* getTypeName();
 
 #define DEFINE_TYPE_NAME(type)                                                                                         \
   template <>                                                                                                          \
-  constexpr const char* getTypeName<IMPL::type##Impl>() {                                                              \
+  consteval const char* getTypeName<IMPL::type##Impl>() {                                                              \
     return #type;                                                                                                      \
   }
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -823,6 +823,10 @@ namespace detail {
   template <>                                                                                                          \
   consteval const char* getTypeName<IMPL::type##Impl>() {                                                              \
     return #type;                                                                                                      \
+  }                                                                                                                    \
+  template <>                                                                                                          \
+  consteval const char* getTypeName<EVENT::type>() {                                                                   \
+    return #type;                                                                                                      \
   }
 
   DEFINE_TYPE_NAME(MCParticle);


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that all the necessary definitions are available
- Force the evaluation of some string constants to compile time to detect undefined functions earlier

ENDRELEASENOTES
