### PR TITLE
Remove the colorFlow from the conversion of the MCParticle

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -484,7 +484,7 @@ std::unique_ptr<lcio::LCCollectionVec> convertMCParticles(const edm4hep::MCParti
       lcio_mcp->setCharge(edm_mcp.getCharge());
       float spin[3] = {edm_mcp.getSpin()[0], edm_mcp.getSpin()[1], edm_mcp.getSpin()[2]};
       lcio_mcp->setSpin(spin);
-      int colorflow[2] = {edm_mcp.getColorFlow()[0], edm_mcp.getColorFlow()[1]};
+      int colorflow[2] = {0, 0};
       lcio_mcp->setColorFlow(colorflow);
 
       lcio_mcp->setCreatedInSimulation(edm_mcp.isCreatedInSimulation());

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -98,7 +98,6 @@ convertMCParticles(const std::string& name, EVENT::LCCollection* LCCollection, M
     lval.setTime(rval->getTime());
     lval.setMass(rval->getMass());
     lval.setSpin(edm4hep::Vector3f(rval->getSpin()));
-    lval.setColorFlow(edm4hep::Vector2i(rval->getColorFlow()));
     lval.setVertex(edm4hep::Vector3d(rval->getVertex()));
     lval.setEndpoint(edm4hep::Vector3d(rval->getEndpoint()));
     lval.setMomentum(rval->getMomentum());

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -59,7 +59,6 @@ bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCPar
     REQUIRE_SAME(origPart.getMass(), part.getMass(), "mass in particle " << i);
     REQUIRE_SAME(origPart.getCharge(), part.getCharge(), "charge in particle " << i);
     REQUIRE_SAME(origPart.getSpin(), part.getSpin(), "spin in particle " << i);
-    REQUIRE_SAME(origPart.getColorFlow(), part.getColorFlow(), "colorFlow in particle " << i);
 
     REQUIRE_SAME(origPart.isCreatedInSimulation(), part.isCreatedInSimulation(), " in particle " << i);
     REQUIRE_SAME(origPart.isBackscatter(), part.isBackscatter(), " in particle " << i);

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -111,7 +111,6 @@ bool compare(const EVENT::MCParticle* lcioElem, const edm4hep::MCParticle& edm4h
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentum, "momentum in MCParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getMomentumAtEndpoint, "momentumAtEndpoint in MCParticle");
   ASSERT_COMPARE(lcioElem, edm4hepElem, getSpin, "spin in MCParticle");
-  ASSERT_COMPARE(lcioElem, edm4hepElem, getColorFlow, "colorFlow in MCParticle");
 
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getDaughters, objectMaps.mcParticles, "daughters in MCParticle");
   ASSERT_COMPARE_RELATION(lcioElem, edm4hepElem, getParents, objectMaps.mcParticles, "parents in MCParticle");

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -4,7 +4,6 @@
 #include "ObjectMapping.h"
 
 #include "edm4hep/Vector2f.h"
-#include "edm4hep/Vector2i.h"
 #include "edm4hep/Vector3d.h"
 #include "edm4hep/Vector3f.h"
 #include <edm4hep/CovMatrix2f.h>
@@ -72,7 +71,7 @@ template <typename LCIO, typename EDM4hepT>
 bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg) {
   constexpr auto isVectorLike =
       has_size_method<EDM4hepT>::value ||
-      isAnyOf<EDM4hepT, edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f, edm4hep::Vector2i,
+      isAnyOf<EDM4hepT, edm4hep::Vector3f, edm4hep::Vector3d, edm4hep::Vector2f,
               // These also effectively behave like vectors for
               // the purposes of this function
               edm4hep::CovMatrix2f, edm4hep::CovMatrix3f, edm4hep::CovMatrix4f, edm4hep::CovMatrix6f>;
@@ -83,7 +82,7 @@ bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg)
         return edm4hepVal.size();
       } else if constexpr (std::is_same_v<EDM4hepT, edm4hep::Vector3f> || std::is_same_v<EDM4hepT, edm4hep::Vector3d>) {
         return 3u;
-      } else if constexpr (std::is_same_v<EDM4hepT, edm4hep::Vector2i> || std::is_same_v<EDM4hepT, edm4hep::Vector2f>) {
+      } else if constexpr (std::is_same_v<EDM4hepT, edm4hep::Vector2f>) {
         return 2;
       }
       return 0;

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -53,7 +53,6 @@ edm4hep::MCParticleCollection createMCParticles(const int num_elements,
     elem.setMomentumAtEndpoint({i * 3.f, i * 2.f, i * 1.f});
     elem.setMass(125. * i);
     elem.setSpin({i * 0.5f, i * 0.25f, i * 0.25f});
-    elem.setColorFlow({i, i * 2});
     elem.setCreatedInSimulation(1);
     elem.setBackscatter(0);
     elem.setVertexIsNotEndpointOfParent(1);


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the conversion of the `colorFlow` from the MCParticle. For LCIO the color flow will be set to `{0, 0}` during the conversion. (`colorFlow` is removed from the `edm4hep::MCParticle` in [EDM4hep#389](https://github.com/key4hep/EDM4hep/pull/389))

ENDRELEASENOTES
