### PR TITLE
Fix builds on Ubuntu 24 in CI

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc src/CompareEDM4hepEDM4hep.cc)
-target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep EDM4HEP::utils LCIO::lcio ROOT::MathCore)
+target_link_libraries(edmCompare PUBLIC k4EDM4hep2LcioConv EDM4HEP::edm4hep EDM4HEP::utils LCIO::lcio ROOT::MathCore)
 target_include_directories(edmCompare
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/k4EDM4hep2LcioConv/include>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(edmCompare SHARED src/CompareEDM4hepLCIO.cc src/ObjectMapping.cc src/CompareEDM4hepEDM4hep.cc)
-target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep LCIO::lcio ROOT::MathCore)
+target_link_libraries(edmCompare PUBLIC EDM4HEP::edm4hep EDM4HEP::utils LCIO::lcio ROOT::MathCore)
 target_include_directories(edmCompare
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/k4EDM4hep2LcioConv/include>


### PR DESCRIPTION
Ubuntu 24 builds have been failing since they were introduced because of missing symbols when running the tests.

BEGINRELEASENOTES
- Link `k4EDM4hep2LcioConv` (needed because of `getRadiusOfStateAtFirstHit`) and `EDM4HEP::utils` (needed because of `edm4hep::utils::TrackPIDHandler`) for `edmCompare` for tests.

ENDRELEASENOTES

I actually can't reproduce the issue on the containers that are used for building Key4hep on Ubuntu 24.