### PR TITLE
Ensure proper conversion of sim - tracker hit relations and links

### DIFF
--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.h
@@ -338,6 +338,17 @@ template <typename LinkCollT, typename FromMapT, typename ToMapT>
 std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const LinkCollT& links, const FromMapT& fromMap,
                                                                const ToMapT& toMap);
 
+/**
+ * Convert the passed link collection to an LCRelation collection
+ *
+ * Dedicated overload for handling tracker hit - sim tracker hit relations since
+ * lookups have to happen in multiple places
+ */
+template <typename Hit3DMap, typename HitPlaneMap, typename SimHitMap>
+std::unique_ptr<lcio::LCCollection>
+createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection& links, const Hit3DMap& hits3DMap,
+                           const HitPlaneMap& hitsPlaneMap, const SimHitMap& simHitMap);
+
 bool collectionExist(const std::string& collection_name, const lcio::LCEventImpl* lcio_event);
 
 /**

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -888,7 +888,7 @@ createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection&
     if (lcioTH) {
       lcioRel->setFrom(lcioTH);
     } else {
-      std::cerr << "Cannot find an object for building an LCRelation of type TrackerHit (3D  or Plane)" << std::endl;
+      std::cerr << "Cannot find a TrackerHit (3D  or Plane) for building an LCRelation from TrackerHits to SimTrackerHits" << std::endl;
     }
 
     const auto edm4hepSimTH = link.getTo();
@@ -896,7 +896,7 @@ createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection&
     if (lcioSimTH) {
       lcioRel->setTo(lcioSimTH.value());
     } else {
-      std::cerr << "Cannot find an object for building an LCRelation of type SimTrackerHit" << std::endl;
+      std::cerr << "Cannot find a SimTrackerHit for building an LCRelation from TrackerHits to SimTrackerHits" << std::endl;
     }
 
     lcioColl->addElement(lcioRel);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -772,8 +772,9 @@ createLCRelationCollections(const std::vector<std::tuple<std::string, const podi
           name, createLCRelationCollection(*caloHitSimCaloHitLink, objectMaps.caloHits, objectMaps.simCaloHits));
     } else if (const auto trackerHitSimTrackerHitLink =
                    dynamic_cast<const edm4hep::TrackerHitSimTrackerHitLinkCollection*>(coll)) {
-      relationColls.emplace_back(name, createLCRelationCollection(*trackerHitSimTrackerHitLink, objectMaps.trackerHits,
-                                                                  objectMaps.simTrackerHits));
+      relationColls.emplace_back(name,
+                                 createLCRelationCollection(*trackerHitSimTrackerHitLink, objectMaps.trackerHits,
+                                                            objectMaps.trackerHitPlanes, objectMaps.simTrackerHits));
     } else if (const auto caloHitMCParticleLink = dynamic_cast<const edm4hep::CaloHitMCParticleLinkCollection*>(coll)) {
       relationColls.emplace_back(
           name, createLCRelationCollection(*caloHitMCParticleLink, objectMaps.caloHits, objectMaps.mcParticles));
@@ -853,6 +854,49 @@ std::unique_ptr<lcio::LCCollection> createLCRelationCollection(const LinkCollT& 
     } else {
       std::cerr << "Cannot find an objects for building an LCRelation of type " << detail::getTypeName<ToLCIOT>()
                 << std::endl;
+    }
+
+    lcioColl->addElement(lcioRel);
+  }
+
+  return lcioColl;
+}
+
+template <typename Hit3DMap, typename HitPlaneMap, typename SimHitMap>
+std::unique_ptr<lcio::LCCollection>
+createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection& links, const Hit3DMap& hits3DMap,
+                           const HitPlaneMap& hitsPlaneMap, const SimHitMap& simHitMap) {
+  auto lcioColl = std::make_unique<lcio::LCCollectionVec>(lcio::LCIO::LCRELATION);
+  lcioColl->parameters().setValue("FromType", detail::getTypeName<EVENT::TrackerHit>());
+  lcioColl->parameters().setValue("ToType", detail::getTypeName<EVENT::SimTrackerHit>());
+
+  for (const auto link : links) {
+    auto lcioRel = new lcio::LCRelationImpl{};
+    lcioRel->setWeight(link.getWeight());
+
+    // Have to look in both maps to figure out where it actually is
+    const auto edm4hepTH = link.getFrom();
+    const auto lcioTH = [&]() -> EVENT::LCObject* {
+      auto lcioHit = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepTH, hits3DMap);
+      if (lcioHit) {
+        return lcioHit.value();
+      }
+      auto lcioHitPlane = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepTH, hitsPlaneMap);
+
+      return lcioHitPlane.value_or(nullptr);
+    }();
+    if (lcioTH) {
+      lcioRel->setFrom(lcioTH);
+    } else {
+      std::cerr << "Cannot find an object for building an LCRelation of type TrackerHit (3D  or Plane)" << std::endl;
+    }
+
+    const auto edm4hepSimTH = link.getTo();
+    const auto lcioSimTH = k4EDM4hep2LcioConv::detail::mapLookupFrom(edm4hepSimTH, simHitMap);
+    if (lcioSimTH) {
+      lcioRel->setTo(lcioSimTH.value());
+    } else {
+      std::cerr << "Cannot find an object for building an LCRelation of type SimTrackerHit" << std::endl;
     }
 
     lcioColl->addElement(lcioRel);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4EDM4hep2LcioConv.ipp
@@ -888,7 +888,9 @@ createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection&
     if (lcioTH) {
       lcioRel->setFrom(lcioTH);
     } else {
-      std::cerr << "Cannot find a TrackerHit (3D  or Plane) for building an LCRelation from TrackerHits to SimTrackerHits" << std::endl;
+      std::cerr
+          << "Cannot find a TrackerHit (3D or Plane) for building an LCRelation from TrackerHits to SimTrackerHits"
+          << std::endl;
     }
 
     const auto edm4hepSimTH = link.getTo();
@@ -896,7 +898,8 @@ createLCRelationCollection(const edm4hep::TrackerHitSimTrackerHitLinkCollection&
     if (lcioSimTH) {
       lcioRel->setTo(lcioSimTH.value());
     } else {
-      std::cerr << "Cannot find a SimTrackerHit for building an LCRelation from TrackerHits to SimTrackerHits" << std::endl;
+      std::cerr << "Cannot find a SimTrackerHit for building an LCRelation from TrackerHits to SimTrackerHits"
+                << std::endl;
     }
 
     lcioColl->addElement(lcioRel);

--- a/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
+++ b/k4EDM4hep2LcioConv/include/k4EDM4hep2LcioConv/k4Lcio2EDM4hepConv.h
@@ -345,6 +345,19 @@ std::unique_ptr<CollT> createLinkCollection(EVENT::LCCollection* relations, cons
                                             const ToMapT& toMap);
 
 /**
+ * Create a TrackerHitSimTrackerHitLinkCollection. This is a dedicated function
+ * (and not part of the createLinkCollection overload-set!) because this
+ * requires lookups in two dedicated tracker hit maps, depending on which type
+ * they actually are.
+ *
+ * Templated on all involved maps to allow for different choices there.
+ */
+template <typename SimHitMap, typename Hit3DMap, typename HitPlaneMap>
+std::unique_ptr<edm4hep::TrackerHitSimTrackerHitLinkCollection>
+createLinkCollection(EVENT::LCCollection* relations, const SimHitMap& simHitMap, const Hit3DMap& hit3DMap,
+                     const HitPlaneMap& hitPlaneMap, bool reverse);
+
+/**
  * Creates the CaloHitContributions for all SimCaloHits.
  * has to be done this way, since the converted McParticles are needeed.
  * The contributions are also attached to their corresponding

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -22,6 +22,7 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::CalorimeterHitCollection, "caloHits");
   ASSERT_SAME_OR_ABORT(edm4hep::MCParticleCollection, "mcParticles");
   ASSERT_SAME_OR_ABORT(edm4hep::SimCalorimeterHitCollection, "simCaloHits");
+  ASSERT_SAME_OR_ABORT(edm4hep::SimTrackerHitCollection, "simTrackerHits");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackCollection, "tracks");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHit3DCollection, "trackerHits");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");

--- a/tests/edm4hep_roundtrip.cpp
+++ b/tests/edm4hep_roundtrip.cpp
@@ -26,6 +26,7 @@ int main() {
   ASSERT_SAME_OR_ABORT(edm4hep::TrackCollection, "tracks");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHit3DCollection, "trackerHits");
   ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitPlaneCollection, "trackerHitPlanes");
+  ASSERT_SAME_OR_ABORT(edm4hep::TrackerHitSimTrackerHitLinkCollection, "simTrackerHitLinks");
   ASSERT_SAME_OR_ABORT(edm4hep::ClusterCollection, "clusters");
   ASSERT_SAME_OR_ABORT(edm4hep::ReconstructedParticleCollection, "recos");
   ASSERT_SAME_OR_ABORT(edm4hep::ParticleIDCollection, "ParticleID_coll_1");

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -65,9 +65,15 @@ int main() {
     ASSERT_COMPARE_OR_EXIT(edm4hep::RawTimeSeriesCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::ClusterCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::VertexCollection)
-    ASSERT_COMPARE_OR_EXIT(edm4hep::RecoMCParticleLinkCollection)
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 2)
+    ASSERT_COMPARE_LINK_OR_EXIT(edm4hep::ReconstructedParticle, edm4hep::MCParticle)
     ASSERT_COMPARE_LINK_OR_EXIT(edm4hep::CalorimeterHit, edm4hep::SimCalorimeterHit)
     ASSERT_COMPARE_LINK_OR_EXIT(edm4hep::TrackerHit, edm4hep::SimTrackerHit)
+#else
+    ASSERT_COMPARE_OR_EXIT(edm4hep::RecoMCParticleLinkCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::CaloHitSimCaloHitLinkCollection)
+    ASSERT_COMPARE_OR_EXIT(edm4hep::TrackerHitSimTrackerHitLinkCollection)
+#endif
 
     // TODO: start vertex association (EDM4hep) vs getStartVertex in LCIO
   }

--- a/tests/edm4hep_to_lcio.cpp
+++ b/tests/edm4hep_to_lcio.cpp
@@ -66,7 +66,8 @@ int main() {
     ASSERT_COMPARE_OR_EXIT(edm4hep::ClusterCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::VertexCollection)
     ASSERT_COMPARE_OR_EXIT(edm4hep::RecoMCParticleLinkCollection)
-    ASSERT_COMPARE_OR_EXIT(edm4hep::CaloHitSimCaloHitLinkCollection)
+    ASSERT_COMPARE_LINK_OR_EXIT(edm4hep::CalorimeterHit, edm4hep::SimCalorimeterHit)
+    ASSERT_COMPARE_LINK_OR_EXIT(edm4hep::TrackerHit, edm4hep::SimTrackerHit)
 
     // TODO: start vertex association (EDM4hep) vs getStartVertex in LCIO
   }

--- a/tests/src/CompareEDM4hepEDM4hep.cc
+++ b/tests/src/CompareEDM4hepEDM4hep.cc
@@ -120,6 +120,24 @@ bool compare(const edm4hep::SimCalorimeterHitCollection& origColl,
   return true;
 }
 
+bool compare(const edm4hep::SimTrackerHitCollection& origColl, const edm4hep::SimTrackerHitCollection& roundtripColl) {
+  for (size_t i = 0; i < origColl.size(); ++i) {
+    auto origHit = origColl[i];
+    auto hit = roundtripColl[i];
+
+    REQUIRE_SAME(origHit.getCellID(), hit.getCellID(), "cellID in hit " << i);
+    REQUIRE_SAME(origHit.getEDep(), hit.getEDep(), "energy in hit " << i);
+    REQUIRE_SAME(origHit.getTime(), hit.getTime(), "time in hit " << i);
+    REQUIRE_SAME(origHit.getPathLength(), hit.getPathLength(), "pathLength in hit " << i);
+    REQUIRE_SAME(origHit.getQuality(), hit.getQuality(), "quality in hit " << i);
+    REQUIRE_SAME(origHit.getPosition(), hit.getPosition(), "position in hit " << i);
+    REQUIRE_SAME(origHit.getMomentum(), hit.getMomentum(), "momentum in hit " << i);
+    REQUIRE_SAME(origHit.getParticle().id(), hit.getParticle().id(), "related particle in hit " << i);
+  }
+
+  return true;
+}
+
 bool compare(const edm4hep::TrackState& orig, const edm4hep::TrackState& roundtrip) {
   REQUIRE_SAME(orig.location, roundtrip.location, "location in TrackState");
   REQUIRE_SAME(orig.D0, roundtrip.D0, "D0 in TrackState");

--- a/tests/src/CompareEDM4hepEDM4hep.h
+++ b/tests/src/CompareEDM4hepEDM4hep.h
@@ -22,6 +22,8 @@ bool compare(const edm4hep::MCParticleCollection& origColl, const edm4hep::MCPar
 bool compare(const edm4hep::SimCalorimeterHitCollection& origColl,
              const edm4hep::SimCalorimeterHitCollection& roundtripColl);
 
+bool compare(const edm4hep::SimTrackerHitCollection& origColl, const edm4hep::SimTrackerHitCollection& roundtripColl);
+
 bool compare(const edm4hep::TrackCollection& origColl, const edm4hep::TrackCollection& roundtripColl);
 
 bool compare(const edm4hep::TrackerHit3DCollection& origColl, const edm4hep::TrackerHit3DCollection& roundtripColl);

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -461,12 +461,12 @@ bool compare(const EVENT::LCRelation* lcioRel, const edm4hep::TrackerHitSimTrack
   ASSERT_COMPARE(lcioRel, edm4hepLink, getWeight, "weight in relation / link");
 
   const auto lcioSimHit = static_cast<EVENT::SimTrackerHit*>(lcioRel->getTo());
-  const auto edm4hepSimHit = edm4hepLink.get<edm4hep::SimTrackerHit>();
+  const auto edm4hepSimHit = edm4hepLink.getTo();
   if (!compareRelation(lcioSimHit, edm4hepSimHit, objectMaps.simTrackerHits, "sim hit in relation / link")) {
     return false;
   }
 
-  const auto edm4hepHit = edm4hepLink.get<edm4hep::TrackerHit>();
+  const auto edm4hepHit = edm4hepLink.getFrom();
   bool anyMatch = false;
   if (edm4hepHit.isA<edm4hep::TrackerHit3D>()) {
     const auto lcioHit = static_cast<EVENT::TrackerHit*>(lcioRel->getFrom());

--- a/tests/src/CompareEDM4hepLCIO.cc
+++ b/tests/src/CompareEDM4hepLCIO.cc
@@ -456,6 +456,37 @@ bool compare(const EVENT::Vertex* lcioElem, const edm4hep::Vertex& edm4hepElem, 
   return true;
 }
 
+bool compare(const EVENT::LCRelation* lcioRel, const edm4hep::TrackerHitSimTrackerHitLink& edm4hepLink,
+             const ObjectMappings& objectMaps) {
+  ASSERT_COMPARE(lcioRel, edm4hepLink, getWeight, "weight in relation / link");
+
+  const auto lcioSimHit = static_cast<EVENT::SimTrackerHit*>(lcioRel->getTo());
+  const auto edm4hepSimHit = edm4hepLink.get<edm4hep::SimTrackerHit>();
+  if (!compareRelation(lcioSimHit, edm4hepSimHit, objectMaps.simTrackerHits, "sim hit in relation / link")) {
+    return false;
+  }
+
+  const auto edm4hepHit = edm4hepLink.get<edm4hep::TrackerHit>();
+  bool anyMatch = false;
+  if (edm4hepHit.isA<edm4hep::TrackerHit3D>()) {
+    const auto lcioHit = static_cast<EVENT::TrackerHit*>(lcioRel->getFrom());
+    anyMatch |= compareRelation(lcioHit, edm4hepHit, objectMaps.trackerHits);
+  } else if (edm4hepHit.isA<edm4hep::TrackerHitPlane>()) {
+    const auto lcioHit = static_cast<EVENT::TrackerHitPlane*>(lcioRel->getFrom());
+    anyMatch |= compareRelation(lcioHit, edm4hepHit, objectMaps.trackerHitPlanes);
+  } else {
+    std::cerr << "Encountered unknown type in TrackerHitSimTrackerHitLink. Please fix the tests" << std::endl;
+    return false;
+  }
+
+  if (!anyMatch) {
+    std::cerr << "Could not find a linked TrackerHit in a relation / link" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
 bool compare(const lcio::LCCollection* lcioCollection, const edm4hep::VertexCollection& edm4hepCollection,
              const ObjectMappings& objectMaps) {
   return compareCollection<EVENT::Vertex>(lcioCollection, edm4hepCollection, objectMaps);

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -10,6 +10,7 @@
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/ClusterMCParticleLinkCollection.h"
+#include "edm4hep/EDM4hepVersion.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/ParticleIDCollection.h"
@@ -238,6 +239,7 @@ bool compareVertexRecoLink(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRe
     }                                                                                                                  \
   }
 
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 2)
 #define ASSERT_COMPARE_LINK_OR_EXIT(fromType, toType)                                                                  \
   if (type == "podio::LinkCollection<" #fromType "," #toType ">") {                                                    \
     auto& edmcoll = edmEvent.get<podio::LinkCollection<fromType, toType>>(name);                                       \
@@ -246,5 +248,6 @@ bool compareVertexRecoLink(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRe
       return 1;                                                                                                        \
     }                                                                                                                  \
   }
+#endif
 
 #endif // K4EDM4HEP2LCIOCONV_TEST_COMPAREEDM4HEPLCIO_H

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -194,7 +194,6 @@ const auto& getObjectMap(const ObjectMappings& maps) {
 
 template <typename LinkT>
 bool compare(const EVENT::LCRelation* lcio, const LinkT& edm4hep, const ObjectMappings& objectMaps) {
-
   ASSERT_COMPARE(lcio, edm4hep, getWeight, "weight in relation / link");
 
   using LcioFromT = detail::getLcioFromType<LinkT>;
@@ -228,6 +227,15 @@ bool compareVertexRecoLink(const EVENT::Vertex* lcioVtx, const edm4hep::VertexRe
 #define ASSERT_COMPARE_OR_EXIT(collType)                                                                               \
   if (type == #collType) {                                                                                             \
     auto& edmcoll = edmEvent.get<collType>(name);                                                                      \
+    if (!compare(lcioColl, edmcoll, objectMapping)) {                                                                  \
+      std::cerr << "in collection: " << name << std::endl;                                                             \
+      return 1;                                                                                                        \
+    }                                                                                                                  \
+  }
+
+#define ASSERT_COMPARE_LINK_OR_EXIT(fromType, toType)                                                                  \
+  if (type == "podio::LinkCollection<" #fromType "," #toType ">") {                                                    \
+    auto& edmcoll = edmEvent.get<podio::LinkCollection<fromType, toType>>(name);                                       \
     if (!compare(lcioColl, edmcoll, objectMapping)) {                                                                  \
       std::cerr << "in collection: " << name << std::endl;                                                             \
       return 1;                                                                                                        \

--- a/tests/src/CompareEDM4hepLCIO.h
+++ b/tests/src/CompareEDM4hepLCIO.h
@@ -215,6 +215,11 @@ bool compare(const EVENT::LCRelation* lcio, const LinkT& edm4hep, const ObjectMa
   return true;
 }
 
+// Dedicated overload for tracker hit - sim tracker hit links since they might
+// require double lookup
+bool compare(const EVENT::LCRelation* lcioRel, const edm4hep::TrackerHitSimTrackerHitLink& edm4hepLink,
+             const ObjectMappings& objectMaps);
+
 /// Compare the information stored in startVertex in LCIO
 
 bool compareStartVertexRelations(const EVENT::ReconstructedParticle* lcioReco,

--- a/tests/src/ComparisonUtils.h
+++ b/tests/src/ComparisonUtils.h
@@ -145,27 +145,34 @@ bool compareValuesNanSafe(LCIO lcioV, EDM4hepT edm4hepV, const std::string& msg)
  */
 template <typename LcioT, typename EDM4hepT, typename MapT>
 inline bool compareRelation(const LcioT* lcioElem, const EDM4hepT& edm4hepElem, const MapT& objectMap,
-                            const std::string& msg) {
+                            const std::string& msg = "") {
   if (lcioElem == nullptr && !edm4hepElem.isAvailable()) {
     // Both elements are "empty". Nothing more to do here
     return true;
   }
   if ((lcioElem == nullptr && edm4hepElem.isAvailable()) || (lcioElem != nullptr && !edm4hepElem.isAvailable())) {
-    const auto emptyOrNot = [](const bool b) { return b ? "not empty" : "empty"; };
-    std::cerr << msg << " LCIO element is " << emptyOrNot(lcioElem) << " but edm4hep element is "
-              << emptyOrNot(edm4hepElem.isAvailable()) << std::endl;
+    if (!msg.empty()) {
+      const auto emptyOrNot = [](const bool b) { return b ? "not empty" : "empty"; };
+      std::cerr << msg << " LCIO element is " << emptyOrNot(lcioElem) << " but edm4hep element is "
+                << emptyOrNot(edm4hepElem.isAvailable()) << std::endl;
+    }
     return false;
   }
 
   // Now we know for sure that
   if (const auto it = objectMap.find(lcioElem); it != objectMap.end()) {
     if (!(it->second == edm4hepElem.getObjectID())) {
-      std::cerr << msg << " LCIO element " << lcioElem << " points to " << it->second << " but should point to "
-                << edm4hepElem.getObjectID() << std::endl;
+      if (!msg.empty()) {
+        std::cerr << msg << " LCIO element " << lcioElem << " points to " << it->second << " but should point to "
+                  << edm4hepElem.getObjectID() << std::endl;
+      }
       return false;
     }
   } else {
-    std::cerr << msg << " cannot find LCIO object " << lcioElem << " in object map for relation checking" << std::endl;
+    if (!msg.empty()) {
+      std::cerr << msg << " cannot find LCIO object " << lcioElem << " in object map for relation checking"
+                << std::endl;
+    }
     return false;
   }
 

--- a/tests/src/EDM4hep2LCIOUtilities.cc
+++ b/tests/src/EDM4hep2LCIOUtilities.cc
@@ -298,8 +298,8 @@ createSimTrackerHitTrackerHitLinks(const std::vector<edm4hep::TrackerHit>& track
 
   for (const auto& [hitIdx, simIdx] : linkIdcs) {
     auto link = links.create();
-    link.set(simHits[simIdx]);
-    link.set(trackerHits[hitIdx]);
+    link.setTo(simHits[simIdx]);
+    link.setFrom(trackerHits[hitIdx]);
   }
 
   return links;

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -8,6 +8,7 @@
 #include "edm4hep/RawCalorimeterHitCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHit3DCollection.h"
 #include <edm4hep/CaloHitMCParticleLinkCollection.h>
@@ -67,6 +68,11 @@ using CaloContIdx = std::tuple<int, int, int>;
 const static std::vector<CaloContIdx> simCaloHitMCIdcs = {{0, 0, 0}, {0, 1, 2}, {0, 2, 1}, {0, 3, 4},
                                                           {1, 0, 1}, {1, 1, 3}, {1, 2, 4}, {1, 3, 4},
                                                           {2, 0, 0}, {2, 1, 3}, {2, 2, 2}, {2, 3, 0}};
+
+constexpr static int nSimTrackerHits = 5; ///< The number of SimTrackeHits to create
+/// The indices of MCParticles to which the SimTrackerHits should be linked.
+/// First index is the sim hit, second index is the MCParticle
+const static std::vector<IdxPair> simTrackHitMCIdcs = {{0, 0}, {1, 0}, {2, 0}, {3, 2}, {4, 1}};
 
 /// The number of clusters to create
 constexpr static int nClusters = 5;
@@ -141,6 +147,11 @@ edm4hep::RawTimeSeriesCollection createTPCHits(const int num_elements, const int
 edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements);
 
 /**
+ * Create a TrackerHitPlane collection
+ */
+edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements);
+
+/**
  * Create a track collection with tracks that have links to other tracks (in the
  * same collection) and tracker hits
  */
@@ -157,6 +168,13 @@ std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionColl
 createSimCalorimeterHits(const int num_elements, const int num_contributions,
                          const edm4hep::MCParticleCollection& mcParticles,
                          const std::vector<test_config::CaloContIdx>& link_mcparticles_idcs);
+
+/**
+ * Create a SimTrackerHitCollection
+ */
+edm4hep::SimTrackerHitCollection createSimTrackerHitCollection(int num_elements,
+                                                               const edm4hep::MCParticleCollection& mcParticles,
+                                                               const std::vector<test_config::IdxPair>& mcParticleIdcs);
 
 edm4hep::EventHeaderCollection createEventHeader();
 

--- a/tests/src/EDM4hep2LCIOUtilities.h
+++ b/tests/src/EDM4hep2LCIOUtilities.h
@@ -152,6 +152,14 @@ edm4hep::TrackerHit3DCollection createTrackerHits(const int num_elements);
 edm4hep::TrackerHitPlaneCollection createTrackerHitPlanes(const int num_elements);
 
 /**
+ * Create a collection linking sim hits with reco hits
+ */
+edm4hep::TrackerHitSimTrackerHitLinkCollection
+createSimTrackerHitTrackerHitLinks(const std::vector<edm4hep::TrackerHit>& trackerHits,
+                                   const edm4hep::SimTrackerHitCollection& simHits,
+                                   const std::vector<test_config::IdxPair>& linkIdcs);
+
+/**
  * Create a track collection with tracks that have links to other tracks (in the
  * same collection) and tracker hits
  */


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that `TrackerHitSimTrackerHitLinkCollection`s are properly converted by ensuring that lookups also happen into the `TrackerHitPlane` maps.

ENDRELEASENOTES

See the discussion in https://github.com/key4hep/CLDConfig/issues/64 for how this was discovered.

