### PR TITLE
Revert "Generalize the functionality of converting parameters"

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -160,32 +160,11 @@ template <typename LCVecType>
 std::vector<CollNamePair> convertLCVec(const std::string& name, EVENT::LCCollection* LCCollection);
 
 /**
- * Converting all parameters of an LCIO Object and passing them to the PutParamF
- * function that takes care of storing them appropriately.
- *
- * The indirection is necessary for better integration with k4FWCore where
- * direct access to a Frame is not possible, but a putParameter method is
- * available instead.
- *
- * The PutParamF has to provide the following interface
- *
- * template<typename T>
- * void(std::string const&, T const&)
- *
- * It will be called for all T that are currently supported as parameters (int,
- * float, double, std::string resp. std::vector of those).
- */
-template <typename LCIOType, typename PutParamF>
-void convertObjectParameters(LCIOType* lcioobj, PutParamF putParamFun);
-
-/**
  * Converting all parameters of an LCIO Object and attaching them to the
  * passed podio::Frame.
  */
 template <typename LCIOType>
-void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event) {
-  convertObjectParameters(lcioobj, [&event](const std::string& key, const auto& v) { event.putParameter(key, v); });
-}
+void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event);
 
 inline edm4hep::Vector3f Vector3fFrom(const double* v) { return edm4hep::Vector3f(v[0], v[1], v[2]); }
 

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.ipp
@@ -6,18 +6,16 @@
 #include <edm4hep/RecDqdxCollection.h>
 
 namespace LCIO2EDM4hepConv {
-
-template <typename LCIOType, typename PutParamF>
-void convertObjectParameters(LCIOType* lcioobj, PutParamF putParamFun) {
+template <typename LCIOType>
+void convertObjectParameters(LCIOType* lcioobj, podio::Frame& event) {
   const auto& params = lcioobj->getParameters();
-
   // handle srting params
   EVENT::StringVec keys;
   const auto stringKeys = params.getStringKeys(keys);
   for (auto i = 0u; i < stringKeys.size(); i++) {
     EVENT::StringVec sValues;
     const auto stringVals = params.getStringVals(stringKeys[i], sValues);
-    putParamFun(stringKeys[i], stringVals);
+    event.putParameter(stringKeys[i], stringVals);
   }
   // handle float params
   EVENT::StringVec fkeys;
@@ -25,7 +23,7 @@ void convertObjectParameters(LCIOType* lcioobj, PutParamF putParamFun) {
   for (auto i = 0u; i < floatKeys.size(); i++) {
     EVENT::FloatVec fValues;
     const auto floatVals = params.getFloatVals(floatKeys[i], fValues);
-    putParamFun(floatKeys[i], floatVals);
+    event.putParameter(floatKeys[i], floatVals);
   }
   // handle int params
   EVENT::StringVec ikeys;
@@ -33,7 +31,7 @@ void convertObjectParameters(LCIOType* lcioobj, PutParamF putParamFun) {
   for (auto i = 0u; i < intKeys.size(); i++) {
     EVENT::IntVec iValues;
     const auto intVals = params.getIntVals(intKeys[i], iValues);
-    putParamFun(intKeys[i], intVals);
+    event.putParameter(intKeys[i], intVals);
   }
   // handle double params
   EVENT::StringVec dkeys;
@@ -41,7 +39,7 @@ void convertObjectParameters(LCIOType* lcioobj, PutParamF putParamFun) {
   for (auto i = 0u; i < dKeys.size(); i++) {
     EVENT::DoubleVec dValues;
     const auto dVals = params.getDoubleVals(dKeys[i], dValues);
-    putParamFun(dKeys[i], dVals);
+    event.putParameter(dKeys[i], dVals);
   }
 }
 


### PR DESCRIPTION
Reverts key4hep/k4EDM4hep2LcioConv#102, see https://github.com/key4hep/k4MarlinWrapper/pull/216#issuecomment-2624106435. I think keeping the simpler version is fine; since this doesn't have any chances of being used if it's not in the Marlin wrapper.