### PR TITLE
Make sure to run pre-commit on supported OS

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,10 +8,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Run pre-commit
-      run: |
-        source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
-        cd ${GITHUB_WORKSPACE}
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: el9
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        run: |
+          echo "::group::Setup pre-commit"
+          # Newer versions of git are more cautious around the github runner
+          # environment and without this git rev-parse --show-cdup in pre-commit
+          # fails
+          git config --global --add safe.directory $(pwd)
+          python -m venv /root/pre-commit-venv
+          source /root/pre-commit-venv/bin/activate
+          pip install pre-commit
+          export PYTHONPATH=$VIRTUAL_ENV/lib/python3.$(python3 -c 'import sys; print(f"{sys.version_info[1]}")')/site-packages:$PYTHONPATH
+          echo "::endgroup::"
+          echo "::group::Run pre-commit"
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files
+          echo "::endgroup::"


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the pre-commit CI workflow run on EL9

ENDRELEASENOTES

Directly running on the gitlab runner with Ubuntu stops working because `ubuntu-latest` is switching to Ubuntu 24, see: https://github.com/actions/runner-images/issues/10636
