### PR TITLE
Switch from Association to Link and use non-deprecated methods

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -5,24 +5,24 @@
 
 // EDM4hep
 #include <edm4hep/CaloHitContributionCollection.h>
+#include <edm4hep/CaloHitMCParticleLinkCollection.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
 #include <edm4hep/CalorimeterHitCollection.h>
 #include <edm4hep/ClusterCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4hep/MCRecoCaloAssociationCollection.h>
-#include <edm4hep/MCRecoCaloParticleAssociationCollection.h>
-#include <edm4hep/MCRecoParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackerAssociationCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/RecDqdxCollection.h>
-#include <edm4hep/RecoParticleVertexAssociationCollection.h>
+#include <edm4hep/RecoMCParticleLinkCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/TrackCollection.h>
+#include <edm4hep/TrackMCParticleLinkCollection.h>
+#include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -1,12 +1,12 @@
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
-#include <edm4hep/MCRecoCaloAssociationCollection.h>
-#include <edm4hep/MCRecoCaloParticleAssociationCollection.h>
-#include <edm4hep/MCRecoClusterParticleAssociationCollection.h>
-#include <edm4hep/MCRecoParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackerAssociationCollection.h>
-#include <edm4hep/RecoParticleVertexAssociationCollection.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+#include <edm4hep/CaloHitMCParticleLinkCollection.h>
+#include <edm4hep/ClusterMCParticleLinkCollection.h>
+#include <edm4hep/RecoMCParticleLinkCollection.h>
+#include <edm4hep/TrackMCParticleLinkCollection.h>
+#include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 
 #include <UTIL/LCRelationNavigator.h>
 
@@ -786,24 +786,24 @@ std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> create
   relationColls.reserve(associationCollections.size());
 
   for (const auto& [name, coll] : associationCollections) {
-    if (const auto assocs = dynamic_cast<const edm4hep::MCRecoParticleAssociationCollection*>(coll)) {
+    if (const auto assocs = dynamic_cast<const edm4hep::RecoMCParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.recoParticles, objectMaps.mcParticles));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoCaloAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::CaloHitSimCaloHitLinkCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.caloHits, objectMaps.simCaloHits));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoTrackerAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::TrackerHitSimTrackerHitLinkCollection*>(coll)) {
       relationColls.emplace_back(
           name, createLCRelationCollection(*assocs, objectMaps.trackerHits, objectMaps.simTrackerHits));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoCaloParticleAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::CaloHitMCParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.caloHits, objectMaps.mcParticles));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoClusterParticleAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::ClusterMCParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.clusters, objectMaps.mcParticles));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::MCRecoTrackParticleAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::TrackMCParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(name, createLCRelationCollection(*assocs, objectMaps.tracks, objectMaps.mcParticles));
-    } else if (const auto assocs = dynamic_cast<const edm4hep::RecoParticleVertexAssociationCollection*>(coll)) {
+    } else if (const auto assocs = dynamic_cast<const edm4hep::VertexRecoParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(name,
                                  createLCRelationCollection(*assocs, objectMaps.recoParticles, objectMaps.vertices));
     } else {
@@ -865,7 +865,7 @@ std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const AssocCollT&
                 << std::endl;
     }
 
-    if constexpr (std::is_same_v<AssocCollT, edm4hep::RecoParticleVertexAssociationCollection>) {
+    if constexpr (std::is_same_v<AssocCollT, edm4hep::VertexRecoParticleLinkCollection>) {
       const auto edm4hepTo = assoc.getVertex();
       const auto lcioTo = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepTo, toMap);
       if (lcioTo) {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -5,24 +5,24 @@
 
 // EDM4hep
 #include "edm4hep/CaloHitContributionCollection.h"
+#include "edm4hep/CaloHitMCParticleLinkCollection.h"
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/ClusterMCParticleLinkCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/MCRecoCaloAssociationCollection.h"
-#include "edm4hep/MCRecoCaloParticleAssociationCollection.h"
-#include "edm4hep/MCRecoClusterParticleAssociationCollection.h"
-#include "edm4hep/MCRecoParticleAssociationCollection.h"
-#include "edm4hep/MCRecoTrackParticleAssociationCollection.h"
-#include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
-#include "edm4hep/RecoParticleVertexAssociationCollection.h"
+#include "edm4hep/RecoMCParticleLinkCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#include "edm4hep/TrackMCParticleLinkCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
+#include "edm4hep/VertexRecoParticleLinkCollection.h"
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
@@ -226,7 +226,7 @@ convertMCParticles(const std::string& name, EVENT::LCCollection* LCCollection, M
  * part of the ReconstructedParticles in LCIO. The name of this collection is
  * <name>_PID_<pid_algo_name> (see getPIDCollName)
  *
- * @note: Also populates one (partially filled) RecoParticleVertexAssociation
+ * @note: Also populates one (partially filled) VertexRecoParticleLink
  * collection for keeping the startVertex information
  */
 template <typename RecoMapT>
@@ -237,7 +237,7 @@ std::vector<CollNamePair> convertReconstructedParticles(const std::string& name,
  * Convert a Vertex collection and return the resulting collection.
  * Simultaneously populates the mapping from LCIO to EDM4hep objects.
  *
- * @note: Also creates a (partially filled) RecoParticleVertexAssociation
+ * @note: Also creates a (partially filled) VertexRecoParticleLink
  * collection for keeping the associatedParticle information
  */
 template <typename VertexMapT>
@@ -404,8 +404,8 @@ void resolveRelationsVertices(VertexMapT& vertexMap, URecoParticleMapT& updateRP
                               const LURecoParticleMapT& lookupRPMap);
 
 template <typename VertexMapT, typename RecoParticleMapT>
-void finalizeRecoParticleVertexAssociations(edm4hep::RecoParticleVertexAssociationCollection& associations,
-                                            const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
+void finalizeVertexRecoParticleLinks(edm4hep::VertexRecoParticleLinkCollection& associations,
+                                     const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
 
 /**
  * Go from chi^2 and probability (1 - CDF(chi^2, ndf)) to ndf by a binary search

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -138,13 +138,19 @@ template <typename ObjectMappingT, typename ObjectMappingU>
 void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
 /**
- * Convert LCRelation collections into the corresponding Association collections
- * in EDM4hep
+ * Convert LCRelation collections into the corresponding Link collections in
+ * EDM4hep
  */
 template <typename ObjectMappingT>
-std::vector<CollNamePair>
+std::vector<CollNamePair> createLinks(const ObjectMappingT& typeMapping,
+                                      const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation);
+
+template <typename ObjectMappingT>
+[[deprecated("use createLinks instead")]] std::vector<CollNamePair>
 createAssociations(const ObjectMappingT& typeMapping,
-                   const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation);
+                   const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation) {
+  return createLinks(typeMapping, LCRelation);
+}
 
 /**
  * Convert a subset collection, dispatching to the correct function for the
@@ -336,10 +342,10 @@ template <typename CollT, typename ObjectMapT,
 auto handleSubsetColl(EVENT::LCCollection* lcioColl, const ObjectMapT& elemMap);
 
 /**
- * Create an Association collection from an LCRelations collection. Templated
+ * Create an Link collection from an LCRelations collection. Templated
  * on the From and To types as well as the direction of the relations in the
  * input LCRelations collection with respect to the order in which they are
- * mentioned in the Association collection of EDM4hep (since those are not
+ * mentioned in the Link collection of EDM4hep (since those are not
  * directed).
  *
  * Necessary inputs apart from the LCRelations collection are the correct LCIO
@@ -350,8 +356,18 @@ template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
           typename ToLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ToMapT>>,
           typename FromEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<FromMapT>,
           typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
-std::unique_ptr<CollT> createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
-                                                   const ToMapT& toMap);
+std::unique_ptr<CollT> createLinkCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
+                                            const ToMapT& toMap);
+
+template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
+          typename FromLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<FromMapT>>,
+          typename ToLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ToMapT>>,
+          typename FromEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<FromMapT>,
+          typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
+[[deprecated("use createLinkCollection instead")]] std::unique_ptr<CollT>
+createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap, const ToMapT& toMap) {
+  return createLinkCollection<CollT, Reverse>(relations, fromMap, toMap);
+}
 
 /**
  * Creates the CaloHitContributions for all SimCaloHits.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -119,7 +119,7 @@ template <typename RecoMapT>
 std::vector<CollNamePair> convertReconstructedParticles(const std::string& name, EVENT::LCCollection* LCCollection,
                                                         RecoMapT& recoparticlesMap) {
   auto dest = std::make_unique<edm4hep::ReconstructedParticleCollection>();
-  auto startVertexAssocs = std::make_unique<edm4hep::RecoParticleVertexAssociationCollection>();
+  auto startVertexAssocs = std::make_unique<edm4hep::VertexRecoParticleLinkCollection>();
 
   // Set up a PIDHandler to split off the ParticlID objects stored in the
   // reconstructed particles into separate collections. Each algorithm id /
@@ -188,7 +188,7 @@ template <typename VertexMapT>
 std::vector<CollNamePair> convertVertices(const std::string& name, EVENT::LCCollection* LCCollection,
                                           VertexMapT& vertexMap) {
   auto dest = std::make_unique<edm4hep::VertexCollection>();
-  auto assocParticles = std::make_unique<edm4hep::RecoParticleVertexAssociationCollection>();
+  auto assocParticles = std::make_unique<edm4hep::VertexRecoParticleLinkCollection>();
 
   for (unsigned i = 0, N = LCCollection->getNumberOfElements(); i < N; ++i) {
     auto* rval = static_cast<EVENT::Vertex*>(LCCollection->getElementAt(i));
@@ -784,7 +784,7 @@ void resolveRelationsVertices(VertexMapT& vertexMap, URecoParticleMapT& updateRP
 }
 
 template <typename VertexMapT, typename RecoParticleMapT>
-void finalizeRecoParticleVertexAssociations(edm4hep::RecoParticleVertexAssociationCollection& associations,
+void finalizeVertexRecoParticleLinks(edm4hep::VertexRecoParticleLinkCollection& associations,
                                             const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap) {
   for (auto assoc : associations) {
     auto assocRec = assoc.getRec();
@@ -892,59 +892,59 @@ createAssociations(const ObjectMappingT& typeMapping,
     }
 
     if (fromType == "MCParticle" && toType == "ReconstructedParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoParticleAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::RecoMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.recoParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "ReconstructedParticle" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoParticleAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::RecoMCParticleLinkCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "CalorimeterHit" && toType == "SimCalorimeterHit") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection, true>(
           relations, typeMapping.caloHits, typeMapping.simCaloHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "SimCalorimeterHit" && toType == "CalorimeterHit") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection, false>(
           relations, typeMapping.simCaloHits, typeMapping.caloHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Cluster" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoClusterParticleAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::ClusterMCParticleLinkCollection, true>(
           relations, typeMapping.clusters, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "MCParticle" && toType == "Cluster") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoClusterParticleAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::ClusterMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.clusters);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "MCParticle" && toType == "Track") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackParticleAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::TrackMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.tracks);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Track" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackParticleAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::TrackMCParticleLinkCollection, true>(
           relations, typeMapping.tracks, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if ((fromType == "TrackerHit" || fromType == "TrackerHitPlane") && toType == "SimTrackerHit") {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, true>(
           relations, typeMapping.trackerHits, typeMapping.simTrackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "SimTrackerHit" && (toType == "TrackerHit" || toType == "TrackerHitPlane")) {
-      auto mc_a = createAssociationCollection<edm4hep::MCRecoTrackerAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "ReconstructedParticle" && toType == "Vertex") {
-      auto mc_a = createAssociationCollection<edm4hep::RecoParticleVertexAssociationCollection, true>(
+      auto mc_a = createAssociationCollection<edm4hep::VertexRecoParticleLinkCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.vertices);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Vertex" && toType == "ReconstructedParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::RecoParticleVertexAssociationCollection, false>(
+      auto mc_a = createAssociationCollection<edm4hep::VertexRecoParticleLinkCollection, false>(
           relations, typeMapping.vertices, typeMapping.recoParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "CalorimeterHit" && toType == "MCParticle") {
-      auto assoc = createAssociationCollection<edm4hep::MCRecoCaloParticleAssociationCollection, true>(
+      auto assoc = createAssociationCollection<edm4hep::CaloHitMCParticleLinkCollection, true>(
           relations, typeMapping.caloHits, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(assoc));
     } else if (fromType == "MCParticle" && toType == "CalorimeterHit") {
-      auto assoc = createAssociationCollection<edm4hep::MCRecoCaloParticleAssociationCollection, false>(
+      auto assoc = createAssociationCollection<edm4hep::CaloHitMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.caloHits);
       assoCollVec.emplace_back(name, std::move(assoc));
     } else {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -785,7 +785,7 @@ void resolveRelationsVertices(VertexMapT& vertexMap, URecoParticleMapT& updateRP
 
 template <typename VertexMapT, typename RecoParticleMapT>
 void finalizeVertexRecoParticleLinks(edm4hep::VertexRecoParticleLinkCollection& associations,
-                                            const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap) {
+                                     const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap) {
   for (auto assoc : associations) {
     auto assocRec = assoc.getRec();
     auto assocVtx = assoc.getVertex();
@@ -841,8 +841,8 @@ void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMa
 
 template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT, typename FromLCIOT, typename ToLCIOT,
           typename FromEDM4hepT, typename ToEDM4hepT>
-std::unique_ptr<CollT> createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
-                                                   const ToMapT& toMap) {
+std::unique_ptr<CollT> createLinkCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
+                                            const ToMapT& toMap) {
   auto assocColl = std::make_unique<CollT>();
   auto relIter = UTIL::LCIterator<EVENT::LCRelation>(relations);
 
@@ -876,9 +876,8 @@ std::unique_ptr<CollT> createAssociationCollection(EVENT::LCCollection* relation
 }
 
 template <typename ObjectMappingT>
-std::vector<CollNamePair>
-createAssociations(const ObjectMappingT& typeMapping,
-                   const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation) {
+std::vector<CollNamePair> createLinks(const ObjectMappingT& typeMapping,
+                                      const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation) {
   std::vector<CollNamePair> assoCollVec;
   for (const auto& [name, relations] : LCRelation) {
     const auto& params = relations->getParameters();
@@ -892,59 +891,59 @@ createAssociations(const ObjectMappingT& typeMapping,
     }
 
     if (fromType == "MCParticle" && toType == "ReconstructedParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::RecoMCParticleLinkCollection, false>(
-          relations, typeMapping.mcParticles, typeMapping.recoParticles);
+      auto mc_a = createLinkCollection<edm4hep::RecoMCParticleLinkCollection, false>(relations, typeMapping.mcParticles,
+                                                                                     typeMapping.recoParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "ReconstructedParticle" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::RecoMCParticleLinkCollection, true>(
+      auto mc_a = createLinkCollection<edm4hep::RecoMCParticleLinkCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "CalorimeterHit" && toType == "SimCalorimeterHit") {
-      auto mc_a = createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection, true>(
-          relations, typeMapping.caloHits, typeMapping.simCaloHits);
+      auto mc_a = createLinkCollection<edm4hep::CaloHitSimCaloHitLinkCollection, true>(relations, typeMapping.caloHits,
+                                                                                       typeMapping.simCaloHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "SimCalorimeterHit" && toType == "CalorimeterHit") {
-      auto mc_a = createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection, false>(
+      auto mc_a = createLinkCollection<edm4hep::CaloHitSimCaloHitLinkCollection, false>(
           relations, typeMapping.simCaloHits, typeMapping.caloHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Cluster" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::ClusterMCParticleLinkCollection, true>(
-          relations, typeMapping.clusters, typeMapping.mcParticles);
+      auto mc_a = createLinkCollection<edm4hep::ClusterMCParticleLinkCollection, true>(relations, typeMapping.clusters,
+                                                                                       typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "MCParticle" && toType == "Cluster") {
-      auto mc_a = createAssociationCollection<edm4hep::ClusterMCParticleLinkCollection, false>(
+      auto mc_a = createLinkCollection<edm4hep::ClusterMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.clusters);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "MCParticle" && toType == "Track") {
-      auto mc_a = createAssociationCollection<edm4hep::TrackMCParticleLinkCollection, false>(
+      auto mc_a = createLinkCollection<edm4hep::TrackMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.tracks);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Track" && toType == "MCParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::TrackMCParticleLinkCollection, true>(
-          relations, typeMapping.tracks, typeMapping.mcParticles);
+      auto mc_a = createLinkCollection<edm4hep::TrackMCParticleLinkCollection, true>(relations, typeMapping.tracks,
+                                                                                     typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if ((fromType == "TrackerHit" || fromType == "TrackerHitPlane") && toType == "SimTrackerHit") {
-      auto mc_a = createAssociationCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, true>(
+      auto mc_a = createLinkCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, true>(
           relations, typeMapping.trackerHits, typeMapping.simTrackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "SimTrackerHit" && (toType == "TrackerHit" || toType == "TrackerHitPlane")) {
-      auto mc_a = createAssociationCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, false>(
+      auto mc_a = createLinkCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, false>(
           relations, typeMapping.simTrackerHits, typeMapping.trackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "ReconstructedParticle" && toType == "Vertex") {
-      auto mc_a = createAssociationCollection<edm4hep::VertexRecoParticleLinkCollection, true>(
+      auto mc_a = createLinkCollection<edm4hep::VertexRecoParticleLinkCollection, true>(
           relations, typeMapping.recoParticles, typeMapping.vertices);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "Vertex" && toType == "ReconstructedParticle") {
-      auto mc_a = createAssociationCollection<edm4hep::VertexRecoParticleLinkCollection, false>(
+      auto mc_a = createLinkCollection<edm4hep::VertexRecoParticleLinkCollection, false>(
           relations, typeMapping.vertices, typeMapping.recoParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "CalorimeterHit" && toType == "MCParticle") {
-      auto assoc = createAssociationCollection<edm4hep::CaloHitMCParticleLinkCollection, true>(
-          relations, typeMapping.caloHits, typeMapping.mcParticles);
+      auto assoc = createLinkCollection<edm4hep::CaloHitMCParticleLinkCollection, true>(relations, typeMapping.caloHits,
+                                                                                        typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(assoc));
     } else if (fromType == "MCParticle" && toType == "CalorimeterHit") {
-      auto assoc = createAssociationCollection<edm4hep::CaloHitMCParticleLinkCollection, false>(
+      auto assoc = createLinkCollection<edm4hep::CaloHitMCParticleLinkCollection, false>(
           relations, typeMapping.mcParticles, typeMapping.caloHits);
       assoCollVec.emplace_back(name, std::move(assoc));
     } else {

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
     } else if (dynamic_cast<const edm4hep::CaloHitContributionCollection*>(edmCollection)) {
       // "converted" during relation resolving later
       continue;
-    } else if (edmCollection->getTypeName().find("Association") != std::string_view::npos) {
+    } else if (edmCollection->getTypeName().find("Link") != std::string_view::npos) {
       associations.emplace_back(name, edmCollection);
     } else {
       std::cerr << "Error trying to convert requested " << edmCollection->getValueTypeName() << " with name " << name

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -118,9 +118,9 @@ podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::pair<std::
   auto headerColl = createEventHeader(evt);
 
   for (const auto& [name, coll] : edmevent) {
-    if (coll->getTypeName() == "edm4hep::RecoParticleVertexAssociationCollection") {
-      finalizeRecoParticleVertexAssociations(static_cast<edm4hep::RecoParticleVertexAssociationCollection&>(*coll),
-                                             typeMapping.vertices, typeMapping.recoParticles);
+    if (coll->getTypeName() == "edm4hep::VertexRecoParticleLinkCollection") {
+      finalizeVertexRecoParticleLinks(static_cast<edm4hep::VertexRecoParticleLinkCollection&>(*coll),
+                                      typeMapping.vertices, typeMapping.recoParticles);
     }
   }
 

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -114,7 +114,7 @@ podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::pair<std::
   // Filling all the OneToMany and OneToOne Relations and creating the
   // AssociationCollections.
   resolveRelations(typeMapping);
-  auto assoCollVec = createAssociations(typeMapping, LCRelations);
+  auto assoCollVec = createLinks(typeMapping, LCRelations);
   auto headerColl = createEventHeader(evt);
 
   for (const auto& [name, coll] : edmevent) {

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -30,12 +30,12 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_1");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_2");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_3");
-  ASSERT_SAME_OR_ABORT(edm4hep::MCRecoParticleAssociationCollection, "mcRecoAssocs");
-  ASSERT_SAME_OR_ABORT(edm4hep::MCRecoCaloAssociationCollection, "mcCaloHitsAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::RecoMCParticleLinkCollection, "mcRecoAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::CaloHitSimCaloHitLinkCollection, "mcCaloHitsAssocs");
   ASSERT_SAME_OR_ABORT(edm4hep::RecDqdxCollection, "tracks_dQdx")
   ASSERT_SAME_OR_ABORT(edm4hep::VertexCollection, "vertices");
   ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "vtx_recos");
-  ASSERT_SAME_OR_ABORT(edm4hep::RecoParticleVertexAssociationCollection, "startVtxAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::VertexRecoParticleLinkCollection, "startVtxAssocs");
 
   return 0;
 }

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -19,7 +19,7 @@ int main() {
     const auto typeName = edmColl->getValueTypeName();
     if (typeName == "edm4hep::CaloHitContribution" || typeName == "edm4hep::ParticleID" ||
         typeName == "edm4hep::EventHeader" || typeName == "edm4hep::RecDqdx" ||
-        typeName == "edm4hep::RecoParticleVertexAssociation") {
+        typeName == "edm4hep::VertexRecoParticleLink") {
       continue;
     }
     try {
@@ -44,7 +44,7 @@ int main() {
       continue;
     }
 
-    if (type == "edm4hep::RecoParticleVertexAssociationCollection") {
+    if (type == "edm4hep::VertexRecoParticleLinkCollection") {
       // TODO: Dispatch to correct comparison function depending on name (which
       // in turn again depends on a convention in the conversion)
 
@@ -65,8 +65,8 @@ int main() {
     ASSERT_COMPARE_OR_EXIT(edm4hep::RawTimeSeriesCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::ClusterCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::VertexCollection)
-    ASSERT_COMPARE_OR_EXIT(edm4hep::MCRecoParticleAssociationCollection)
-    ASSERT_COMPARE_OR_EXIT(edm4hep::MCRecoCaloAssociationCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::RecoMCParticleLinkCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::CaloHitSimCaloHitLinkCollection)
 
     // TODO: start vertex association (EDM4hep) vs getStartVertex in LCIO
   }

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -358,8 +358,8 @@ bool compare(const edm4hep::VertexCollection& origColl, const edm4hep::VertexCol
   return true;
 }
 
-bool compare(const edm4hep::RecoParticleVertexAssociationCollection& origColl,
-             const edm4hep::RecoParticleVertexAssociationCollection& roundtripColl) {
+bool compare(const edm4hep::VertexRecoParticleLinkCollection& origColl,
+             const edm4hep::VertexRecoParticleLinkCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
     const auto origAssoc = origColl[i];

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -366,8 +366,8 @@ bool compare(const edm4hep::VertexRecoParticleLinkCollection& origColl,
     const auto assoc = roundtripColl[i];
 
     REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
-    REQUIRE_SAME(origAssoc.getVertex().id(), assoc.getVertex().id(), "vertex in association " << i);
-    REQUIRE_SAME(origAssoc.getRec().id(), assoc.getRec().id(), "reco particle in association " << i);
+    REQUIRE_SAME(origAssoc.getFrom().id(), assoc.getFrom().id(), "vertex in association " << i);
+    REQUIRE_SAME(origAssoc.getTo().id(), assoc.getTo().id(), "reco particle in association " << i);
   }
 
   return true;

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -49,8 +49,8 @@ bool compare(const AssociationCollT& origColl, const AssociationCollT& roundtrip
     const auto assoc = roundtripColl[i];
 
     REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
-    REQUIRE_SAME(origAssoc.getSim().id(), assoc.getSim().id(), "MC part(icle) in association " << i);
-    REQUIRE_SAME(origAssoc.getRec().id(), assoc.getRec().id(), "reco part(icle) in association " << i);
+    REQUIRE_SAME(origAssoc.getTo().id(), assoc.getTo().id(), "MC part(icle) in association " << i);
+    REQUIRE_SAME(origAssoc.getFrom().id(), assoc.getFrom().id(), "reco part(icle) in association " << i);
   }
   return true;
 }

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -38,8 +38,8 @@ bool compare(const edm4hep::ParticleIDCollection& origColl, const edm4hep::Parti
 
 bool compare(const edm4hep::VertexCollection& origColl, const edm4hep::VertexCollection& roundtripColl);
 
-bool compare(const edm4hep::RecoParticleVertexAssociationCollection& origColl,
-             const edm4hep::RecoParticleVertexAssociationCollection& roundtripColl);
+bool compare(const edm4hep::VertexRecoParticleLinkCollection& origColl,
+             const edm4hep::VertexRecoParticleLinkCollection& roundtripColl);
 
 template <typename AssociationCollT>
 bool compare(const AssociationCollT& origColl, const AssociationCollT& roundtripColl) {

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -482,7 +482,7 @@ bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEven
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
                                  const edm4hep::VertexRecoParticleLink& association, const ObjectMappings& objectMaps) {
   const auto lcioVertex = lcioReco->getStartVertex();
-  const auto edm4hepVertex = association.getVertex();
+  const auto edm4hepVertex = association.getFrom();
   if (!compareRelation(lcioVertex, edm4hepVertex, objectMaps.vertices, "")) {
     return false;
   }

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -6,7 +6,7 @@
 
 #include <cmath>
 #include <cstdint>
-#include <edm4hep/RecoParticleVertexAssociationCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 
 #include "TMath.h"
 
@@ -470,7 +470,7 @@ bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEven
   return true;
 }
 
-// bool compareStartVertexRelations(const edm4hep::RecoParticleVertexAssociationCollection& startVtxAssociations, const
+// bool compareStartVertexRelations(const edm4hep::VertexRecoParticleLinkCollection& startVtxAssociations, const
 // ObjectMappings& objectMaps, const podio::Frame& event) {
 //   for (const auto& assoc : startVtxAssociations) {
 //     const auto edmVtx = assoc.getVertex();
@@ -480,8 +480,7 @@ bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEven
 // }
 
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
-                                 const edm4hep::RecoParticleVertexAssociation& association,
-                                 const ObjectMappings& objectMaps) {
+                                 const edm4hep::VertexRecoParticleLink& association, const ObjectMappings& objectMaps) {
   const auto lcioVertex = lcioReco->getStartVertex();
   const auto edm4hepVertex = association.getVertex();
   if (!compareRelation(lcioVertex, edm4hepVertex, objectMaps.vertices, "")) {
@@ -491,8 +490,7 @@ bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
   return true;
 }
 
-bool compareVertexRecoAssociation(const EVENT::Vertex*, const edm4hep::RecoParticleVertexAssociation&,
-                                  const ObjectMappings&) {
+bool compareVertexRecoAssociation(const EVENT::Vertex*, const edm4hep::VertexRecoParticleLink&, const ObjectMappings&) {
   // TODO: Actually implement the checks
   // TODO: Figure out if this is even the right interface here
   return false;

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -5,25 +5,25 @@
 #include "ObjectMapping.h"
 
 #include "edm4hep/CaloHitContributionCollection.h"
+#include "edm4hep/CaloHitMCParticleLinkCollection.h"
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/ClusterMCParticleLinkCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/MCRecoCaloAssociationCollection.h"
-#include "edm4hep/MCRecoCaloParticleAssociationCollection.h"
-#include "edm4hep/MCRecoClusterParticleAssociationCollection.h"
-#include "edm4hep/MCRecoParticleAssociationCollection.h"
-#include "edm4hep/MCRecoTrackParticleAssociationCollection.h"
-#include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
-#include "edm4hep/RecoParticleVertexAssociationCollection.h"
+#include "edm4hep/RecoMCParticleLinkCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include <edm4hep/RecoParticleVertexAssociation.h>
+#include "edm4hep/TrackMCParticleLinkCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
+#include "edm4hep/VertexRecoParticleLinkCollection.h"
+#include <edm4hep/VertexRecoParticleLink.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
@@ -129,43 +129,43 @@ template <typename AssocT>
 struct LcioFromToTypeHelper;
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoParticleAssociation> {
+struct LcioFromToTypeHelper<edm4hep::RecoMCParticleLink> {
   using from_type = EVENT::ReconstructedParticle;
   using to_type = EVENT::MCParticle;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoCaloAssociation> {
+struct LcioFromToTypeHelper<edm4hep::CaloHitSimCaloHitLink> {
   using from_type = EVENT::CalorimeterHit;
   using to_type = EVENT::SimCalorimeterHit;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoTrackerAssociation> {
+struct LcioFromToTypeHelper<edm4hep::TrackerHitSimTrackerHitLink> {
   using from_type = EVENT::TrackerHit;
   using to_type = EVENT::SimTrackerHit;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoCaloParticleAssociation> {
+struct LcioFromToTypeHelper<edm4hep::CaloHitMCParticleLink> {
   using from_type = EVENT::CalorimeterHit;
   using to_type = EVENT::MCParticle;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoClusterParticleAssociation> {
+struct LcioFromToTypeHelper<edm4hep::ClusterMCParticleLink> {
   using from_type = EVENT::Cluster;
   using to_type = EVENT::MCParticle;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::MCRecoTrackParticleAssociation> {
+struct LcioFromToTypeHelper<edm4hep::TrackMCParticleLink> {
   using from_type = EVENT::Track;
   using to_type = EVENT::MCParticle;
 };
 
 template <>
-struct LcioFromToTypeHelper<edm4hep::RecoParticleVertexAssociation> {
+struct LcioFromToTypeHelper<edm4hep::VertexRecoParticleLink> {
   using from_type = EVENT::ReconstructedParticle;
   using to_type = EVENT::Vertex;
 };
@@ -217,7 +217,7 @@ bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectM
   }
 
   const auto lcioTo = static_cast<LcioToT*>(lcio->getTo());
-  if constexpr (std::is_same_v<AssocT, edm4hep::RecoParticleVertexAssociation>) {
+  if constexpr (std::is_same_v<AssocT, edm4hep::VertexRecoParticleLink>) {
     const auto edm4hepTo = edm4hep.getVertex();
     if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
                          "vertex object in relation / association")) {
@@ -237,12 +237,10 @@ bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectM
 /// Compare the information stored in startVertex in LCIO
 
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
-                                 const edm4hep::RecoParticleVertexAssociation& association,
-                                 const ObjectMappings& objectMaps);
+                                 const edm4hep::VertexRecoParticleLink& association, const ObjectMappings& objectMaps);
 
 /// Compare the information stored in associatedParticle in LCIO
-bool compareVertexRecoAssociation(const EVENT::Vertex* lcioVtx,
-                                  const edm4hep::RecoParticleVertexAssociation& association,
+bool compareVertexRecoAssociation(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRecoParticleLink& association,
                                   const ObjectMappings& objectMaps);
 
 #define ASSERT_COMPARE_OR_EXIT(collType)                                                                               \

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -210,25 +210,17 @@ bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectM
   using LcioToT = detail::getLcioToType<AssocT>;
 
   const auto lcioFrom = static_cast<LcioFromT*>(lcio->getFrom());
-  const auto edm4hepFrom = edm4hep.getRec();
+  const auto edm4hepFrom = edm4hep.getFrom();
   if (!compareRelation(lcioFrom, edm4hepFrom, detail::getObjectMap<LcioFromT>(objectMaps),
-                       "from / rec object in relation / association")) {
+                       "from object in relation / association")) {
     return false;
   }
 
   const auto lcioTo = static_cast<LcioToT*>(lcio->getTo());
-  if constexpr (std::is_same_v<AssocT, edm4hep::VertexRecoParticleLink>) {
-    const auto edm4hepTo = edm4hep.getVertex();
-    if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
-                         "vertex object in relation / association")) {
-      return false;
-    }
-  } else {
-    const auto edm4hepTo = edm4hep.getSim();
-    if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
-                         "to / mc object in relation / association")) {
-      return false;
-    }
+  const auto edm4hepTo = edm4hep.getTo();
+  if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
+                       "to object in relation / association")) {
+    return false;
   }
 
   return true;

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -353,8 +353,8 @@ AssocCollT createAssociationCollection(const CollT& collA, const CollU& collB) {
   for (size_t i = 0; i < maxSize; ++i) {
     auto assoc = assocs.create();
     assoc.setWeight(i * 10.f / maxSize);
-    assoc.setSim(collA[i]);
-    assoc.setRec(collB[maxSize - 1 - i]);
+    assoc.setTo(collA[i]);
+    assoc.setFrom(collB[maxSize - 1 - i]);
   }
 
   return assocs;
@@ -392,8 +392,8 @@ createVertices(const int nVertices, const edm4hep::ReconstructedParticleCollecti
   for (const auto& [iV, iP] : recoIdcs) {
     vtxColl[iV].addToParticles(particles[iP]);
     auto assoc = assocColl.create();
-    assoc.setRec(particles[iP]);
-    assoc.setVertex(vtxColl[iV]);
+    assoc.setTo(particles[iP]);
+    assoc.setFrom(vtxColl[iV]);
   }
 
   for (const auto& [iP, iV] : vtxRecoIdcs) {

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -360,20 +360,20 @@ AssocCollT createAssociationCollection(const CollT& collA, const CollU& collB) {
   return assocs;
 }
 
-edm4hep::MCRecoParticleAssociationCollection
+edm4hep::RecoMCParticleLinkCollection
 createMCRecoParticleAssocs(const edm4hep::MCParticleCollection& mcParticles,
                            const edm4hep::ReconstructedParticleCollection& recoParticles) {
-  return createAssociationCollection<edm4hep::MCRecoParticleAssociationCollection>(mcParticles, recoParticles);
+  return createAssociationCollection<edm4hep::RecoMCParticleLinkCollection>(mcParticles, recoParticles);
 }
 
-edm4hep::MCRecoCaloAssociationCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
+edm4hep::CaloHitSimCaloHitLinkCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
                                                             const edm4hep::CalorimeterHitCollection& caloHits) {
 
-  return createAssociationCollection<edm4hep::MCRecoCaloAssociationCollection>(simHits, caloHits);
+  return createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection>(simHits, caloHits);
 }
 
 std::tuple<edm4hep::VertexCollection, edm4hep::ReconstructedParticleCollection,
-           edm4hep::RecoParticleVertexAssociationCollection>
+           edm4hep::VertexRecoParticleLinkCollection>
 createVertices(const int nVertices, const edm4hep::ReconstructedParticleCollection& particles,
                const std::vector<test_config::IdxPair>& recoIdcs,
                const std::vector<test_config::IdxPair>& vtxRecoIdcs) {
@@ -387,7 +387,7 @@ createVertices(const int nVertices, const edm4hep::ReconstructedParticleCollecti
     auto reco = recoColl.create();
   }
 
-  auto assocColl = edm4hep::RecoParticleVertexAssociationCollection{};
+  auto assocColl = edm4hep::VertexRecoParticleLinkCollection{};
 
   for (const auto& [iV, iP] : recoIdcs) {
     vtxColl[iV].addToParticles(particles[iP]);

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -9,18 +9,18 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#include <edm4hep/CaloHitMCParticleLinkCollection.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+#include <edm4hep/ClusterMCParticleLinkCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
-#include <edm4hep/MCRecoCaloAssociationCollection.h>
-#include <edm4hep/MCRecoCaloParticleAssociationCollection.h>
-#include <edm4hep/MCRecoClusterParticleAssociationCollection.h>
-#include <edm4hep/MCRecoParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackParticleAssociationCollection.h>
-#include <edm4hep/MCRecoTrackerAssociationCollection.h>
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/RecDqdxCollection.h>
-#include <edm4hep/RecoParticleVertexAssociationCollection.h>
+#include <edm4hep/RecoMCParticleLinkCollection.h>
+#include <edm4hep/TrackMCParticleLinkCollection.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
+#include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 #if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
 #else
@@ -182,11 +182,11 @@ std::vector<edm4hep::ParticleIDCollection>
 createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
                   const edm4hep::ReconstructedParticleCollection& recoParticles);
 
-edm4hep::MCRecoParticleAssociationCollection
+edm4hep::RecoMCParticleLinkCollection
 createMCRecoParticleAssocs(const edm4hep::MCParticleCollection& mcParticles,
                            const edm4hep::ReconstructedParticleCollection& recoParticles);
 
-edm4hep::MCRecoCaloAssociationCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
+edm4hep::CaloHitSimCaloHitLinkCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
                                                             const edm4hep::CalorimeterHitCollection& caloHits);
 
 /**
@@ -194,7 +194,7 @@ edm4hep::MCRecoCaloAssociationCollection createMCCaloAssocs(const edm4hep::SimCa
  * collection that uses them as decay vertices.
  */
 std::tuple<edm4hep::VertexCollection, edm4hep::ReconstructedParticleCollection,
-           edm4hep::RecoParticleVertexAssociationCollection>
+           edm4hep::VertexRecoParticleLinkCollection>
 createVertices(const int nVertices, const edm4hep::ReconstructedParticleCollection& particles,
                const std::vector<test_config::IdxPair>& recoIdcs, const std::vector<test_config::IdxPair>& vtxRecoIdcs);
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch from `Association` to the newer `Link` types (key4hep/EDM4hep#341) and use the non-deprecated methods on them
- Update some conversion functions and docstrings to also reflect this renaming

ENDRELEASENOTES
