### PR TITLE
Remove inclusion of no longer existing header

### DIFF
--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -27,7 +27,6 @@
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/VertexRecoParticleLinkCollection.h"
 #include "edm4hep/utils/ParticleIDUtils.h"
-#include <edm4hep/VertexRecoParticleLink.h>
 
 #include "podio/Frame.h"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the inclusion of a no longer existing header in the tests.

ENDRELEASENOTES

Removed in https://github.com/key4hep/EDM4hep/pull/373
