### PR TITLE
Don't throw a pedantic warning because of #warning

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -342,10 +342,8 @@ std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(const edm4hep::RawTimeSeri
     if (edm_tpchit.isAvailable()) {
       auto* lcio_tpchit = new lcio::TPCHitImpl();
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#warning "unsigned long long conversion to int"
-#pragma GCC diagnostic pop
+#pragma message "unsigned long long conversion to int"
+
       lcio_tpchit->setCellID(edm_tpchit.getCellID());
       lcio_tpchit->setTime(edm_tpchit.getTime());
       lcio_tpchit->setCharge(edm_tpchit.getCharge());

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -342,7 +342,10 @@ std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(const edm4hep::RawTimeSeri
     if (edm_tpchit.isAvailable()) {
       auto* lcio_tpchit = new lcio::TPCHitImpl();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #warning "unsigned long long conversion to int"
+#pragma GCC diagnostic pop
       lcio_tpchit->setCellID(edm_tpchit.getCellID());
       lcio_tpchit->setTime(edm_tpchit.getTime());
       lcio_tpchit->setCharge(edm_tpchit.getCharge());


### PR DESCRIPTION
I have enabled `-Werror` in CI to avoid people introducing more warnings. But I get a double warning with `#warning` so this should make CI pass. Apparently it is not possible to disable the warning about `#warning` being a GCC extension without removing `-Wpedantic`: https://stackoverflow.com/questions/16872923/how-to-disable-gcc-warning-about-the-warning-directive-being-a-gcc-extension

BEGINRELEASENOTES
- Don't throw a pedantic warning because of #warning

ENDRELEASENOTES