### PR TITLE
Remove the check for TrackerHit3D from edm4hep

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -23,15 +23,7 @@
 #include <edm4hep/TrackMCParticleLinkCollection.h>
 #include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
 #include <edm4hep/VertexRecoParticleLinkCollection.h>
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-using TrackerHit3D = edm4hep::TrackerHit;
-} // namespace edm4hep
-#endif
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/VertexCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -4,6 +4,7 @@
 #include "k4EDM4hep2LcioConv/MappingUtils.h"
 
 // EDM4hep
+#include "edm4hep/TrackerHit3DCollection.h"
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/CaloHitMCParticleLinkCollection.h>
 #include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
@@ -21,11 +22,10 @@
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/TrackCollection.h>
 #include <edm4hep/TrackMCParticleLinkCollection.h>
-#include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
-#include <edm4hep/VertexRecoParticleLinkCollection.h>
-#include "edm4hep/TrackerHit3DCollection.h"
 #include <edm4hep/TrackerHitPlaneCollection.h>
+#include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
 #include <edm4hep/VertexCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>
 
 #include "podio/Frame.h"

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -21,11 +21,11 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackMCParticleLinkCollection.h"
-#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
-#include "edm4hep/VertexRecoParticleLinkCollection.h"
 #include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include "edm4hep/VertexRecoParticleLinkCollection.h"
 #include "edm4hep/utils/ParticleIDUtils.h"
 
 // LCIO

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -23,15 +23,7 @@
 #include "edm4hep/TrackMCParticleLinkCollection.h"
 #include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 #include "edm4hep/VertexRecoParticleLinkCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-using MutableTrackerHit3D = edm4hep::TrackerHit;
-} // namespace edm4hep
-#endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/utils/ParticleIDUtils.h"

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -21,13 +21,13 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackMCParticleLinkCollection.h"
-#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
-#include "edm4hep/VertexRecoParticleLinkCollection.h"
-#include <edm4hep/VertexRecoParticleLink.h>
 #include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include "edm4hep/VertexRecoParticleLinkCollection.h"
 #include "edm4hep/utils/ParticleIDUtils.h"
+#include <edm4hep/VertexRecoParticleLink.h>
 
 #include "podio/Frame.h"
 

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -24,15 +24,7 @@
 #include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 #include "edm4hep/VertexRecoParticleLinkCollection.h"
 #include <edm4hep/VertexRecoParticleLink.h>
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-using TrackerHit3D = edm4hep::TrackerHit;
-} // namespace edm4hep
-#endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/utils/ParticleIDUtils.h"

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -7,12 +7,10 @@
 #include "edm4hep/Vector2i.h"
 #include "edm4hep/Vector3d.h"
 #include "edm4hep/Vector3f.h"
-#if __has_include("edm4hep/CovMatrix3f.h")
 #include <edm4hep/CovMatrix2f.h>
 #include <edm4hep/CovMatrix3f.h>
 #include <edm4hep/CovMatrix4f.h>
 #include <edm4hep/CovMatrix6f.h>
-#endif
 
 #include "EVENT/LCCollection.h"
 #include "UTIL/LCIterator.h"
@@ -74,14 +72,10 @@ template <typename LCIO, typename EDM4hepT>
 bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg) {
   constexpr auto isVectorLike =
       has_size_method<EDM4hepT>::value ||
-      isAnyOf<EDM4hepT, edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f, edm4hep::Vector2i
-#if __has_include("edm4hep/CovMatrix3f.h")
-              ,
+      isAnyOf<EDM4hepT, edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f, edm4hep::Vector2i,
               // These also effectively behave like vectors for
               // the purposes of this function
-              edm4hep::CovMatrix2f, edm4hep::CovMatrix3f, edm4hep::CovMatrix4f, edm4hep::CovMatrix6f
-#endif
-              >;
+              edm4hep::CovMatrix2f, edm4hep::CovMatrix3f, edm4hep::CovMatrix4f, edm4hep::CovMatrix6f>;
 
   if constexpr (isVectorLike) {
     const auto vecSize = [](EDM4hepT& edm4hepVal) -> std::size_t {

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -21,14 +21,7 @@
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
 #include <edm4hep/VertexRecoParticleLinkCollection.h>
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-} // namespace edm4hep
-#endif
 #include <edm4hep/VertexCollection.h>
 
 #include <cstddef>

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -9,6 +9,7 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include <edm4hep/CaloHitMCParticleLinkCollection.h>
 #include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
 #include <edm4hep/ClusterMCParticleLinkCollection.h>
@@ -20,9 +21,8 @@
 #include <edm4hep/TrackMCParticleLinkCollection.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/TrackerHitSimTrackerHitLinkCollection.h>
-#include <edm4hep/VertexRecoParticleLinkCollection.h>
-#include "edm4hep/TrackerHit3DCollection.h"
 #include <edm4hep/VertexCollection.h>
+#include <edm4hep/VertexRecoParticleLinkCollection.h>
 
 #include <cstddef>
 #include <tuple>

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -20,14 +20,7 @@
 
 #include "edm4hep/TrackCollection.h"
 #include <edm4hep/RecDqdxCollection.h>
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-} // namespace edm4hep
-#endif
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/MCParticleCollection.h"

--- a/tests/src/ObjectMapping.cc
+++ b/tests/src/ObjectMapping.cc
@@ -18,9 +18,6 @@
 #include "UTIL/LCIterator.h"
 #include "UTIL/PIDHandler.h"
 
-#include "edm4hep/TrackCollection.h"
-#include <edm4hep/RecDqdxCollection.h>
-#include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/MCParticleCollection.h"
@@ -30,8 +27,11 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#include "edm4hep/TrackCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/VertexCollection.h"
+#include <edm4hep/RecDqdxCollection.h>
 
 #include "podio/Frame.h"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the check for TrackerHit3D from edm4hep
- Remove the check for `CovMatrix3f.h`

ENDRELEASENOTES

See https://github.com/key4hep/k4FWCore/pull/265