### PR TITLE
Convert `Nholes` and `subdetectorHoleNumbers` for tracks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(cmake/compiler_output.cmake)
 include(cmake/build_flags.cmake)
 k4edm4hep2lcioconv_set_compiler_flags()
 
-find_package(LCIO 2.20.1 REQUIRED)
+find_package(LCIO 2.22 REQUIRED)
 find_package(podio 1.0 REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
 find_package(ROOT REQUIRED COMPONENTS MathCore)

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -48,6 +48,13 @@ std::unique_ptr<lcio::LCCollectionVec> convertTracks(const edm4hep::TrackCollect
         }
       }
 
+      lcio_tr->setNholes(edm_tr.getNholes());
+      const auto edmHoleNumbers = edm_tr.getSubdetectorHoleNumbers();
+      lcio_tr->subdetectorHoleNumbers().resize(edmHoleNumbers.size());
+      for (auto i = 0u; i < edmHoleNumbers.size(); ++i) {
+        lcio_tr->subdetectorHoleNumbers()[i] = edmHoleNumbers[i];
+      }
+
       // Loop over the track states in the track
       const auto edm_track_states = edm_tr.getTrackStates();
       for (const auto& tr_state : edm_track_states) {

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -367,16 +367,22 @@ std::vector<CollNamePair> convertTracks(const std::string& name, EVENT::LCCollec
     lval.setType(rval->getType());
     lval.setChi2(rval->getChi2());
     lval.setNdf(rval->getNdf());
+    lval.setNholes(rval->getNholes());
 
     auto& dqdx = trackDqdx.getDQdx();
     dqdx.value = rval->getdEdx();
     dqdx.error = rval->getdEdxError();
 
-    auto subdetectorHitNum = rval->getSubdetectorHitNumbers();
+    const auto& subdetectorHitNum = rval->getSubdetectorHitNumbers();
     for (auto hitNum : subdetectorHitNum) {
       lval.addToSubdetectorHitNumbers(hitNum);
     }
-    auto& trackStates = rval->getTrackStates();
+    const auto& subdetectorHoleNum = rval->getSubdetectorHoleNumbers();
+    for (auto holeNum : subdetectorHoleNum) {
+      lval.addToSubdetectorHoleNumbers(holeNum);
+    }
+
+    const auto& trackStates = rval->getTrackStates();
     for (auto& trackState : trackStates) {
       lval.addToTrackStates(convertTrackState(trackState));
     }

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -147,6 +147,14 @@ bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackColle
 
     REQUIRE_SAME(origTrack.getChi2(), track.getChi2(), "chi2 in track " << i);
     REQUIRE_SAME(origTrack.getNdf(), track.getNdf(), "chi2 in track " << i);
+    REQUIRE_SAME(origTrack.getNholes(), track.getNholes(), "Nholes in track " << i);
+
+    const auto origSubDetHoles = origTrack.getSubdetectorHoleNumbers();
+    const auto subDetHoles = track.getSubdetectorHoleNumbers();
+    REQUIRE_SAME(origSubDetHoles.size(), subDetHoles.size(), "number of subdetector holes in track " << i);
+    for (size_t iSN = 0; iSN < origSubDetHoles.size(); ++iSN) {
+      REQUIRE_SAME(origSubDetHoles[iSN], subDetHoles[iSN], "subdetector hole numbers " << iSN << " in track " << i);
+    }
 
     const auto origSubDetHitNumbers = origTrack.getSubdetectorHitNumbers();
     const auto subDetHitNumbers = track.getSubdetectorHitNumbers();

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -316,6 +316,10 @@ bool compare(const EVENT::Track* lcioElem, const edm4hep::Track& edm4hepElem, co
   ASSERT_COMPARE(lcioElem, edm4hepElem, getType, "type in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getChi2, "chi2 in Track");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getNdf, "ndf in Track");
+  ASSERT_COMPARE(lcioElem, edm4hepElem, getNholes, "Nholes in Track");
+
+  ASSERT_COMPARE(lcioElem, edm4hepElem, getSubdetectorHitNumbers, "subdetectorHitNumbers");
+  ASSERT_COMPARE(lcioElem, edm4hepElem, getSubdetectorHoleNumbers, "subdetectorHitNumbers");
 
   // EDM4hep does not have the dEdx information inside the track, but rather
   // inside a RecDqdx object

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -182,6 +182,10 @@ edm4hep::TrackCollection createTracks(const int num_elements, const int subdetec
     for (int j = 0; j < subdetectorhitnumbers; ++j) {
       elem.addToSubdetectorHitNumbers(i + 10 * j);
     }
+    elem.setNholes(i + 3);
+    for (int j = 0; j < subdetectorhitnumbers; ++j) {
+      elem.addToSubdetectorHoleNumbers(j + 10 * i);
+    }
 
     for (auto& idx : link_trackerhit_idcs) {
       elem.addToTrackerHits(trackerHits[idx]);


### PR DESCRIPTION
BEGINRELEASENOTES
- Convert `Nholes` and `subdetectorHoleNumbers` for tracks
- Bump the minimum LCIO version to `2.22` since this information is not available before that

ENDRELEASENOTES

- Fixes #85 