### PR TITLE
Fix compiler error in GCC < 15 by avoiding an ambiguous operator=

### DIFF
--- a/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
+++ b/k4EDM4hep2LcioConv/src/k4Lcio2EDM4hepConv.cpp
@@ -19,7 +19,7 @@ edm4hep::TrackState convertTrackState(const EVENT::TrackState* trackState) {
   const auto refPoint = trackState->getReferencePoint();
   edmtrackState.referencePoint = Vector3fFrom({refPoint[0], refPoint[1], refPoint[2]});
   const auto& covMatrix = trackState->getCovMatrix();
-  edmtrackState.covMatrix = {
+  edmtrackState.covMatrix = edm4hep::CovMatrix6f{
       covMatrix[0],  covMatrix[1], covMatrix[2], covMatrix[3],  covMatrix[4],  covMatrix[5],  covMatrix[6],
       covMatrix[7],  covMatrix[8], covMatrix[9], covMatrix[10], covMatrix[11], covMatrix[12], covMatrix[13],
       covMatrix[14], 0.f,          0.f,          0.f,           0.f,           0.f,           0.f};


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compiler error in GCC < 15 by avoiding an ambiguous operator=

ENDRELEASENOTES

The error seems to be that there are three candidates:
```
edm4hep::CovMatrix6f::operator=(const std::array<float, 21>&)
edm4hep::CovMatrix6f::operator=(const edm4hep::CovMatrix6f&)
edm4hep::CovMatrix6f::operator=(edm4hep::CovMatrix6f&&)
```
after const was added in https://github.com/key4hep/EDM4hep/pull/435. Both GCC 15 and Clang 20 are happy without this fix, but GCC 13 and GCC 14 are not, so the nightlies today failed.