### PR TITLE
Exclude release notes from pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: mixed-line-ending
       - id: trailing-whitespace
+        exclude: (doc/ReleaseNotes.md)
   - repo: local
     hooks:
       - id: clang-format


### PR DESCRIPTION
BEGINRELEASENOTES
- Exclude the release notes from pre-commit check for trailing whitespaces

ENDRELEASENOTES
