### PR TITLE
Remove deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ auto* lcio_converted_sim_tracker_hit_ptr = convSimTrackerHits(
   collection_pairs.simtrackerhits,
   collection_pairs.mcparticles);
 
-// Run function to fix missing associations between collections.
+// Run function to fix missing links between collections.
 // Some collections that need to be linked to other collections may be converted
 // after these are linked. Running this function after all conversions guarantees correct links
 // between collections.

--- a/doc/LCIO2EDM4hep.md
+++ b/doc/LCIO2EDM4hep.md
@@ -128,7 +128,7 @@ handles all the type details and can obviously also be used directly.
 available in EDM4hep. They use the `"FromType"` and `"ToType"` collection
 parameters to get the necessary type information.
 
-The AssociationCollections in EDM4hep are then created using `createAssociations`.
+The LinkCollections in EDM4hep are then created using `createLinks`.
 
 ## Converting entire events
 Converting an entire event can be done calling the `convertEvent`. This can also

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -332,18 +332,18 @@ template <typename ObjectMappingT, typename ObjectMappingU>
 void resolveRelations(ObjectMappingT& updateMaps, const ObjectMappingU& lookupMaps);
 
 /**
- * Convert the passed associatoin collections to LCRelation collections
+ * Convert the passed link collections to LCRelation collections
  */
 template <typename ObjectMappingT>
-std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>> createLCRelationCollections(
-    const std::vector<std::tuple<std::string, const podio::CollectionBase*>>& associationCollections,
-    const ObjectMappingT& objectMaps);
+std::vector<std::tuple<std::string, std::unique_ptr<lcio::LCCollection>>>
+createLCRelationCollections(const std::vector<std::tuple<std::string, const podio::CollectionBase*>>& linkCollections,
+                            const ObjectMappingT& objectMaps);
 
 /**
- * Create an LCRelation collection from the passed Association Collection
+ * Create an LCRelation collection from the passed Link Collection
  */
-template <typename AssocCollT, typename FromMapT, typename ToMapT>
-std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const AssocCollT& associations, const FromMapT& fromMap,
+template <typename LinkCollT, typename FromMapT, typename ToMapT>
+std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const LinkCollT& links, const FromMapT& fromMap,
                                                                const ToMapT& toMap);
 
 bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -72,9 +72,6 @@ namespace EDM4hep2LCIOConv {
 template <typename T1, typename T2>
 using ObjectMapT = k4EDM4hep2LcioConv::VecMapT<T1, T2>;
 
-template <typename T1, typename T2>
-using vec_pair [[deprecated("Use a more descriptive alias")]] = ObjectMapT<T1, T2>;
-
 using CellIDStrType = const std::optional<std::string>;
 
 struct CollectionsPairVectors {
@@ -144,12 +141,6 @@ template <typename TrackMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollection* const edmCollection,
                                                      TrackMapT& trackMap);
 
-template <typename TrackMapT, typename TrackerHitMapT>
-[[deprecated("Use convertTracks instead")]] lcio::LCCollectionVec*
-convTracks(const edm4hep::TrackCollection* const tracks_coll, TrackMapT& tracks_vec, const TrackerHitMapT&) {
-  return convertTracks(tracks_coll, tracks_vec).release();
-}
-
 /**
  * Convert EDM4hep TrackerHits to LCIO. Simultaneously populate mapping from
  * EDM4hep to LCIO objects for relation resolving in a second step.
@@ -158,13 +149,6 @@ template <typename TrackerHitMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertTrackerHits(const edm4hep::TrackerHit3DCollection* const edmCollection,
                                                           const CellIDStrType& cellIDStr,
                                                           TrackerHitMapT& trackerHitMap);
-
-template <typename TrackerHitMapT>
-[[deprecated("Use convertTrackerHits instead")]] lcio::LCCollectionVec*
-convTrackerHits(const edm4hep::TrackerHit3DCollection* const trackerhits_coll, const CellIDStrType& cellIDstr,
-                TrackerHitMapT& trackerhits_vec) {
-  return convertTrackerHits(trackerhits_coll, cellIDstr, trackerhits_vec).release();
-}
 
 /**
  * Convert EDM4hep TrackerHitPlanes to LCIO. Simultaneously populate mapping
@@ -175,13 +159,6 @@ std::unique_ptr<lcio::LCCollectionVec>
 convertTrackerHitPlanes(const edm4hep::TrackerHitPlaneCollection* const edmCollection, const CellIDStrType& cellIDstr,
                         TrackerHitPlaneMapT& trackerHitsMap);
 
-template <typename TrackerHitPlaneMapT>
-[[deprecated("Use convertTrackerHitPlanes instead")]] lcio::LCCollectionVec*
-convTrackerHitPlanes(const edm4hep::TrackerHitPlaneCollection* const trackerhits_coll, const CellIDStrType& cellIDstr,
-                     TrackerHitPlaneMapT& trackerhits_vec) {
-  return convertTrackerHitPlanes(trackerhits_coll, cellIDstr, trackerhits_vec).release();
-}
-
 /**
  * Convert EDM4hep SimTrackerHits to LCIO. Simultaneously populate mapping
  * from EDM4hep to LCIO objects for relation resolving in a second step.
@@ -190,13 +167,6 @@ template <typename SimTrHitMapT>
 std::unique_ptr<lcio::LCCollectionVec>
 convertSimTrackerHits(const edm4hep::SimTrackerHitCollection* const edmCollection, const CellIDStrType& cellIDstr,
                       SimTrHitMapT& simTrHitMap);
-
-template <typename SimTrHitMapT, typename MCParticleMapT>
-[[deprecated("Use convertSimTrackerHits instead")]] lcio::LCCollectionVec*
-convSimTrackerHits(const edm4hep::SimTrackerHitCollection* const simtrackerhits_coll, const CellIDStrType& cellIDstr,
-                   SimTrHitMapT& simtrackerhits_vec, const MCParticleMapT&) {
-  return convertSimTrackerHits(simtrackerhits_coll, cellIDstr, simtrackerhits_vec).release();
-}
 
 /**
  * Convert EDM4hep CalorimeterHits to LCIO. Simultaneously populate mapping
@@ -207,13 +177,6 @@ std::unique_ptr<lcio::LCCollectionVec>
 convertCalorimeterHits(const edm4hep::CalorimeterHitCollection* const edmCollection, const CellIDStrType& cellIDstr,
                        CaloHitMapT& caloHitMap);
 
-template <typename CaloHitMapT>
-[[deprecated("Use convertCalorimeterHits instead")]] lcio::LCCollectionVec*
-convCalorimeterHits(const edm4hep::CalorimeterHitCollection* const calohit_coll, const CellIDStrType& cellIDstr,
-                    CaloHitMapT& calo_hits_vec) {
-  return convertCalorimeterHits(calohit_coll, cellIDstr, calo_hits_vec).release();
-}
-
 /**
  * Convert EDM4hep RawCalorimeterHits to LCIO. Simultaneously populate mapping
  * from EDM4hep to LCIO objects for relation resolving in a second step.
@@ -222,13 +185,6 @@ template <typename RawCaloHitMapT>
 std::unique_ptr<lcio::LCCollectionVec>
 convertRawCalorimeterHits(const edm4hep::RawCalorimeterHitCollection* const edmCollection,
                           RawCaloHitMapT& rawCaloHitMap);
-
-template <typename RawCaloHitMapT>
-[[deprecated("use convertRawCalorimeterHits instead")]] lcio::LCCollectionVec*
-convRawCalorimeterHits(const edm4hep::RawCalorimeterHitCollection* const rawcalohit_coll,
-                       RawCaloHitMapT& raw_calo_hits_vec) {
-  return convertRawCalorimeterHits(rawcalohit_coll, raw_calo_hits_vec).release();
-}
 
 /**
  * Convert EDM4hep SimCalorimeterHits to LCIO. Simultaneously populate mapping
@@ -239,19 +195,6 @@ std::unique_ptr<lcio::LCCollectionVec>
 convertSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const edmCollection,
                           const CellIDStrType& cellIDstr, SimCaloHitMapT& simCaloHitMap);
 
-template <typename SimCaloHitMapT>
-lcio::LCCollectionVec* convSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
-                                              const CellIDStrType& cellIDstr, SimCaloHitMapT& sim_calo_hits_vec) {
-  return convertSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec).release();
-}
-
-template <typename SimCaloHitMapT, typename MCParticleMapT>
-[[deprecated("remove MCParticleMap argument since it is unused")]] lcio::LCCollectionVec*
-convSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const simcalohit_coll,
-                       const CellIDStrType& cellIDstr, SimCaloHitMapT& sim_calo_hits_vec, const MCParticleMapT&) {
-  return convSimCalorimeterHits(simcalohit_coll, cellIDstr, sim_calo_hits_vec);
-}
-
 /**
  * Convert EDM4hep TPC Hits to LCIO. Simultaneously populate mapping from
  * EDM4hep to LCIO objects for relation resolving in a second step.
@@ -259,12 +202,6 @@ convSimCalorimeterHits(const edm4hep::SimCalorimeterHitCollection* const simcalo
 template <typename TPCHitMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertTPCHits(const edm4hep::RawTimeSeriesCollection* const edmCollection,
                                                       TPCHitMapT& tpcHitMap);
-
-template <typename TPCHitMapT>
-[[deprecated("Use convertTPCHits instead")]] lcio::LCCollectionVec*
-convTPCHits(const edm4hep::RawTimeSeriesCollection* const tpchit_coll, TPCHitMapT& tpc_hits_vec) {
-  return convertTPCHits(tpchit_coll, tpc_hits_vec).release();
-}
 
 /**
  * Convert EDM4hep Clusters to LCIO. Simultaneously populate mapping from
@@ -274,18 +211,6 @@ template <typename ClusterMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertClusters(const edm4hep::ClusterCollection* const edmCollection,
                                                        ClusterMapT& clusterMap);
 
-template <typename ClusterMapT>
-[[deprecated("Use convertClusters instead")]] lcio::LCCollectionVec*
-convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec) {
-  return convertClusters(cluster_coll, cluster_vec).release();
-}
-
-template <typename ClusterMapT, typename CaloHitMapT>
-[[deprecated("remove CaloHitMap argument since it is unused")]] lcio::LCCollectionVec*
-convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& cluster_vec, const CaloHitMapT&) {
-  return convClusters(cluster_coll, cluster_vec);
-}
-
 /**
  * Convert EDM4hep Vertices to LCIO. Simultaneously populate mapping from
  * EDM4hep to LCIO objects for relation resolving in a second step.
@@ -293,12 +218,6 @@ convClusters(const edm4hep::ClusterCollection* const cluster_coll, ClusterMapT& 
 template <typename VertexMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertVertices(const edm4hep::VertexCollection* const edmCollection,
                                                        VertexMapT& vertexMap);
-
-template <typename VertexMapT, typename RecoPartMapT>
-[[deprecated("Use convertVertices instead")]] lcio::LCCollectionVec*
-convVertices(const edm4hep::VertexCollection* const vertex_coll, VertexMapT& vertex_vec, const RecoPartMapT&) {
-  return convertVertices(vertex_coll, vertex_vec).release();
-}
 
 /**
  * Convert EDM4hep ReconstructedParticles to LCIO. Simultaneously populate
@@ -310,13 +229,6 @@ std::unique_ptr<lcio::LCCollectionVec>
 convertReconstructedParticles(const edm4hep::ReconstructedParticleCollection* const edmCollection,
                               RecoParticleMapT& recoParticleMap);
 
-template <typename RecoPartMapT, typename TrackMapT, typename VertexMapT, typename ClusterMapT>
-[[deprecated("Use convertReconstructedParticle instead")]] lcio::LCCollectionVec*
-convReconstructedParticles(const edm4hep::ReconstructedParticleCollection* const recos_coll,
-                           RecoPartMapT& recoparticles_vec, const TrackMapT&, const VertexMapT&, const ClusterMapT&) {
-  return convertReconstructedParticles(recos_coll, recoparticles_vec).release();
-}
-
 /**
  * Convert EDM4hep MCParticles to LCIO. Simultaneously populate mapping from
  * EDM4hep to LCIO objects for relation resolving in a second step.
@@ -324,12 +236,6 @@ convReconstructedParticles(const edm4hep::ReconstructedParticleCollection* const
 template <typename MCPartMapT>
 std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(const edm4hep::MCParticleCollection* const edmCollection,
                                                           MCPartMapT& mcParticleMap);
-
-template <typename MCPartMapT>
-[[deprecated("Use convertMCParticles")]] lcio::LCCollectionVec*
-convMCParticles(const edm4hep::MCParticleCollection* const mcparticle_coll, MCPartMapT& mc_particles_vec) {
-  return convertMCParticles(mcparticle_coll, mc_particles_vec).release();
-}
 
 /**
  * Convert EDM4hep ParticleIDs to LCIO. NOTE: Since ParticleIDs cannot live in
@@ -346,9 +252,6 @@ void convertParticleIDs(const edm4hep::ParticleIDCollection* const edmCollection
  * to be of length 1!
  */
 void convertEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
-
-[[deprecated("Use convertEventheader instead")]] void
-convEventHeader(const edm4hep::EventHeaderCollection* const header_coll, lcio::LCEventImpl* const lcio_event);
 
 /**
  * Resolve the relations for MCParticles
@@ -443,17 +346,6 @@ template <typename AssocCollT, typename FromMapT, typename ToMapT>
 std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const AssocCollT& associations, const FromMapT& fromMap,
                                                                const ToMapT& toMap);
 
-template <typename ObjectMappingT>
-[[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs) {
-  resolveRelations(update_pairs);
-}
-
-template <typename ObjectMappingT, typename ObjectMappingU>
-[[deprecated("Use resolveRelations instead")]] void FillMissingCollections(ObjectMappingT& update_pairs,
-                                                                           const ObjectMappingU& lookup_pairs) {
-  resolveRelations(update_pairs, lookup_pairs);
-}
-
 bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);
 
 /**
@@ -461,11 +353,6 @@ bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl
  */
 std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent,
                                                 const podio::Frame& metadata = podio::Frame{});
-
-[[deprecated("Use convertEvent")]] std::unique_ptr<lcio::LCEventImpl>
-convEvent(const podio::Frame& edmEvent, const podio::Frame& metadata = podio::Frame{}) {
-  return convertEvent(edmEvent, metadata);
-}
 
 /**
  * Get the radius of the TrackState at the first from the given track. This is

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -145,13 +145,6 @@ template <typename ObjectMappingT>
 std::vector<CollNamePair> createLinks(const ObjectMappingT& typeMapping,
                                       const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation);
 
-template <typename ObjectMappingT>
-[[deprecated("use createLinks instead")]] std::vector<CollNamePair>
-createAssociations(const ObjectMappingT& typeMapping,
-                   const std::vector<std::pair<std::string, EVENT::LCCollection*>>& LCRelation) {
-  return createLinks(typeMapping, LCRelation);
-}
-
 /**
  * Convert a subset collection, dispatching to the correct function for the
  * type of the input collection
@@ -358,16 +351,6 @@ template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
           typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
 std::unique_ptr<CollT> createLinkCollection(EVENT::LCCollection* relations, const FromMapT& fromMap,
                                             const ToMapT& toMap);
-
-template <typename CollT, bool Reverse, typename FromMapT, typename ToMapT,
-          typename FromLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<FromMapT>>,
-          typename ToLCIOT = std::remove_pointer_t<k4EDM4hep2LcioConv::detail::key_t<ToMapT>>,
-          typename FromEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<FromMapT>,
-          typename ToEDM4hepT = k4EDM4hep2LcioConv::detail::mapped_t<ToMapT>>
-[[deprecated("use createLinkCollection instead")]] std::unique_ptr<CollT>
-createAssociationCollection(EVENT::LCCollection* relations, const FromMapT& fromMap, const ToMapT& toMap) {
-  return createLinkCollection<CollT, Reverse>(relations, fromMap, toMap);
-}
 
 /**
  * Creates the CaloHitContributions for all SimCaloHits.

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -403,8 +403,8 @@ void resolveRelationsVertices(VertexMapT& vertexMap, URecoParticleMapT& updateRP
                               const LURecoParticleMapT& lookupRPMap);
 
 template <typename VertexMapT, typename RecoParticleMapT>
-void finalizeVertexRecoParticleLinks(edm4hep::VertexRecoParticleLinkCollection& associations,
-                                     const VertexMapT& vertexMap, const RecoParticleMapT& recoParticleMap);
+void finalizeVertexRecoParticleLinks(edm4hep::VertexRecoParticleLinkCollection& links, const VertexMapT& vertexMap,
+                                     const RecoParticleMapT& recoParticleMap);
 
 /**
  * Go from chi^2 and probability (1 - CDF(chi^2, ndf)) to ndf by a binary search

--- a/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4EDM4hep2LcioConv.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
 
   // We convert these at the very end, once all the necessary information is
   // available
-  std::vector<std::tuple<std::string, const podio::CollectionBase*>> associations{};
+  std::vector<std::tuple<std::string, const podio::CollectionBase*>> linkCollections{};
   std::vector<TrackDqdxConvData> dQdxCollections{};
 
   const auto& collections = edmEvent.getAvailableCollections();
@@ -131,7 +131,7 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
       // "converted" during relation resolving later
       continue;
     } else if (edmCollection->getTypeName().find("Link") != std::string_view::npos) {
-      associations.emplace_back(name, edmCollection);
+      linkCollections.emplace_back(name, edmCollection);
     } else {
       std::cerr << "Error trying to convert requested " << edmCollection->getValueTypeName() << " with name " << name
                 << "\n"
@@ -155,7 +155,7 @@ std::unique_ptr<lcio::LCEventImpl> convertEvent(const podio::Frame& edmEvent, co
 
   resolveRelations(objectMappings);
 
-  for (auto& [name, coll] : createLCRelationCollections(associations, objectMappings)) {
+  for (auto& [name, coll] : createLCRelationCollections(linkCollections, objectMappings)) {
     lcioEvent->addCollection(coll.release(), name);
   }
 

--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -86,7 +86,7 @@ podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::pair<std::
     const auto& lciotype = lcioColl->getTypeName();
     if (lciotype == "LCRelation") {
       LCRelations.push_back(std::make_pair(lcioname, lcioColl));
-      // We handle Relations (aka Associations) once we have converted all the
+      // We handle Relations (aka Links) once we have converted all the
       // data parts.
       continue;
     }
@@ -112,9 +112,9 @@ podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::pair<std::
   }
 
   // Filling all the OneToMany and OneToOne Relations and creating the
-  // AssociationCollections.
+  // LinkCollections.
   resolveRelations(typeMapping);
-  auto assoCollVec = createLinks(typeMapping, LCRelations);
+  auto linksCollVec = createLinks(typeMapping, LCRelations);
   auto headerColl = createEventHeader(evt);
 
   for (const auto& [name, coll] : edmevent) {
@@ -139,7 +139,7 @@ podio::Frame convertEvent(EVENT::LCEvent* evt, const std::vector<std::pair<std::
   for (auto& [name, coll] : edmevent) {
     event.put(std::move(coll), name);
   }
-  for (auto& [name, coll] : assoCollVec) {
+  for (auto& [name, coll] : linksCollVec) {
     event.put(std::move(coll), name);
   }
   return event;

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -30,12 +30,12 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_1");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_2");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_3");
-  ASSERT_SAME_OR_ABORT(edm4hep::RecoMCParticleLinkCollection, "mcRecoAssocs");
-  ASSERT_SAME_OR_ABORT(edm4hep::CaloHitSimCaloHitLinkCollection, "mcCaloHitsAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::RecoMCParticleLinkCollection, "mcRecoLinks");
+  ASSERT_SAME_OR_ABORT(edm4hep::CaloHitSimCaloHitLinkCollection, "mcCaloHitsLinks");
   ASSERT_SAME_OR_ABORT(edm4hep::RecDqdxCollection, "tracks_dQdx")
   ASSERT_SAME_OR_ABORT(edm4hep::VertexCollection, "vertices");
   ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "vtx_recos");
-  ASSERT_SAME_OR_ABORT(edm4hep::VertexRecoParticleLinkCollection, "startVtxAssocs");
+  ASSERT_SAME_OR_ABORT(edm4hep::VertexRecoParticleLinkCollection, "startVtxLinks");
 
   return 0;
 }

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -370,12 +370,12 @@ bool compare(const edm4hep::VertexRecoParticleLinkCollection& origColl,
              const edm4hep::VertexRecoParticleLinkCollection& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
-    const auto origAssoc = origColl[i];
-    const auto assoc = roundtripColl[i];
+    const auto origLink = origColl[i];
+    const auto link = roundtripColl[i];
 
-    REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
-    REQUIRE_SAME(origAssoc.getFrom().id(), assoc.getFrom().id(), "vertex in association " << i);
-    REQUIRE_SAME(origAssoc.getTo().id(), assoc.getTo().id(), "reco particle in association " << i);
+    REQUIRE_SAME(origLink.getWeight(), link.getWeight(), "weight in link " << i);
+    REQUIRE_SAME(origLink.getFrom().id(), link.getFrom().id(), "vertex in link " << i);
+    REQUIRE_SAME(origLink.getTo().id(), link.getTo().id(), "reco particle in link " << i);
   }
 
   return true;

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -41,16 +41,16 @@ bool compare(const edm4hep::VertexCollection& origColl, const edm4hep::VertexCol
 bool compare(const edm4hep::VertexRecoParticleLinkCollection& origColl,
              const edm4hep::VertexRecoParticleLinkCollection& roundtripColl);
 
-template <typename AssociationCollT>
-bool compare(const AssociationCollT& origColl, const AssociationCollT& roundtripColl) {
+template <typename LinkCollT>
+bool compare(const LinkCollT& origColl, const LinkCollT& roundtripColl) {
   REQUIRE_SAME(origColl.size(), roundtripColl.size(), "collection sizes");
   for (size_t i = 0; i < origColl.size(); ++i) {
-    const auto origAssoc = origColl[i];
-    const auto assoc = roundtripColl[i];
+    const auto origLink = origColl[i];
+    const auto link = roundtripColl[i];
 
-    REQUIRE_SAME(origAssoc.getWeight(), assoc.getWeight(), "weight in association " << i);
-    REQUIRE_SAME(origAssoc.getTo().id(), assoc.getTo().id(), "MC part(icle) in association " << i);
-    REQUIRE_SAME(origAssoc.getFrom().id(), assoc.getFrom().id(), "reco part(icle) in association " << i);
+    REQUIRE_SAME(origLink.getWeight(), link.getWeight(), "weight in link " << i);
+    REQUIRE_SAME(origLink.getTo().id(), link.getTo().id(), "MC part(icle) in link " << i);
+    REQUIRE_SAME(origLink.getFrom().id(), link.getFrom().id(), "reco part(icle) in link " << i);
   }
   return true;
 }

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -474,19 +474,19 @@ bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEven
   return true;
 }
 
-// bool compareStartVertexRelations(const edm4hep::VertexRecoParticleLinkCollection& startVtxAssociations, const
+// bool compareStartVertexRelations(const edm4hep::VertexRecoParticleLinkCollection& startVtxLinks, const
 // ObjectMappings& objectMaps, const podio::Frame& event) {
-//   for (const auto& assoc : startVtxAssociations) {
-//     const auto edmVtx = assoc.getVertex();
-//     const auto edmReco = assoc.getRec();
+//   for (const auto& link : startVtxLinks) {
+//     const auto edmVtx = link.getVertex();
+//     const auto edmReco = link.getRec();
 
 //   }
 // }
 
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
-                                 const edm4hep::VertexRecoParticleLink& association, const ObjectMappings& objectMaps) {
+                                 const edm4hep::VertexRecoParticleLink& link, const ObjectMappings& objectMaps) {
   const auto lcioVertex = lcioReco->getStartVertex();
-  const auto edm4hepVertex = association.getFrom();
+  const auto edm4hepVertex = link.getFrom();
   if (!compareRelation(lcioVertex, edm4hepVertex, objectMaps.vertices, "")) {
     return false;
   }
@@ -494,7 +494,7 @@ bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
   return true;
 }
 
-bool compareVertexRecoAssociation(const EVENT::Vertex*, const edm4hep::VertexRecoParticleLink&, const ObjectMappings&) {
+bool compareVertexRecoLink(const EVENT::Vertex*, const edm4hep::VertexRecoParticleLink&, const ObjectMappings&) {
   // TODO: Actually implement the checks
   // TODO: Figure out if this is even the right interface here
   return false;

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -118,14 +118,14 @@ bool compare(const EVENT::ParticleID* lcio, const edm4hep::ParticleID& edm4hep);
 
 bool compareEventHeader(const EVENT::LCEvent* lcevt, const podio::Frame* edmEvent);
 
-template <typename AssocCollT>
-bool compare(const lcio::LCCollection* lcioCollection, const AssocCollT& edm4hepCollection,
+template <typename LinkCollT>
+bool compare(const lcio::LCCollection* lcioCollection, const LinkCollT& edm4hepCollection,
              const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::LCRelation>(lcioCollection, edm4hepCollection, objectMaps);
 }
 
 namespace detail {
-template <typename AssocT>
+template <typename LinkT>
 struct LcioFromToTypeHelper;
 
 template <>
@@ -170,11 +170,11 @@ struct LcioFromToTypeHelper<edm4hep::VertexRecoParticleLink> {
   using to_type = EVENT::Vertex;
 };
 
-template <typename AssocT>
-using getLcioFromType = typename LcioFromToTypeHelper<AssocT>::from_type;
+template <typename LinkT>
+using getLcioFromType = typename LcioFromToTypeHelper<LinkT>::from_type;
 
-template <typename AssocT>
-using getLcioToType = typename LcioFromToTypeHelper<AssocT>::to_type;
+template <typename LinkT>
+using getLcioToType = typename LcioFromToTypeHelper<LinkT>::to_type;
 
 template <typename T>
 const auto& getObjectMap(const ObjectMappings& maps) {
@@ -201,25 +201,24 @@ const auto& getObjectMap(const ObjectMappings& maps) {
 
 } // namespace detail
 
-template <typename AssocT>
-bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectMappings& objectMaps) {
+template <typename LinkT>
+bool compare(const EVENT::LCRelation* lcio, const LinkT& edm4hep, const ObjectMappings& objectMaps) {
 
-  ASSERT_COMPARE(lcio, edm4hep, getWeight, "weight in relation / association");
+  ASSERT_COMPARE(lcio, edm4hep, getWeight, "weight in relation / link");
 
-  using LcioFromT = detail::getLcioFromType<AssocT>;
-  using LcioToT = detail::getLcioToType<AssocT>;
+  using LcioFromT = detail::getLcioFromType<LinkT>;
+  using LcioToT = detail::getLcioToType<LinkT>;
 
   const auto lcioFrom = static_cast<LcioFromT*>(lcio->getFrom());
   const auto edm4hepFrom = edm4hep.getFrom();
   if (!compareRelation(lcioFrom, edm4hepFrom, detail::getObjectMap<LcioFromT>(objectMaps),
-                       "from object in relation / association")) {
+                       "from object in relation / link")) {
     return false;
   }
 
   const auto lcioTo = static_cast<LcioToT*>(lcio->getTo());
   const auto edm4hepTo = edm4hep.getTo();
-  if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps),
-                       "to object in relation / association")) {
+  if (!compareRelation(lcioTo, edm4hepTo, detail::getObjectMap<LcioToT>(objectMaps), "to object in relation / link")) {
     return false;
   }
 
@@ -229,11 +228,11 @@ bool compare(const EVENT::LCRelation* lcio, const AssocT& edm4hep, const ObjectM
 /// Compare the information stored in startVertex in LCIO
 
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,
-                                 const edm4hep::VertexRecoParticleLink& association, const ObjectMappings& objectMaps);
+                                 const edm4hep::VertexRecoParticleLink& link, const ObjectMappings& objectMaps);
 
 /// Compare the information stored in associatedParticle in LCIO
-bool compareVertexRecoAssociation(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRecoParticleLink& association,
-                                  const ObjectMappings& objectMaps);
+bool compareVertexRecoLink(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRecoParticleLink& link,
+                           const ObjectMappings& objectMaps);
 
 #define ASSERT_COMPARE_OR_EXIT(collType)                                                                               \
   if (type == #collType) {                                                                                             \

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -348,32 +348,32 @@ createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
   return collections;
 }
 
-template <typename AssocCollT, typename CollT, typename CollU>
-AssocCollT createAssociationCollection(const CollT& collA, const CollU& collB) {
+template <typename LinkCollT, typename CollT, typename CollU>
+LinkCollT createLinkCollection(const CollT& collA, const CollU& collB) {
   const auto maxSize = std::min(collA.size(), collB.size());
 
-  auto assocs = AssocCollT{};
+  auto links = LinkCollT{};
 
   for (size_t i = 0; i < maxSize; ++i) {
-    auto assoc = assocs.create();
-    assoc.setWeight(i * 10.f / maxSize);
-    assoc.setTo(collA[i]);
-    assoc.setFrom(collB[maxSize - 1 - i]);
+    auto link = links.create();
+    link.setWeight(i * 10.f / maxSize);
+    link.setTo(collA[i]);
+    link.setFrom(collB[maxSize - 1 - i]);
   }
 
-  return assocs;
+  return links;
 }
 
 edm4hep::RecoMCParticleLinkCollection
-createMCRecoParticleAssocs(const edm4hep::MCParticleCollection& mcParticles,
-                           const edm4hep::ReconstructedParticleCollection& recoParticles) {
-  return createAssociationCollection<edm4hep::RecoMCParticleLinkCollection>(mcParticles, recoParticles);
+createMCRecoParticleLinks(const edm4hep::MCParticleCollection& mcParticles,
+                          const edm4hep::ReconstructedParticleCollection& recoParticles) {
+  return createLinkCollection<edm4hep::RecoMCParticleLinkCollection>(mcParticles, recoParticles);
 }
 
-edm4hep::CaloHitSimCaloHitLinkCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
-                                                            const edm4hep::CalorimeterHitCollection& caloHits) {
+edm4hep::CaloHitSimCaloHitLinkCollection createMCCaloLinks(const edm4hep::SimCalorimeterHitCollection& simHits,
+                                                           const edm4hep::CalorimeterHitCollection& caloHits) {
 
-  return createAssociationCollection<edm4hep::CaloHitSimCaloHitLinkCollection>(simHits, caloHits);
+  return createLinkCollection<edm4hep::CaloHitSimCaloHitLinkCollection>(simHits, caloHits);
 }
 
 std::tuple<edm4hep::VertexCollection, edm4hep::ReconstructedParticleCollection,
@@ -391,20 +391,20 @@ createVertices(const int nVertices, const edm4hep::ReconstructedParticleCollecti
     auto reco = recoColl.create();
   }
 
-  auto assocColl = edm4hep::VertexRecoParticleLinkCollection{};
+  auto linkColl = edm4hep::VertexRecoParticleLinkCollection{};
 
   for (const auto& [iV, iP] : recoIdcs) {
     vtxColl[iV].addToParticles(particles[iP]);
-    auto assoc = assocColl.create();
-    assoc.setTo(particles[iP]);
-    assoc.setFrom(vtxColl[iV]);
+    auto link = linkColl.create();
+    link.setTo(particles[iP]);
+    link.setFrom(vtxColl[iV]);
   }
 
   for (const auto& [iP, iV] : vtxRecoIdcs) {
     recoColl[iP].setDecayVertex(vtxColl[iV]);
   }
 
-  return {std::move(vtxColl), std::move(recoColl), std::move(assocColl)};
+  return {std::move(vtxColl), std::move(recoColl), std::move(linkColl)};
 }
 
 std::tuple<podio::Frame, podio::Frame> createExampleEvent() {
@@ -454,14 +454,14 @@ std::tuple<podio::Frame, podio::Frame> createExampleEvent() {
     algoId++;
   }
 
-  event.put(createMCRecoParticleAssocs(mcParticles, recoColl), "mcRecoAssocs");
-  event.put(createMCCaloAssocs(simCaloHits, caloHits), "mcCaloHitsAssocs");
+  event.put(createMCRecoParticleLinks(mcParticles, recoColl), "mcRecoLinks");
+  event.put(createMCCaloLinks(simCaloHits, caloHits), "mcCaloHitsLinks");
 
-  auto [vtxColl, vtxRecos, startVtxAssocs] =
+  auto [vtxColl, vtxRecos, startVtxLinks] =
       createVertices(test_config::nVertices, recoColl, test_config::vtxParticleIdcs, test_config::recoVtxIdcs);
   event.put(std::move(vtxColl), "vertices");
   event.put(std::move(vtxRecos), "vtx_recos");
-  event.put(std::move(startVtxAssocs), "startVtxAssocs");
+  event.put(std::move(startVtxLinks), "startVtxLinks");
 
   return retTuple;
 }

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -183,8 +183,8 @@ createParticleIDs(const std::vector<std::vector<int>>& recoIdcs,
                   const edm4hep::ReconstructedParticleCollection& recoParticles);
 
 edm4hep::RecoMCParticleLinkCollection
-createMCRecoParticleAssocs(const edm4hep::MCParticleCollection& mcParticles,
-                           const edm4hep::ReconstructedParticleCollection& recoParticles);
+createMCRecoParticleLinks(const edm4hep::MCParticleCollection& mcParticles,
+                          const edm4hep::ReconstructedParticleCollection& recoParticles);
 
 edm4hep::CaloHitSimCaloHitLinkCollection createMCCaloAssocs(const edm4hep::SimCalorimeterHitCollection& simHits,
                                                             const edm4hep::CalorimeterHitCollection& caloHits);


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove deprecated conversion functions now that all downstream consumers have switched.
- Remove *association* (and derived terms) from documentation, variable names and comments.

ENDRELEASENOTES

These were introduced in #86 and #54 to decouple the changes from necessary fixes in k4MarlinWrapper.

- [x] Needs https://github.com/key4hep/k4MarlinWrapper/pull/200