### PR TITLE
fix linking of simtrackerhits and trackerhitplanes

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/MappingUtils.h
@@ -188,7 +188,7 @@ namespace detail {
       if (insertMode == InsertMode::Checked) {
         if (auto existing = mapLookupTo(key, map)) {
           // Explicitly casting to the actual key type here to make return
-          // type deductoin work even in cases where we have a Map<Base*, V>
+          // type deduction work even in cases where we have a Map<Base*, V>
           // but the KeyT has been deduced as Derived*
           return std::make_pair(std::make_tuple(key_t<MapT>(key), existing.value()), false);
         }

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -924,9 +924,13 @@ std::vector<CollNamePair> createLinks(const ObjectMappingT& typeMapping,
       auto mc_a = createLinkCollection<edm4hep::TrackMCParticleLinkCollection, true>(relations, typeMapping.tracks,
                                                                                      typeMapping.mcParticles);
       assoCollVec.emplace_back(name, std::move(mc_a));
-    } else if ((fromType == "TrackerHit" || fromType == "TrackerHitPlane") && toType == "SimTrackerHit") {
+    } else if (fromType == "TrackerHit" && toType == "SimTrackerHit") {
       auto mc_a = createLinkCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, true>(
           relations, typeMapping.trackerHits, typeMapping.simTrackerHits);
+      assoCollVec.emplace_back(name, std::move(mc_a));
+    } else if (fromType == "TrackerHitPlane" && toType == "SimTrackerHit") {
+      auto mc_a = createLinkCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, true>(
+          relations, typeMapping.trackerHitPlanes, typeMapping.simTrackerHits);
       assoCollVec.emplace_back(name, std::move(mc_a));
     } else if (fromType == "SimTrackerHit" && (toType == "TrackerHit" || toType == "TrackerHitPlane")) {
       auto mc_a = createLinkCollection<edm4hep::TrackerHitSimTrackerHitLinkCollection, false>(


### PR DESCRIPTION
BEGINRELEASENOTES
- LCIO2EDM4hep collection: fix linking of simtrackerhits and trackerhitplanes. The wrong map was used for associating the converted (edm4hep) trackerhitplanes, since the other map is for TrackerHit3D, fixes https://github.com/key4hep/CLDConfig/issues/48

ENDRELEASENOTES
