### PR TITLE
Replace link to local file with link to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ conversion tool for LCIO to EDM4hep.
 
 ## Build and install
 
-If you have an environment that fulfills all dependencies (e.g. a Key4hep stack), simply do
+If you have an environment that fulfils all dependencies (e.g. a Key4hep stack), simply do
 
 - Get the sources to build from
 ```bash

--- a/doc/LCIO2EDM4hep.md
+++ b/doc/LCIO2EDM4hep.md
@@ -142,7 +142,7 @@ This can be done by calling `convertObjectParameters` that will put all the even
 There are a few small differences between LCIO and EDM4hep that shine through in the conversion, these are:
 
 - `CaloHitContributions` are part of the SimCalorimeterHits in LCIO while being their own data type in EDM4hep. They are created by [`createCaloHitContributions`](https://github.com/key4hep/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h).
-- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate  EventHeader Collection. It can be created using [`EventHeaderCollection`](https://github.com/key4hep/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
+- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate EventHeader Collection. It can be created using [`EventHeaderCollection`](https://github.com/key4hep/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
 - Particle IDs are converted during the conversion of the the reconstructed Particle collection.
 
 ## Example for a ReconstructedParticle Collection

--- a/doc/LCIO2EDM4hep.md
+++ b/doc/LCIO2EDM4hep.md
@@ -141,8 +141,8 @@ This can be done by calling `convertObjectParameters` that will put all the even
 ## Subtle differences between LCIO and EDM4hep
 There are a few small differences between LCIO and EDM4hep that shine through in the conversion, these are:
 
-- `CaloHitContributions` are part of the SimCalorimeterHits in LCIO while being their own data type in EDM4hep. They are created by [`createCaloHitContributions`](../k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h).
-- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate  EventHeader Collection. It can be created using [`EventHeaderCollection`](../k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
+- `CaloHitContributions` are part of the SimCalorimeterHits in LCIO while being their own data type in EDM4hep. They are created by [`createCaloHitContributions`](https://github.com/m-fila/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h).
+- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate  EventHeader Collection. It can be created using [`EventHeaderCollection`](https://github.com/m-fila/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
 - Particle IDs are converted during the conversion of the the reconstructed Particle collection.
 
 ## Example for a ReconstructedParticle Collection

--- a/doc/LCIO2EDM4hep.md
+++ b/doc/LCIO2EDM4hep.md
@@ -141,8 +141,8 @@ This can be done by calling `convertObjectParameters` that will put all the even
 ## Subtle differences between LCIO and EDM4hep
 There are a few small differences between LCIO and EDM4hep that shine through in the conversion, these are:
 
-- `CaloHitContributions` are part of the SimCalorimeterHits in LCIO while being their own data type in EDM4hep. They are created by [`createCaloHitContributions`](https://github.com/m-fila/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h).
-- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate  EventHeader Collection. It can be created using [`EventHeaderCollection`](https://github.com/m-fila/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
+- `CaloHitContributions` are part of the SimCalorimeterHits in LCIO while being their own data type in EDM4hep. They are created by [`createCaloHitContributions`](https://github.com/key4hep/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h).
+- The event information like an event number is part of the `LCEvent` in LCIO. In EDM4hep there is a separate  EventHeader Collection. It can be created using [`EventHeaderCollection`](https://github.com/key4hep/k4EDM4hep2LcioConv/blob/main/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h) which is stored under the name `"EventHeader"`.
 - Particle IDs are converted during the conversion of the the reconstructed Particle collection.
 
 ## Example for a ReconstructedParticle Collection


### PR DESCRIPTION
BEGINRELEASENOTES
- Replaced link to local file with link to github, so the page build correctly in keyhep documentation

ENDRELEASENOTES

Links to local files are replaced with links to github as the documentation page is included in the main key4hep documentation where that local files are not present. key4hep/key4hep-doc#78